### PR TITLE
chore: add GetTypeName() for KongConsumerGroup

### DIFF
--- a/api/configuration/v1beta1/kongconsumergroup_types.go
+++ b/api/configuration/v1beta1/kongconsumergroup_types.go
@@ -38,6 +38,10 @@ type KongConsumerGroup struct {
 	Status KongConsumerGroupStatus `json:"status,omitempty"`
 }
 
+func (c KongConsumerGroup) GetTypeName() string {
+	return "KongConsumerGroup"
+}
+
 // +kubebuilder:object:root=true
 
 // KongConsumerGroupList contains a list of KongConsumerGroups.


### PR DESCRIPTION
**What this PR does / why we need it**:

Add GetTypeName() for KongConsumerGroup