### PR TITLE
test(crd): Fix status definition of KongTarget and add CRD validations

### DIFF
--- a/api/configuration/v1alpha1/kong_target_types.go
+++ b/api/configuration/v1alpha1/kong_target_types.go
@@ -32,14 +32,14 @@ import (
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
-// +kubebuilder:validation:XValidation:rule="oldSelf.spec.upstreamRef == self.spec.upstreamRef", message="upstreamRef is immutable"
+// +kubebuilder:validation:XValidation:rule="oldSelf.spec.upstreamRef == self.spec.upstreamRef", message="spec.upstreamRef is immutable"
 type KongTarget struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec KongTargetSpec `json:"spec"`
 	// +kubebuilder:default={conditions: {{type: "Programmed", status: "Unknown", reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"}}}
-	Status KongTargetStatus `json:"status"`
+	Status KongTargetStatus `json:"status,omitempty"`
 }
 
 func (t *KongTarget) initKonnectStatus() {

--- a/config/crd/bases/configuration.konghq.com_kongtargets.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongtargets.yaml
@@ -208,7 +208,6 @@ spec:
             type: object
         required:
         - spec
-        - status
         type: object
         x-kubernetes-validations:
         - message: controlPlaneRef is required once set
@@ -216,7 +215,7 @@ spec:
         - message: spec.controlPlaneRef is immutable when an entity is already Programmed
           rule: '(!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
             == ''True'')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef'
-        - message: upstreamRef is immutable
+        - message: spec.upstreamRef is immutable
           rule: oldSelf.spec.upstreamRef == self.spec.upstreamRef
     served: true
     storage: true

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
 - bases/configuration.konghq.com_kongservices.yaml
 - bases/configuration.konghq.com_kongroutes.yaml
 - bases/configuration.konghq.com_kongupstreams.yaml
+- bases/configuration.konghq.com_kongtargets.yaml
 
 - bases/konnect.konghq.com_konnectapiauthconfigurations.yaml
 - bases/konnect.konghq.com_konnectgatewaycontrolplanes.yaml

--- a/test/crdsvalidation/kongroute/testcases/common.go
+++ b/test/crdsvalidation/kongroute/testcases/common.go
@@ -6,7 +6,7 @@ import (
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 )
 
-// testCase is a test case related to KongService validation.
+// testCase is a test case related to KongRoute validation.
 type testCase struct {
 	Name                       string
 	KongRoute                  configurationv1alpha1.KongRoute
@@ -16,14 +16,14 @@ type testCase struct {
 	ExpectedUpdateErrorMessage *string
 }
 
-// testCasesGroup is a group of test cases related to KongService validation.
+// testCasesGroup is a group of test cases related to KongRoute validation.
 // The grouping is done by a common name.
 type testCasesGroup struct {
 	Name      string
 	TestCases []testCase
 }
 
-// TestCases is a collection of all test cases groups related to KongService validation.
+// TestCases is a collection of all test cases groups related to KongRoute validation.
 var TestCases = []testCasesGroup{}
 
 func init() {

--- a/test/crdsvalidation/kongtarget/kongtarget_test.go
+++ b/test/crdsvalidation/kongtarget/kongtarget_test.go
@@ -1,0 +1,66 @@
+package kongtarget
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	configurationv1alpha1client "github.com/kong/kubernetes-configuration/pkg/clientset/typed/configuration/v1alpha1"
+	"github.com/kong/kubernetes-configuration/test/crdsvalidation/kongtarget/testcases"
+)
+
+func TestKongTarget(t *testing.T) {
+	ctx := context.Background()
+	cfg, err := config.GetConfig()
+	require.NoError(t, err, "error loading Kubernetes config")
+	cl, err := configurationv1alpha1client.NewForConfig(cfg)
+	require.NoError(t, err, "error creating configurationv1alpha1 client")
+
+	for _, tcsGroup := range testcases.TestCases {
+		t.Run(tcsGroup.Name, func(t *testing.T) {
+			for _, tc := range tcsGroup.TestCases {
+				t.Run(tc.Name, func(t *testing.T) {
+					cl := cl.KongTargets(tc.KongTarget.Namespace)
+					entity, err := cl.Create(ctx, &tc.KongTarget, metav1.CreateOptions{})
+					if err == nil {
+						t.Cleanup(func() {
+							assert.NoError(t, client.IgnoreNotFound(cl.Delete(ctx, entity.Name, metav1.DeleteOptions{})))
+						})
+					}
+
+					if tc.ExpectedErrorMessage == nil {
+						assert.NoError(t, err)
+
+						// if the status has to be updated, update it.
+						if tc.KongTargetStatus != nil {
+							entity.Status = *tc.KongTargetStatus
+							entity, err = cl.UpdateStatus(ctx, entity, metav1.UpdateOptions{})
+							assert.NoError(t, err)
+						}
+
+						// Update the object and check if the update is allowed.
+						if tc.Update != nil {
+							tc.Update(entity)
+							_, err := cl.Update(ctx, entity, metav1.UpdateOptions{})
+							if tc.ExpectedUpdateErrorMessage != nil {
+								require.Error(t, err)
+								assert.Contains(t, err.Error(), *tc.ExpectedUpdateErrorMessage)
+							} else {
+								assert.NoError(t, err)
+							}
+						}
+					} else {
+						require.Error(t, err)
+						require.ErrorContains(t, err, *tc.ExpectedErrorMessage)
+					}
+				})
+			}
+		})
+	}
+
+}

--- a/test/crdsvalidation/kongtarget/testcases/common.go
+++ b/test/crdsvalidation/kongtarget/testcases/common.go
@@ -1,0 +1,34 @@
+package testcases
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+)
+
+// testCase is a test case related to KongTarget validation.
+type testCase struct {
+	Name                       string
+	KongTarget                 configurationv1alpha1.KongTarget
+	KongTargetStatus           *configurationv1alpha1.KongTargetStatus
+	Update                     func(*configurationv1alpha1.KongTarget)
+	ExpectedErrorMessage       *string
+	ExpectedUpdateErrorMessage *string
+}
+
+type testCasesGroup struct {
+	Name      string
+	TestCases []testCase
+}
+
+// TestCases is a collection of all test cases groups related to KongTarget validation.
+var TestCases = []testCasesGroup{}
+
+func init() {
+	TestCases = append(TestCases, controlPlaneRef, upstreamRef, kongTargetAPISpec)
+}
+
+var commonObjectMeta = metav1.ObjectMeta{
+	GenerateName: "test-kongtarget-",
+	Namespace:    "default",
+}

