### PR TITLE
chore: add Kong/k8s-maintainers as CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Kong/k8s-maintainers


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes @Kong/k8s-maintainers code owners on this repo.