### PR TITLE
fix: make KongRoute CEL validations work as expected

### DIFF
--- a/api/configuration/v1/kongconsumer_types.go
+++ b/api/configuration/v1/kongconsumer_types.go
@@ -34,7 +34,7 @@ import (
 // +kubebuilder:printcolumn:name="Programmed",type=string,JSONPath=`.status.conditions[?(@.type=="Programmed")].status`
 // +kubebuilder:validation:XValidation:rule="has(self.username) || has(self.custom_id)", message="Need to provide either username or custom_id"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
-// +kubebuilder:validation:XValidation:rule="(!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when entity is already Programmed."
+// +kubebuilder:validation:XValidation:rule="(!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 
 // KongConsumer is the Schema for the kongconsumers API.
 type KongConsumer struct {

--- a/api/configuration/v1alpha1/kongpluginbinding_types.go
+++ b/api/configuration/v1alpha1/kongpluginbinding_types.go
@@ -34,7 +34,7 @@ import (
 // +kubebuilder:printcolumn:name="Plugin-name",type=string,JSONPath=`.spec.pluginRef.name`,description="Name of the plugin"
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
-// +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when entity is already Programmed."
+// +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 type KongPluginBinding struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongroute_types.go
+++ b/api/configuration/v1alpha1/kongroute_types.go
@@ -36,7 +36,8 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.serviceRef) || has(self.spec.serviceRef)", message="serviceRef is required once set"
-// +kubebuilder:validation:XValidation:rule="self.spec.protocols.exists(p, p == 'http') ? (has(self.spec.hosts) || has(self.spec.methods) || has(self.spec.paths) || has(self.spec.paths) || has(self.spec.paths) || has(self.spec.headers) ) : true", message="If protocols has 'http', at least one of 'hosts', 'methods', 'paths' or 'headers' must be set"
+// +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.serviceRef == self.spec.serviceRef", message="spec.serviceRef is immutable when entity is already Programmed."
+// +kubebuilder:validation:XValidation:rule="has(self.spec.protocols) && self.spec.protocols.exists(p, p == 'http') ? (has(self.spec.hosts) || has(self.spec.methods) || has(self.spec.paths) || has(self.spec.paths) || has(self.spec.paths) || has(self.spec.headers) ) : true", message="If protocols has 'http', at least one of 'hosts', 'methods', 'paths' or 'headers' must be set"
 type KongRoute struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongroute_types.go
+++ b/api/configuration/v1alpha1/kongroute_types.go
@@ -36,7 +36,7 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.serviceRef) || has(self.spec.serviceRef)", message="serviceRef is required once set"
-// +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.serviceRef == self.spec.serviceRef", message="spec.serviceRef is immutable when entity is already Programmed."
+// +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.serviceRef == self.spec.serviceRef", message="spec.serviceRef is immutable when an entity is already Programmed"
 // +kubebuilder:validation:XValidation:rule="has(self.spec.protocols) && self.spec.protocols.exists(p, p == 'http') ? (has(self.spec.hosts) || has(self.spec.methods) || has(self.spec.paths) || has(self.spec.paths) || has(self.spec.paths) || has(self.spec.headers) ) : true", message="If protocols has 'http', at least one of 'hosts', 'methods', 'paths' or 'headers' must be set"
 type KongRoute struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/configuration/v1alpha1/kongservice_types.go
+++ b/api/configuration/v1alpha1/kongservice_types.go
@@ -35,7 +35,7 @@ import (
 // +kubebuilder:printcolumn:name="Protocol",type=string,JSONPath=`.spec.procol`,description="Protocol of the service"
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
-// +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when entity is already Programmed."
+// +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 type KongService struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/service_ref.go
+++ b/api/configuration/v1alpha1/service_ref.go
@@ -1,14 +1,18 @@
 package v1alpha1
 
 const (
+	// ServiceRefNamespacedRef is a namespaced reference to a KongService.
 	ServiceRefNamespacedRef = "namespacedRef"
 )
 
+// ServiceRef is a reference to a KongService.
+// +kubebuilder:validation:XValidation:rule="self.type == 'namespacedRef' ? has(self.namespacedRef) : true", message="when type is namespacedRef, namespacedRef must be set"
 type ServiceRef struct {
 	// Type can be one of:
 	// - namespacedRef
 	Type string `json:"type,omitempty"`
 
+	// NamespacedRef is a reference to a KongService.
 	NamespacedRef *NamespacedServiceRef `json:"namespacedRef,omitempty"`
 }
 

--- a/api/configuration/v1beta1/kongconsumergroup_types.go
+++ b/api/configuration/v1beta1/kongconsumergroup_types.go
@@ -32,7 +32,7 @@ import (
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age"
 // +kubebuilder:printcolumn:name="Programmed",type=string,JSONPath=`.status.conditions[?(@.type=="Programmed")].status`
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
-// +kubebuilder:validation:XValidation:rule="(!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when entity is already Programmed."
+// +kubebuilder:validation:XValidation:rule="(!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 
 // KongConsumerGroup is the Schema for the kongconsumergroups API.
 type KongConsumerGroup struct {

--- a/api/konnect/v1alpha1/konnect_gateway_controlplane_types.go
+++ b/api/konnect/v1alpha1/konnect_gateway_controlplane_types.go
@@ -19,8 +19,8 @@ func init() {
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:printcolumn:name="ID",description="Konnect ID",type=string,JSONPath=`.status.id`
 // +kubebuilder:printcolumn:name="OrgID",description="Konnect Organization ID this resource belongs to.",type=string,JSONPath=`.status.organizationID`
-// +kubebuilder:validation:XValidation:rule="!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef", message="spec.konnect.authRef is immutable when entity is already Programmed."
-// +kubebuilder:validation:XValidation:rule="!self.status.conditions.exists(c, c.type == 'APIAuthValid' && c.status == 'True') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef", message="spec.konnect.authRef is immutable when entity refers to a Valid API Auth Configuration."
+// +kubebuilder:validation:XValidation:rule="!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef", message="spec.konnect.authRef is immutable when an entity is already Programmed"
+// +kubebuilder:validation:XValidation:rule="!self.status.conditions.exists(c, c.type == 'APIAuthValid' && c.status == 'True') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef", message="spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration"
 type KonnectGatewayControlPlane struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/configuration.konghq.com_kongconsumergroups.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongconsumergroups.yaml
@@ -195,7 +195,7 @@ spec:
         x-kubernetes-validations:
         - message: controlPlaneRef is required once set
           rule: '!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)'
-        - message: spec.controlPlaneRef is immutable when entity is already Programmed.
+        - message: spec.controlPlaneRef is immutable when an entity is already Programmed
           rule: '(!has(self.status) || !self.status.conditions.exists(c, c.type ==
             ''Programmed'' && c.status == ''True'')) ? true : oldSelf.spec.controlPlaneRef
             == self.spec.controlPlaneRef'

--- a/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
@@ -222,7 +222,7 @@ spec:
           rule: has(self.username) || has(self.custom_id)
         - message: controlPlaneRef is required once set
           rule: '!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)'
-        - message: spec.controlPlaneRef is immutable when entity is already Programmed.
+        - message: spec.controlPlaneRef is immutable when an entity is already Programmed
           rule: '(!has(self.status) || !self.status.conditions.exists(c, c.type ==
             ''Programmed'' && c.status == ''True'')) ? true : oldSelf.spec.controlPlaneRef
             == self.spec.controlPlaneRef'

--- a/config/crd/bases/configuration.konghq.com_kongpluginbindings.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongpluginbindings.yaml
@@ -351,7 +351,7 @@ spec:
         x-kubernetes-validations:
         - message: controlPlaneRef is required once set
           rule: '!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)'
-        - message: spec.controlPlaneRef is immutable when entity is already Programmed.
+        - message: spec.controlPlaneRef is immutable when an entity is already Programmed
           rule: '(!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
             == ''True'')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef'
     served: true

