### PR TITLE
feat(crd): add konnect specific validations and crd validation tests for KongVault

### DIFF
--- a/api/configuration/v1alpha1/kong_vault_types.go
+++ b/api/configuration/v1alpha1/kong_vault_types.go
@@ -39,6 +39,8 @@ const (
 // +kubebuilder:printcolumn:name="Description",type=string,JSONPath=`.spec.description`,description="Description",priority=1
 // +kubebuilder:printcolumn:name="Programmed",type=string,JSONPath=`.status.conditions[?(@.type=="Programmed")].status`
 // +kubebuilder:validation:XValidation:rule="self.spec.prefix == oldSelf.spec.prefix", message="The spec.prefix field is immutable"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
+// +kubebuilder:validation:XValidation:rule="(!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 
 // KongVault is the schema for kongvaults API which defines a custom Kong vault.
 // A Kong vault is a storage to store sensitive data, where the values can be referenced in configuration of plugins.
@@ -77,6 +79,14 @@ func (v *KongVault) SetKonnectID(id string) {
 		v.initKonnectStatus()
 	}
 	v.Status.Konnect.ID = id
+}
+
+// GetControlPlaneID returns the ControlPlane ID in the KongVault status.
+func (v *KongVault) GetControlPlaneID() string {
+	if v.Status.Konnect == nil {
+		return ""
+	}
+	return v.Status.Konnect.ControlPlaneID
 }
 
 // SetControlPlaneID sets the ControlPlane ID in the KongVault status.

--- a/config/crd/bases/configuration.konghq.com_kongvaults.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongvaults.yaml
@@ -241,6 +241,12 @@ spec:
         x-kubernetes-validations:
         - message: The spec.prefix field is immutable
           rule: self.spec.prefix == oldSelf.spec.prefix
+        - message: controlPlaneRef is required once set
+          rule: '!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)'
+        - message: spec.controlPlaneRef is immutable when an entity is already Programmed
+          rule: '(!has(self.status) || !self.status.conditions.exists(c, c.type ==
+            ''Programmed'' && c.status == ''True'')) ? true : oldSelf.spec.controlPlaneRef
+            == self.spec.controlPlaneRef'
     served: true
     storage: true
     subresources:

--- a/test/crdsvalidation/kongvault/kongvault_test.go
+++ b/test/crdsvalidation/kongvault/kongvault_test.go
@@ -1,0 +1,65 @@
+package kongvault
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	configurationv1alpha1client "github.com/kong/kubernetes-configuration/pkg/clientset/typed/configuration/v1alpha1"
+	"github.com/kong/kubernetes-configuration/test/crdsvalidation/kongvault/testcases"
+)
+
+func TestKongVault(t *testing.T) {
+	ctx := context.Background()
+	cfg, err := config.GetConfig()
+	require.NoError(t, err, "error loading Kubernetes config")
+	cl, err := configurationv1alpha1client.NewForConfig(cfg)
+	require.NoError(t, err, "error creating configurationv1alpha1 client")
+
+	for _, tcsGroup := range testcases.TestCases {
+		t.Run(tcsGroup.Name, func(t *testing.T) {
+			for _, tc := range tcsGroup.TestCases {
+				t.Run(tc.Name, func(t *testing.T) {
+					cl := cl.KongVaults()
+					entity, err := cl.Create(ctx, &tc.KongVault, metav1.CreateOptions{})
+					if err == nil {
+						t.Cleanup(func() {
+							assert.NoError(t, client.IgnoreNotFound(cl.Delete(ctx, entity.Name, metav1.DeleteOptions{})))
+						})
+					}
+
+					if tc.ExpectedErrorMessage == nil {
+						assert.NoError(t, err)
+
+						// if the status has to be updated, update it.
+						if tc.KongVaultStatus != nil {
+							entity.Status = *tc.KongVaultStatus
+							entity, err = cl.UpdateStatus(ctx, entity, metav1.UpdateOptions{})
+							assert.NoError(t, err)
+						}
+
+						// Update the object and check if the update is allowed.
+						if tc.Update != nil {
+							tc.Update(entity)
+							_, err := cl.Update(ctx, entity, metav1.UpdateOptions{})
+							if tc.ExpectedUpdateErrorMessage != nil {
+								require.Error(t, err)
+								assert.Contains(t, err.Error(), *tc.ExpectedUpdateErrorMessage)
+							} else {
+								assert.NoError(t, err)
+							}
+						}
+					} else {
+						require.Error(t, err)
+						require.ErrorContains(t, err, *tc.ExpectedErrorMessage)
+					}
+				})
+			}
+		})
+	}
+}

--- a/test/crdsvalidation/kongvault/testcases/common.go
+++ b/test/crdsvalidation/kongvault/testcases/common.go
@@ -1,0 +1,34 @@
+package testcases
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+)
+
+// testCase is a test case related to KongTarget validation.
+type testCase struct {
+	Name                       string
+	KongVault                  configurationv1alpha1.KongVault
+	KongVaultStatus            *configurationv1alpha1.KongVaultStatus
+	Update                     func(*configurationv1alpha1.KongVault)
+	ExpectedErrorMessage       *string
+	ExpectedUpdateErrorMessage *string
+}
+
+type testCasesGroup struct {
+	Name      string
+	TestCases []testCase
+}
+
+// TestCases is a collection of all test cases groups related to KongTarget validation.
+var TestCases = []testCasesGroup{}
+
+func init() {
+	TestCases = append(TestCases, controlPlaneRef, vaultSpec)
+}
+
+var commonObjectMeta = metav1.ObjectMeta{
+	GenerateName: "test-kongvault-",
+	Namespace:    "default",
+}