--- a/test/crdsvalidation/kongtarget/testcases/controlplaneref.go
+++ b/test/crdsvalidation/kongtarget/testcases/controlplaneref.go
@@ -1,0 +1,99 @@
+package testcases
+
+import (
+	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
+)
+
+var controlPlaneRef = testCasesGroup{
+	Name: "controlPlaneRef",
+	TestCases: []testCase{
+		{
+			Name: "no control plane ref to have control plane ref in valid",
+			KongTarget: configurationv1alpha1.KongTarget{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1alpha1.KongTargetSpec{
+					UpstreamRef: configurationv1alpha1.TargetRef{
+						Name: "upstream",
+					},
+					KongTargetAPISpec: configurationv1alpha1.KongTargetAPISpec{
+						Target: "example.com",
+						Weight: 100,
+					},
+				},
+			},
+			Update: func(kt *configurationv1alpha1.KongTarget) {
+				kt.Spec.ControlPlaneRef = &configurationv1alpha1.ControlPlaneRef{
+					Type:      configurationv1alpha1.ControlPlaneRefKonnectID,
+					KonnectID: lo.ToPtr("konnect-1"),
+				}
+			},
+		},
+		{
+			Name: "have control plane to no control plane is invalid",
+			KongTarget: configurationv1alpha1.KongTarget{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1alpha1.KongTargetSpec{
+					ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+						Type:      configurationv1alpha1.ControlPlaneRefKonnectID,
+						KonnectID: lo.ToPtr("konnect-1"),
+					},
+					UpstreamRef: configurationv1alpha1.TargetRef{
+						Name: "upstream",
+					},
+					KongTargetAPISpec: configurationv1alpha1.KongTargetAPISpec{
+						Target: "example.com",
+						Weight: 100,
+					},
+				},
+			},
+			Update: func(kt *configurationv1alpha1.KongTarget) {
+				kt.Spec.ControlPlaneRef = nil
+			},
+			ExpectedUpdateErrorMessage: lo.ToPtr("controlPlaneRef is required once set"),
+		},
+		{
+			Name: "control plane is immutable once programmed",
+			KongTarget: configurationv1alpha1.KongTarget{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1alpha1.KongTargetSpec{
+					ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+						Type:      configurationv1alpha1.ControlPlaneRefKonnectID,
+						KonnectID: lo.ToPtr("konnect-1"),
+					},
+					UpstreamRef: configurationv1alpha1.TargetRef{
+						Name: "upstream",
+					},
+					KongTargetAPISpec: configurationv1alpha1.KongTargetAPISpec{
+						Target: "example.com",
+						Weight: 100,
+					},
+				},
+			},
+			KongTargetStatus: &configurationv1alpha1.KongTargetStatus{
+				Konnect: &konnectv1alpha1.KonnectEntityStatusWithControlPlaneRef{
+					ControlPlaneID: "konnect-1",
+				},
+				Conditions: []metav1.Condition{
+					{
+						Type:               "Programmed",
+						Status:             metav1.ConditionTrue,
+						ObservedGeneration: 1,
+						Reason:             "Programmed",
+						LastTransitionTime: metav1.Now(),
+					},
+				},
+			},
+			Update: func(kt *configurationv1alpha1.KongTarget) {
+				kt.Spec.ControlPlaneRef = &configurationv1alpha1.ControlPlaneRef{
+					Type:      configurationv1alpha1.ControlPlaneRefKonnectID,
+					KonnectID: lo.ToPtr("konnect-2"),
+				}
+			},
+			ExpectedUpdateErrorMessage: lo.ToPtr("spec.controlPlaneRef is immutable when an entity is already Programmed"),
+		},
+	},
+}