--- a/config/crd/bases/configuration.konghq.com_kongroutes.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongroutes.yaml
@@ -141,6 +141,7 @@ spec:
                   associated with.
                 properties:
                   namespacedRef:
+                    description: NamespacedRef is a reference to a KongService.
                     properties:
                       name:
                         type: string
@@ -155,6 +156,10 @@ spec:
                       - namespacedRef
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: when type is namespacedRef, namespacedRef must be set
+                  rule: 'self.type == ''namespacedRef'' ? has(self.namespacedRef)
+                    : true'
               snis:
                 description: A list of SNIs that match this Route when using stream
                   routing.
@@ -290,11 +295,15 @@ spec:
         x-kubernetes-validations:
         - message: serviceRef is required once set
           rule: '!has(oldSelf.spec.serviceRef) || has(self.spec.serviceRef)'
+        - message: spec.serviceRef is immutable when entity is already Programmed.
+          rule: '(!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
+            == ''True'')) ? true : oldSelf.spec.serviceRef == self.spec.serviceRef'
         - message: If protocols has 'http', at least one of 'hosts', 'methods', 'paths'
             or 'headers' must be set
-          rule: 'self.spec.protocols.exists(p, p == ''http'') ? (has(self.spec.hosts)
-            || has(self.spec.methods) || has(self.spec.paths) || has(self.spec.paths)
-            || has(self.spec.paths) || has(self.spec.headers) ) : true'
+          rule: 'has(self.spec.protocols) && self.spec.protocols.exists(p, p == ''http'')
+            ? (has(self.spec.hosts) || has(self.spec.methods) || has(self.spec.paths)
+            || has(self.spec.paths) || has(self.spec.paths) || has(self.spec.headers)
+            ) : true'
     served: true
     storage: true
     subresources:

--- a/config/crd/bases/configuration.konghq.com_kongroutes.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongroutes.yaml
@@ -295,7 +295,7 @@ spec:
         x-kubernetes-validations:
         - message: serviceRef is required once set
           rule: '!has(oldSelf.spec.serviceRef) || has(self.spec.serviceRef)'
-        - message: spec.serviceRef is immutable when entity is already Programmed.
+        - message: spec.serviceRef is immutable when an entity is already Programmed
           rule: '(!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
             == ''True'')) ? true : oldSelf.spec.serviceRef == self.spec.serviceRef'
         - message: If protocols has 'http', at least one of 'hosts', 'methods', 'paths'

--- a/config/crd/bases/configuration.konghq.com_kongservices.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongservices.yaml
@@ -255,7 +255,7 @@ spec:
         x-kubernetes-validations:
         - message: controlPlaneRef is required once set
           rule: '!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)'
-        - message: spec.controlPlaneRef is immutable when entity is already Programmed.
+        - message: spec.controlPlaneRef is immutable when an entity is already Programmed
           rule: '(!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
             == ''True'')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef'
     served: true

--- a/config/crd/bases/konnect.konghq.com_konnectgatewaycontrolplanes.yaml
+++ b/config/crd/bases/konnect.konghq.com_konnectgatewaycontrolplanes.yaml
@@ -212,11 +212,11 @@ spec:
             type: object
         type: object
         x-kubernetes-validations:
-        - message: spec.konnect.authRef is immutable when entity is already Programmed.
+        - message: spec.konnect.authRef is immutable when an entity is already Programmed
           rule: '!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
             == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
-        - message: spec.konnect.authRef is immutable when entity refers to a Valid
-            API Auth Configuration.
+        - message: spec.konnect.authRef is immutable when an entity refers to a Valid
+            API Auth Configuration
           rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status
             == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
     served: true

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -854,14 +854,14 @@ _Appears in:_
 #### ServiceRef
 
 
