### PR TITLE
refactor(konnect): KongService remove KonnectAPIAuthConfiguration ref

### DIFF
--- a/api/configuration/v1alpha1/kongservice_types.go
+++ b/api/configuration/v1alpha1/kongservice_types.go
@@ -34,7 +34,8 @@ import (
 // +kubebuilder:printcolumn:name="Host",type=string,JSONPath=`.spec.host`,description="Host of the service"
 // +kubebuilder:printcolumn:name="Protocol",type=string,JSONPath=`.spec.procol`,description="Protocol of the service"
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
-// +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.konnect.authRef) || has(self.spec.konnect.authRef)", message="Konnect Configuration's API auth ref reference is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
+// +kubebuilder:validation:XValidation:rule="(!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when entity is already Programmed."
 type KongService struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -75,10 +76,6 @@ func (c KongService) GetTypeName() string {
 func (c *KongService) SetKonnectLabels(labels map[string]string) {
 }
 
-func (c *KongService) GetKonnectAPIAuthConfigurationRef() konnectv1alpha1.KonnectAPIAuthConfigurationRef {
-	return c.Spec.KonnectConfiguration.APIAuthConfigurationRef
-}
-
 // GetConditions returns the Status Conditions
 func (c *KongService) GetConditions() []metav1.Condition {
 	return c.Status.Conditions
@@ -94,10 +91,6 @@ type KongServiceSpec struct {
 	// ControlPlaneRef is a reference to a ControlPlane this Route is associated with.
 	// +kubebuilder:validation:Required
 	ControlPlaneRef ControlPlaneRef `json:"controlPlaneRef"`
-
-	// KonnectConfiguration holds the Konnect configuration like authentication configuration.
-	// +kubebuilder:validation:Required
-	KonnectConfiguration konnectv1alpha1.KonnectConfiguration `json:"konnect,omitempty"`
 
 	KongServiceAPISpec `json:",inline"`
 }

--- a/api/configuration/v1alpha1/zz_generated.deepcopy.go
+++ b/api/configuration/v1alpha1/zz_generated.deepcopy.go
@@ -885,7 +885,6 @@ func (in *KongServiceList) DeepCopyObject() runtime.Object {
 func (in *KongServiceSpec) DeepCopyInto(out *KongServiceSpec) {
 	*out = *in
 	in.ControlPlaneRef.DeepCopyInto(&out.ControlPlaneRef)
-	out.KonnectConfiguration = in.KonnectConfiguration
 	in.KongServiceAPISpec.DeepCopyInto(&out.KongServiceAPISpec)
 }
 

--- a/config/crd/bases/configuration.konghq.com_kongservices.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongservices.yaml
@@ -99,28 +99,6 @@ spec:
                 description: The host of the upstream server. Note that the host value
                   is case sensitive.
                 type: string
-              konnect:
-                description: KonnectConfiguration holds the Konnect configuration
-                  like authentication configuration.
-                properties:
-                  authRef:
-                    description: |-
-                      APIAuthConfigurationRef is the reference to the API Auth Configuration
-                      that should be used for this Konnect Configuration.
-                    properties:
-                      name:
-                        description: Name is the name of the KonnectAPIAuthConfiguration
-                          resource.
-                        type: string
-                    required:
-                    - name
-                    type: object
-                    x-kubernetes-validations:
-                    - message: authRef is immutable
-                      rule: self == oldSelf
-                required:
-                - authRef
-                type: object
               name:
                 description: The Service name.
                 type: string
@@ -282,9 +260,12 @@ spec:
         - spec
         type: object
         x-kubernetes-validations:
-        - message: Konnect Configuration's API auth ref reference is required once
-            set
-          rule: '!has(oldSelf.spec.konnect.authRef) || has(self.spec.konnect.authRef)'
+        - message: controlPlaneRef is required once set
+          rule: '!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)'
+        - message: spec.controlPlaneRef is immutable when entity is already Programmed.
+          rule: '(!has(self.status) || !self.status.conditions.exists(c, c.type ==
+            ''Programmed'' && c.status == ''True'')) ? true : oldSelf.spec.controlPlaneRef
+            == self.spec.controlPlaneRef'
     served: true
     storage: true
     subresources:

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -733,7 +733,6 @@ KongServiceSpec defines specification of a Kong Route.
 | Field | Description |
 | --- | --- |
 | `controlPlaneRef` _[ControlPlaneRef](#controlplaneref)_ | ControlPlaneRef is a reference to a ControlPlane this Route is associated with. |
-| `konnect` _[KonnectConfiguration](#konnectconfiguration)_ | KonnectConfiguration holds the Konnect configuration like authentication configuration. |
 | `url` _string_ | Helper field to set `protocol`, `host`, `port` and `path` using a URL. This field is write-only and is not returned in responses. |
 | `connect_timeout` _integer_ | The timeout in milliseconds for establishing a connection to the upstream server. |
 | `enabled` _boolean_ | Whether the Service is active. If set to `false`, the proxy behavior will be as if any routes attached to it do not exist (404). Default: `true`. |


### PR DESCRIPTION
**What this PR does / why we need it**:

This removes the KonnectAPIAuthConfiguration reference from KongService in favor of relying on referenced control plane API auth config.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