--- a/test/crdsvalidation/kongtarget/testcases/kongtargetapispec.go
+++ b/test/crdsvalidation/kongtarget/testcases/kongtargetapispec.go
@@ -1,0 +1,36 @@
+package testcases
+
+import (
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+	"github.com/samber/lo"
+)
+
+var kongTargetAPISpec = testCasesGroup{
+	Name: "kongTargetAPISpec",
+	TestCases: []testCase{
+		{
+			Name: "weight must between 0 and 65535",
+			KongTarget: configurationv1alpha1.KongTarget{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1alpha1.KongTargetSpec{
+					ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+						Type:      configurationv1alpha1.ControlPlaneRefKonnectID,
+						KonnectID: lo.ToPtr("konnect-1"),
+					},
+					UpstreamRef: configurationv1alpha1.TargetRef{
+						Name: "upstream",
+					},
+					KongTargetAPISpec: configurationv1alpha1.KongTargetAPISpec{
+						Target: "example.com",
+						Weight: 100000,
+					},
+				},
+			},
+			ExpectedErrorMessage: lo.ToPtr("spec.weight: Invalid value: 100000"),
+			Update: func(kt *configurationv1alpha1.KongTarget) {
+				kt.Spec.KongTargetAPISpec.Weight = -1
+			},
+			ExpectedUpdateErrorMessage: lo.ToPtr("spec.weight: Invalid value: -1"),
+		},
+	},
+}

--- a/test/crdsvalidation/kongtarget/testcases/upstreamref.go
+++ b/test/crdsvalidation/kongtarget/testcases/upstreamref.go
@@ -1,0 +1,37 @@
+package testcases
+
+import (
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+	"github.com/samber/lo"
+)
+
+var upstreamRef = testCasesGroup{
+	Name: "upstreamRef",
+	TestCases: []testCase{
+		{
+			Name: "upstream ref is immutable",
+			KongTarget: configurationv1alpha1.KongTarget{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1alpha1.KongTargetSpec{
+					ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+						Type:      configurationv1alpha1.ControlPlaneRefKonnectID,
+						KonnectID: lo.ToPtr("konnect-1"),
+					},
+					UpstreamRef: configurationv1alpha1.TargetRef{
+						Name: "upstream",
+					},
+					KongTargetAPISpec: configurationv1alpha1.KongTargetAPISpec{
+						Target: "example.com",
+						Weight: 100,
+					},
+				},
+			},
+			Update: func(kt *configurationv1alpha1.KongTarget) {
+				kt.Spec.UpstreamRef = configurationv1alpha1.TargetRef{
+					Name: "upstream-2",
+				}
+			},
+			ExpectedUpdateErrorMessage: lo.ToPtr("spec.upstreamRef is immutable"),
+		},
+	},
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Add CRD validation tests and some minor fixes in `KongTarget` CRD. Also add `KongTarget` and `KongUpstream` to kustomize manifests.

**Which issue this PR fixes**
required for https://github.com/Kong/gateway-operator/issues/576

**Special notes for your reviewer**:
Also fixed some copy-pasta errors in CRD validation tests

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