-
+ServiceRef is a reference to a KongService.
 
 
 
 | Field | Description |
 | --- | --- |
 | `type` _string_ | Type can be one of: - namespacedRef |
-| `namespacedRef` _[NamespacedServiceRef](#namespacedserviceref)_ |  |
+| `namespacedRef` _[NamespacedServiceRef](#namespacedserviceref)_ | NamespacedRef is a reference to a KongService. |
 
 
 _Appears in:_

--- a/test/crdsvalidation/kongconsumer/testcases/cpref-update-not-allowed-for-status.go
+++ b/test/crdsvalidation/kongconsumer/testcases/cpref-update-not-allowed-for-status.go
@@ -42,7 +42,7 @@ var updatesNotAllowedForStatus = testCasesGroup{
 			Update: func(c *configurationv1.KongConsumer) {
 				c.Spec.ControlPlaneRef.KonnectNamespacedRef.Name = "new-konnect-control-plane"
 			},
-			ExpectedUpdateErrorMessage: lo.ToPtr("spec.controlPlaneRef is immutable when entity is already Programmed"),
+			ExpectedUpdateErrorMessage: lo.ToPtr("spec.controlPlaneRef is immutable when an entity is already Programmed"),
 		},
 		{
 			Name: "cpRef change is allowed when cp is not Programmed=True nor APIAuthValid=True",

--- a/test/crdsvalidation/kongconsumergroup/testcases/cpref-update-not-allowed-for-status.go
+++ b/test/crdsvalidation/kongconsumergroup/testcases/cpref-update-not-allowed-for-status.go
@@ -41,7 +41,7 @@ var updatesNotAllowedForStatus = testCasesGroup{
 			Update: func(c *configurationv1beta1.KongConsumerGroup) {
 				c.Spec.ControlPlaneRef.KonnectNamespacedRef.Name = "new-konnect-control-plane"
 			},
-			ExpectedUpdateErrorMessage: lo.ToPtr("spec.controlPlaneRef is immutable when entity is already Programmed"),
+			ExpectedUpdateErrorMessage: lo.ToPtr("spec.controlPlaneRef is immutable when an entity is already Programmed"),
 		},
 		{
 			Name: "cpRef change is allowed when cp is not Programmed=True nor APIAuthValid=True",

--- a/test/crdsvalidation/kongpluginbindings/testcases/cpref-update-not-allowed-for-status.go
+++ b/test/crdsvalidation/kongpluginbindings/testcases/cpref-update-not-allowed-for-status.go
@@ -51,7 +51,7 @@ var updatesNotAllowedForStatusTCs = testCasesGroup{
 			Update: func(c *configurationv1alpha1.KongPluginBinding) {
 				c.Spec.ControlPlaneRef.KonnectNamespacedRef.Name = "new-konnect-control-plane"
 			},
-			ExpectedUpdateErrorMessage: lo.ToPtr("spec.controlPlaneRef is immutable when entity is already Programmed"),
+			ExpectedUpdateErrorMessage: lo.ToPtr("spec.controlPlaneRef is immutable when an entity is already Programmed"),
 		},
 		{
 			Name: "cpRef change is allowed when cp is not Programmed=True nor APIAuthValid=True",

--- a/test/crdsvalidation/kongroute/kongroute_test.go
+++ b/test/crdsvalidation/kongroute/kongroute_test.go
@@ -1,0 +1,67 @@
+package kongpluginbindings
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	configurationv1alpha1client "github.com/kong/kubernetes-configuration/pkg/clientset/typed/configuration/v1alpha1"
+	"github.com/kong/kubernetes-configuration/test/crdsvalidation/kongroute/testcases"
+)
+
+func TestKongRoute(t *testing.T) {
+	ctx := context.Background()
+	cfg, err := config.GetConfig()
+	require.NoError(t, err, "error loading Kubernetes config")
+	cl, err := configurationv1alpha1client.NewForConfig(cfg)
+	require.NoError(t, err, "error creating configurationv1alpha1 client")
+
+	for _, tcsGroup := range testcases.TestCases {
+		tcsGroup := tcsGroup
+		t.Run(tcsGroup.Name, func(t *testing.T) {
+			for _, tc := range tcsGroup.TestCases {
+				tc := tc
+				t.Run(tc.Name, func(t *testing.T) {
+					cl := cl.KongRoutes(tc.KongRoute.Namespace)
+					entity, err := cl.Create(ctx, &tc.KongRoute, metav1.CreateOptions{})
+					if err == nil {
+						t.Cleanup(func() {
+							assert.NoError(t, client.IgnoreNotFound(cl.Delete(ctx, entity.Name, metav1.DeleteOptions{})))
+						})
+					}
+
+					if tc.ExpectedErrorMessage == nil {
+						assert.NoError(t, err)
+
+						// if the status has to be updated, update it.
+						if tc.KongRouteStatus != nil {
+							entity.Status = *tc.KongRouteStatus
+							entity, err = cl.UpdateStatus(ctx, entity, metav1.UpdateOptions{})
+							assert.NoError(t, err)
+						}
+
+						// Update the object and check if the update is allowed.
+						if tc.Update != nil {
+							tc.Update(entity)
+							_, err := cl.Update(ctx, entity, metav1.UpdateOptions{})
+							if tc.ExpectedUpdateErrorMessage != nil {
+								require.Error(t, err)
+								assert.Contains(t, err.Error(), *tc.ExpectedUpdateErrorMessage)
+							} else {
+								assert.NoError(t, err)
+							}
+						}
+					} else {
+						require.Error(t, err)
+						require.ErrorContains(t, err, *tc.ExpectedErrorMessage)
+					}
+				})
+			}
+		})
+	}
+}

--- a/test/crdsvalidation/kongroute/testcases/common.go
+++ b/test/crdsvalidation/kongroute/testcases/common.go
@@ -1,0 +1,39 @@
+package testcases
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+)
+
+// testCase is a test case related to KongService validation.
+type testCase struct {
+	Name                       string
+	KongRoute                  configurationv1alpha1.KongRoute
+	KongRouteStatus            *configurationv1alpha1.KongRouteStatus
+	Update                     func(*configurationv1alpha1.KongRoute)
+	ExpectedErrorMessage       *string
+	ExpectedUpdateErrorMessage *string
+}
+
+// testCasesGroup is a group of test cases related to KongService validation.
+// The grouping is done by a common name.
+type testCasesGroup struct {
+	Name      string
+	TestCases []testCase
+}
+
+// TestCases is a collection of all test cases groups related to KongService validation.
+var TestCases = []testCasesGroup{}
+
+func init() {
+	TestCases = append(TestCases,
+		serviceRef,
+		protocols,
+	)
+}
+
+var commonObjectMeta = metav1.ObjectMeta{
+	GenerateName: "test-kongroute-",
+	Namespace:    "default",
+}

--- a/test/crdsvalidation/kongroute/testcases/protocols.go
+++ b/test/crdsvalidation/kongroute/testcases/protocols.go
@@ -1,0 +1,60 @@
+package testcases
+
+import (
+	"github.com/Kong/sdk-konnect-go/models/components"
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+	"github.com/samber/lo"
+)
+
+var protocols = testCasesGroup{
+	Name: "protocols validation",
+	TestCases: []testCase{
+		{
+			Name: "no http in protocols implies no other requirements",
+			KongRoute: configurationv1alpha1.KongRoute{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1alpha1.KongRouteSpec{
+					ServiceRef: &configurationv1alpha1.ServiceRef{
+						Type:          configurationv1alpha1.ServiceRefNamespacedRef,
+						NamespacedRef: &configurationv1alpha1.NamespacedServiceRef{Name: "svc"},
+					},
+					KongRouteAPISpec: configurationv1alpha1.KongRouteAPISpec{
+						Paths: []string{"/"},
+					},
+				},
+			},
+		},
+		{
+			Name: "http in protocols with hosts set yields no error",
+			KongRoute: configurationv1alpha1.KongRoute{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1alpha1.KongRouteSpec{
+					ServiceRef: &configurationv1alpha1.ServiceRef{
+						Type:          configurationv1alpha1.ServiceRefNamespacedRef,
+						NamespacedRef: &configurationv1alpha1.NamespacedServiceRef{Name: "svc"},
+					},
+					KongRouteAPISpec: configurationv1alpha1.KongRouteAPISpec{
+						Protocols: []components.RouteProtocols{"http"},
+						Hosts:     []string{"example.com"},
+					},
+				},
+			},
+		},
+		{
+			Name: "http in protocols no hosts, methods, paths or headers yields an error",
+			KongRoute: configurationv1alpha1.KongRoute{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1alpha1.KongRouteSpec{
+					ServiceRef: &configurationv1alpha1.ServiceRef{
+						Type:          configurationv1alpha1.ServiceRefNamespacedRef,
+						NamespacedRef: &configurationv1alpha1.NamespacedServiceRef{Name: "svc"},
+					},
+					KongRouteAPISpec: configurationv1alpha1.KongRouteAPISpec{
+						Protocols: []components.RouteProtocols{"http"},
+					},
+				},
+			},
+			ExpectedErrorMessage: lo.ToPtr("If protocols has 'http', at least one of 'hosts', 'methods', 'paths' or 'headers' must be set"),
+		},
+	},
+}

--- a/test/crdsvalidation/kongroute/testcases/serviceref.go
+++ b/test/crdsvalidation/kongroute/testcases/serviceref.go
@@ -42,7 +42,7 @@ var serviceRef = testCasesGroup{
 			ExpectedErrorMessage: lo.ToPtr("when type is namespacedRef, namespacedRef must be set"),
 		},
 		{
-			Name: "NamespacedRef reference name cannot be changed when entity is Programmed",
+			Name: "NamespacedRef reference name cannot be changed when an entity is Programmed",
 			KongRoute: configurationv1alpha1.KongRoute{
 				ObjectMeta: commonObjectMeta,
 				Spec: configurationv1alpha1.KongRouteSpec{
@@ -70,10 +70,10 @@ var serviceRef = testCasesGroup{
 			Update: func(ks *configurationv1alpha1.KongRoute) {
 				ks.Spec.ServiceRef.NamespacedRef.Name = "new-konnect-service"
 			},
-			ExpectedUpdateErrorMessage: lo.ToPtr("spec.serviceRef is immutable when entity is already Programmed."),
+			ExpectedUpdateErrorMessage: lo.ToPtr("spec.serviceRef is immutable when an entity is already Programmed"),
 		},
 		{
-			Name: "NamespacedRef reference type cannot be changed when entity is Programmed",
+			Name: "NamespacedRef reference type cannot be changed when an entity is Programmed",
 			KongRoute: configurationv1alpha1.KongRoute{
 				ObjectMeta: commonObjectMeta,
 				Spec: configurationv1alpha1.KongRouteSpec{
@@ -101,7 +101,7 @@ var serviceRef = testCasesGroup{
 			Update: func(ks *configurationv1alpha1.KongRoute) {
 				ks.Spec.ServiceRef.Type = "otherRef"
 			},
-			ExpectedUpdateErrorMessage: lo.ToPtr("spec.serviceRef is immutable when entity is already Programmed."),
+			ExpectedUpdateErrorMessage: lo.ToPtr("spec.serviceRef is immutable when an entity is already Programmed"),
 		},
 	},
 }

--- a/test/crdsvalidation/kongroute/testcases/serviceref.go
+++ b/test/crdsvalidation/kongroute/testcases/serviceref.go
@@ -1,0 +1,107 @@
+package testcases
+
+import (
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var serviceRef = testCasesGroup{
+	Name: "service ref validation",
+	TestCases: []testCase{
+		{
+			Name: "NamespacedRef reference is valid",
+			KongRoute: configurationv1alpha1.KongRoute{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1alpha1.KongRouteSpec{
+					ServiceRef: &configurationv1alpha1.ServiceRef{
+						Type: configurationv1alpha1.ServiceRefNamespacedRef,
+						NamespacedRef: &configurationv1alpha1.NamespacedServiceRef{
+							Name: "test-konnect-service",
+						},
+					},
+					KongRouteAPISpec: configurationv1alpha1.KongRouteAPISpec{
+						Paths: []string{"/"},
+					},
+				},
+			},
+		},
+		{
+			Name: "not providing namespacedRef when type is namespacedRef yields an error",
+			KongRoute: configurationv1alpha1.KongRoute{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1alpha1.KongRouteSpec{
+					ServiceRef: &configurationv1alpha1.ServiceRef{
+						Type: configurationv1alpha1.ServiceRefNamespacedRef,
+					},
+					KongRouteAPISpec: configurationv1alpha1.KongRouteAPISpec{
+						Paths: []string{"/"},
+					},
+				},
+			},
+			ExpectedErrorMessage: lo.ToPtr("when type is namespacedRef, namespacedRef must be set"),
+		},
+		{
+			Name: "NamespacedRef reference name cannot be changed when entity is Programmed",
+			KongRoute: configurationv1alpha1.KongRoute{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1alpha1.KongRouteSpec{
+					ServiceRef: &configurationv1alpha1.ServiceRef{
+						Type: configurationv1alpha1.ServiceRefNamespacedRef,
+						NamespacedRef: &configurationv1alpha1.NamespacedServiceRef{
+							Name: "test-konnect-service",
+						},
+					},
+					KongRouteAPISpec: configurationv1alpha1.KongRouteAPISpec{
+						Paths: []string{"/"},
+					},
+				},
+			},
+			KongRouteStatus: &configurationv1alpha1.KongRouteStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:               "Programmed",
+						Status:             metav1.ConditionTrue,
+						Reason:             "Programmed",
+						LastTransitionTime: metav1.Now(),
+					},
+				},
+			},
+			Update: func(ks *configurationv1alpha1.KongRoute) {
+				ks.Spec.ServiceRef.NamespacedRef.Name = "new-konnect-service"
+			},
+			ExpectedUpdateErrorMessage: lo.ToPtr("spec.serviceRef is immutable when entity is already Programmed."),
+		},
+		{
+			Name: "NamespacedRef reference type cannot be changed when entity is Programmed",
+			KongRoute: configurationv1alpha1.KongRoute{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1alpha1.KongRouteSpec{
+					ServiceRef: &configurationv1alpha1.ServiceRef{
+						Type: configurationv1alpha1.ServiceRefNamespacedRef,
+						NamespacedRef: &configurationv1alpha1.NamespacedServiceRef{
+							Name: "test-konnect-service",
+						},
+					},
+					KongRouteAPISpec: configurationv1alpha1.KongRouteAPISpec{
+						Paths: []string{"/"},
+					},
+				},
+			},
+			KongRouteStatus: &configurationv1alpha1.KongRouteStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:               "Programmed",
+						Status:             metav1.ConditionTrue,
+						Reason:             "Programmed",
+						LastTransitionTime: metav1.Now(),
+					},
+				},
+			},
+			Update: func(ks *configurationv1alpha1.KongRoute) {
+				ks.Spec.ServiceRef.Type = "otherRef"
+			},
+			ExpectedUpdateErrorMessage: lo.ToPtr("spec.serviceRef is immutable when entity is already Programmed."),
+		},
+	},
+}

--- a/test/crdsvalidation/kongservice/testcases/controlplaneref.go
+++ b/test/crdsvalidation/kongservice/testcases/controlplaneref.go
@@ -58,7 +58,7 @@ var cpRef = testCasesGroup{
 			ExpectedErrorMessage: lo.ToPtr("when type is konnectID, konnectID must be set"),
 		},
 		{
-			Name: "konnectNamespacedRef reference name cannot be changed when entity is Programmed",
+			Name: "konnectNamespacedRef reference name cannot be changed when an entity is Programmed",
 			KongService: configurationv1alpha1.KongService{
 				ObjectMeta: commonObjectMeta,
 				Spec: configurationv1alpha1.KongServiceSpec{
@@ -86,10 +86,10 @@ var cpRef = testCasesGroup{
 			Update: func(ks *configurationv1alpha1.KongService) {
 				ks.Spec.ControlPlaneRef.KonnectNamespacedRef.Name = "new-konnect-control-plane"
 			},
-			ExpectedUpdateErrorMessage: lo.ToPtr("spec.controlPlaneRef is immutable when entity is already Programmed."),
+			ExpectedUpdateErrorMessage: lo.ToPtr("spec.controlPlaneRef is immutable when an entity is already Programmed"),
 		},
 		{
-			Name: "konnectNamespacedRef reference type cannot be changed when entity is Programmed",
+			Name: "konnectNamespacedRef reference type cannot be changed when an entity is Programmed",
 			KongService: configurationv1alpha1.KongService{
 				ObjectMeta: commonObjectMeta,
 				Spec: configurationv1alpha1.KongServiceSpec{
@@ -117,7 +117,7 @@ var cpRef = testCasesGroup{
 			Update: func(ks *configurationv1alpha1.KongService) {
 				ks.Spec.ControlPlaneRef.Type = configurationv1alpha1.ControlPlaneRefKonnectID
 			},
-			ExpectedUpdateErrorMessage: lo.ToPtr("spec.controlPlaneRef is immutable when entity is already Programmed."),
+			ExpectedUpdateErrorMessage: lo.ToPtr("spec.controlPlaneRef is immutable when an entity is already Programmed"),
 		},
 	},
 }

--- a/test/crdsvalidation/konnectgatewaycontrolplane/testcases/update-not-allowed-for-status.go
+++ b/test/crdsvalidation/konnectgatewaycontrolplane/testcases/update-not-allowed-for-status.go
@@ -42,7 +42,7 @@ var updatesNotAllowedForStatus = testCasesGroup{
 			Update: func(kcp *konnectv1alpha1.KonnectGatewayControlPlane) {
 				kcp.Spec.KonnectConfiguration.APIAuthConfigurationRef.Name = "name-2"
 			},
-			ExpectedUpdateErrorMessage: lo.ToPtr("spec.konnect.authRef is immutable when entity is already Programme"),
+			ExpectedUpdateErrorMessage: lo.ToPtr("spec.konnect.authRef is immutable when an entity is already Programme"),
 		},
 		{
 			Name: "konnect.authRef change is not allowed for APIAuthValid=True",
@@ -73,7 +73,7 @@ var updatesNotAllowedForStatus = testCasesGroup{
 			Update: func(kcp *konnectv1alpha1.KonnectGatewayControlPlane) {
 				kcp.Spec.KonnectConfiguration.APIAuthConfigurationRef.Name = "name-2"
 			},
-			ExpectedUpdateErrorMessage: lo.ToPtr("spec.konnect.authRef is immutable when entity refers to a Valid API Auth Configuration"),
+			ExpectedUpdateErrorMessage: lo.ToPtr("spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration"),
 		},
 		{
 			Name: "konnect.authRef change is allowed when cp is not Programmed=True nor APIAuthValid=True",


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds missing `KongRoute` CEL rules and fixes the existing one for `protocols` that was failing when no `protocols` is provided (which should be correct). 