--- a/test/crdsvalidation/kongvault/testcases/controlplaneref.go
+++ b/test/crdsvalidation/kongvault/testcases/controlplaneref.go
@@ -1,0 +1,84 @@
+package testcases
+
+import (
+	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
+)
+
+var controlPlaneRef = testCasesGroup{
+	Name: "control plane ref",
+	TestCases: []testCase{
+		{
+			Name: "no control plane ref to have control plane ref in valid",
+			KongVault: configurationv1alpha1.KongVault{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1alpha1.KongVaultSpec{
+					Backend: "aws",
+					Prefix:  "aws-vault",
+				},
+			},
+			Update: func(v *configurationv1alpha1.KongVault) {
+				v.Spec.ControlPlaneRef = &configurationv1alpha1.ControlPlaneRef{
+					Type:      configurationv1alpha1.ControlPlaneRefKonnectID,
+					KonnectID: lo.ToPtr("konnect-1"),
+				}
+			},
+		},
+		{
+			Name: "have control plane to no control plane is invalid",
+			KongVault: configurationv1alpha1.KongVault{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1alpha1.KongVaultSpec{
+					ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+						Type:      configurationv1alpha1.ControlPlaneRefKonnectID,
+						KonnectID: lo.ToPtr("konnect-1"),
+					},
+					Backend: "aws",
+					Prefix:  "aws-vault",
+				},
+			},
+			Update: func(v *configurationv1alpha1.KongVault) {
+				v.Spec.ControlPlaneRef = nil
+			},
+			ExpectedUpdateErrorMessage: lo.ToPtr("controlPlaneRef is required once set"),
+		},
+		{
+			Name: "control plane is immutable once programmed",
+			KongVault: configurationv1alpha1.KongVault{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1alpha1.KongVaultSpec{
+					ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+						Type:      configurationv1alpha1.ControlPlaneRefKonnectID,
+						KonnectID: lo.ToPtr("konnect-1"),
+					},
+					Backend: "aws",
+					Prefix:  "aws-vault",
+				},
+			},
+			KongVaultStatus: &configurationv1alpha1.KongVaultStatus{
+				Konnect: &konnectv1alpha1.KonnectEntityStatusWithControlPlaneRef{
+					ControlPlaneID: "konnect-1",
+				},
+				Conditions: []metav1.Condition{
+					{
+						Type:               "Programmed",
+						Status:             metav1.ConditionTrue,
+						ObservedGeneration: 1,
+						Reason:             "Programmed",
+						LastTransitionTime: metav1.Now(),
+					},
+				},
+			},
+			Update: func(v *configurationv1alpha1.KongVault) {
+				v.Spec.ControlPlaneRef = &configurationv1alpha1.ControlPlaneRef{
+					Type:      configurationv1alpha1.ControlPlaneRefKonnectID,
+					KonnectID: lo.ToPtr("konnect-2"),
+				}
+			},
+			ExpectedUpdateErrorMessage: lo.ToPtr("spec.controlPlaneRef is immutable when an entity is already Programmed"),
+		},
+	},
+}

--- a/test/crdsvalidation/kongvault/testcases/vaultspec.go
+++ b/test/crdsvalidation/kongvault/testcases/vaultspec.go
@@ -1,0 +1,46 @@
+package testcases
+
+import (
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+	"github.com/samber/lo"
+)
+
+var vaultSpec = testCasesGroup{
+	Name: "vault specification",
+	TestCases: []testCase{
+		{
+			Name: "backend must be non-empty",
+			KongVault: configurationv1alpha1.KongVault{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1alpha1.KongVaultSpec{
+					Prefix: "aws-vault",
+				},
+			},
+			ExpectedErrorMessage: lo.ToPtr("spec.backend: Invalid value"),
+		},
+		{
+			Name: "prefix must be non-empty",
+			KongVault: configurationv1alpha1.KongVault{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1alpha1.KongVaultSpec{
+					Backend: "aws",
+				},
+			},
+			ExpectedErrorMessage: lo.ToPtr("spec.prefix: Invalid value"),
+		},
+		{
+			Name: "prefix is immutatble",
+			KongVault: configurationv1alpha1.KongVault{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1alpha1.KongVaultSpec{
+					Backend: "aws",
+					Prefix:  "aws-vault",
+				},
+			},
+			Update: func(v *configurationv1alpha1.KongVault) {
+				v.Spec.Prefix = v.Spec.Prefix + "-1"
+			},
+			ExpectedUpdateErrorMessage: lo.ToPtr("The spec.prefix field is immutable"),
+		},
+	},
+}

--- a/test/unit/konvault_test.go
+++ b/test/unit/konvault_test.go
@@ -1,0 +1,23 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+)
+
+func TestKongVault(t *testing.T) {
+	v := &configurationv1alpha1.KongVault{}
+
+	require.Nil(t, v.GetKonnectStatus())
+	require.Empty(t, v.GetKonnectStatus().GetKonnectID())
+	require.Empty(t, v.GetKonnectStatus().GetOrgID())
+	require.Empty(t, v.GetKonnectStatus().GetServerURL())
+
+	require.Equal(t, "", v.GetControlPlaneID())
+	v.SetControlPlaneID("123")
+	require.Equal(t, "123", v.GetControlPlaneID())
+	require.Equal(t, "123", v.Status.Konnect.ControlPlaneID)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add Konnect specific validations (`spec.controlPlaneRef`) and CRD validation tests for `KongVault`.
**Which issue this PR fixes**

Related to [KGO#577](https://github.com/Kong/gateway-operator/issues/577)

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
