### PR TITLE
chore: always execute the cleanup

### DIFF
--- a/test/crdsvalidation/kongpluginbindings/kongpluginbindings_test.go
+++ b/test/crdsvalidation/kongpluginbindings/kongpluginbindings_test.go
@@ -29,7 +29,7 @@ func TestKongPluginBindings(t *testing.T) {
 				t.Run(tc.Name, func(t *testing.T) {
 					cl := cl.KongPluginBindings(tc.KongPluginBinding.Namespace)
 					kpb, err := cl.Create(ctx, &tc.KongPluginBinding, metav1.CreateOptions{})
-					if err != nil {
+					if err == nil {
 						t.Cleanup(func() {
 							assert.NoError(t, client.IgnoreNotFound(cl.Delete(ctx, kpb.Name, metav1.DeleteOptions{})))
 						})

--- a/test/crdsvalidation/kongpluginbindings/kongpluginbindings_test.go
+++ b/test/crdsvalidation/kongpluginbindings/kongpluginbindings_test.go
@@ -29,11 +29,13 @@ func TestKongPluginBindings(t *testing.T) {
 				t.Run(tc.Name, func(t *testing.T) {
 					cl := cl.KongPluginBindings(tc.KongPluginBinding.Namespace)
 					kpb, err := cl.Create(ctx, &tc.KongPluginBinding, metav1.CreateOptions{})
-					if tc.ExpectedErrorMessage == nil {
-						assert.NoError(t, err)
+					if err != nil {
 						t.Cleanup(func() {
 							assert.NoError(t, client.IgnoreNotFound(cl.Delete(ctx, kpb.Name, metav1.DeleteOptions{})))
 						})
+					}
+					if tc.ExpectedErrorMessage == nil {
+						assert.NoError(t, err)
 					} else {
 						require.NotNil(t, err)
 						assert.Contains(t, err.Error(), *tc.ExpectedErrorMessage)

--- a/test/crdsvalidation/konnectcontrolplane/konnectcontrolplane_test.go
+++ b/test/crdsvalidation/konnectcontrolplane/konnectcontrolplane_test.go
@@ -29,7 +29,7 @@ func TestKonnectControlPlane(t *testing.T) {
 				t.Run(tc.Name, func(t *testing.T) {
 					cl := cl.KonnectControlPlanes(tc.KonnectControlPlane.Namespace)
 					kcp, err := cl.Create(ctx, &tc.KonnectControlPlane, metav1.CreateOptions{})
-					if err != nil {
+					if err == nil {
 						t.Cleanup(func() {
 							assert.NoError(t, client.IgnoreNotFound(cl.Delete(ctx, kcp.Name, metav1.DeleteOptions{})))
 						})

--- a/test/crdsvalidation/konnectcontrolplane/konnectcontrolplane_test.go
+++ b/test/crdsvalidation/konnectcontrolplane/konnectcontrolplane_test.go
@@ -29,16 +29,17 @@ func TestKonnectControlPlane(t *testing.T) {
 				t.Run(tc.Name, func(t *testing.T) {
 					cl := cl.KonnectControlPlanes(tc.KonnectControlPlane.Namespace)
 					kcp, err := cl.Create(ctx, &tc.KonnectControlPlane, metav1.CreateOptions{})
-					if tc.ExpectedErrorMessage == nil {
-						assert.NoError(t, err)
+					if err != nil {
 						t.Cleanup(func() {
 							assert.NoError(t, client.IgnoreNotFound(cl.Delete(ctx, kcp.Name, metav1.DeleteOptions{})))
 						})
+					}
+					if tc.ExpectedErrorMessage == nil {
+						assert.NoError(t, err)
 
 						// Update the object and check if the update is allowed.
 						if tc.Update != nil {
 							tc.Update(kcp)
-
 							_, err := cl.Update(ctx, kcp, metav1.UpdateOptions{})
 							if tc.ExpectedUpdateErrorMessage != nil {
 								require.NotNil(t, err)


### PR DESCRIPTION
**What this PR does / why we need it**:

We need to always run the cleanup. In case an error in the creation was occurred, `client.IgnoreNotFound` does not return any error in the creation.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
