### PR TITLE
ci: add golangci-lint

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,6 +55,21 @@ jobs:
     - name: Verify
       run: make verify.diff
 
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+
+    - uses: jdx/mise-action@v2
+      with:
+        install: false
+
+    - run: make lint
+
   apply:
     runs-on: ubuntu-latest
     steps:
@@ -108,6 +123,7 @@ jobs:
       - test-unit
       - generate
       - apply
+      - lint
       - CRDs-validation
     if: always()
     steps:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,124 @@
+run:
+  timeout: 5m
+linters:
+  enable:
+  - asciicheck
+  - bodyclose
+  - copyloopvar
+  - dogsled
+  - durationcheck
+  - errcheck
+  - errorlint
+  - exhaustive
+  - forbidigo
+  - gci
+  - gocritic
+  - gofmt
+  - goimports
+  - gomodguard
+  - gosec
+  - gosimple
+  - govet
+  - importas
+  - ineffassign
+  - misspell
+  - nakedret
+  - nilerr
+  - nolintlint
+  - predeclared
+  - revive
+  - staticcheck
+  - typecheck
+  - unconvert
+  - unparam
+  - unused
+  - wastedassign
+linters-settings:
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(github.com/Kong/sdk-konnect-go)
+      - prefix(github.com/kong/kubernetes-configuration)
+  importas:
+    no-unaliased: true
+    alias:
+      - pkg: k8s.io/api/core/v1
+        alias: corev1
+      - pkg: k8s.io/api/apps/v1
+        alias: appsv1
+      - pkg: k8s.io/api/admission/v1
+        alias: admissionv1
+      - pkg: k8s.io/api/certificates/v1
+        alias: certificatesv1
+
+      - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+        alias: metav1
+      - pkg: sigs.k8s.io/gateway-api/apis/(v[\w\d]+)
+        alias: gateway${1}
+
+      - pkg: sigs.k8s.io/controller-runtime/pkg/log
+        alias: ctrllog
+
+      - pkg: github.com/Kong/sdk-konnect-go/models/components
+        alias: sdkkonnectcomp
+      - pkg: github.com/Kong/sdk-konnect-go/models/operations
+        alias: sdkkonnectops
+      - pkg: github.com/Kong/sdk-konnect-go/models/sdkerrors
+        alias: sdkkonnecterrs
+  revive:
+    rules:
+      - name: errorf
+        severity: warning
+        disabled: false
+      - name: error-strings
+        severity: warning
+        disabled: false
+      - name: error-naming
+        severity: warning
+        disabled: false
+      - name: duplicated-imports
+        severity: warning
+        disabled: false
+      - name: empty-block
+        severity: warning
+        disabled: false
+      - name: exported
+        severity: warning
+        disabled: false
+        arguments:
+          - "checkPrivateReceivers"
+          # TODO: enable this when ready to refactor exported types that stutter at call site.
+          - "disableStutteringCheck"
+      - name: context-as-argument
+        # TODO: re-add this rule after https://github.com/golangci/golangci-lint/issues/3280
+        # is resolved and released.
+        # arguments:
+        #   - "allowTypesBefore": "*testing.T"
+        disabled: true
+  exhaustive:
+    default-signifies-exhaustive: true
+  gomodguard:
+    blocked:
+      modules:
+      - golang.org/x/exp:
+         recommendations:
+          - maps
+          - slices
+          - github.com/samber/lo
+      - github.com/pkg/errors:
+          recommendations:
+          - fmt
+          - errors
+      - github.com/sirupsen/logrus:
+          recommendations:
+          - sigs.k8s.io/controller-runtime/pkg/log
+          - go.uber.org/zap/zapcore
+issues:
+  max-same-issues: 0
+  fix: true
+  exclude-dirs:
+    - pkg/clientset
+    - api
+  include:
+    - EXC0012

--- a/.tools_versions.yaml
+++ b/.tools_versions.yaml
@@ -10,3 +10,5 @@ crd-ref-docs: "0.1.0"
 yq: "4.44.3"
 # renovate: datasource=github-releases depName=gotestyourself/gotestsum
 gotestsum: "1.12.0"
+# renovate: datasource=github-releases depName=golangci/golangci-lint
+golangci-lint: "1.61.0"

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,13 @@ gotestsum: mise yq ## Download gotestsum locally if necessary.
 	@$(MISE) plugin install --yes -q gotestsum https://github.com/pmalek/mise-gotestsum.git
 	@$(MISE) install -q gotestsum@$(GOTESTSUM_VERSION)
 
+GOLANGCI_LINT_VERSION = $(shell $(YQ) -r '.golangci-lint' < $(TOOLS_VERSIONS_FILE))
+GOLANGCI_LINT = $(PROJECT_DIR)/bin/installs/golangci-lint/$(GOLANGCI_LINT_VERSION)/bin/golangci-lint
+.PHONY: golangci-lint
+golangci-lint: mise yq ## Download golangci-lint locally if necessary.
+	@$(MISE) plugin install --yes -q golangci-lint
+	@$(MISE) install -q golangci-lint@$(GOLANGCI_LINT_VERSION)
+
 # ------------------------------------------------------------------------------
 # Verify steps
 # ------------------------------------------------------------------------------
@@ -182,6 +189,11 @@ generate.apidocs: crd-ref-docs
 .PHONY: install
 install: generate.crds kustomize
 	$(KUSTOMIZE) build config/crd | kubectl apply -f -
+
+GOLANGCI_LINT_CONFIG ?= $(PROJECT_DIR)/.golangci.yaml
+.PHONY: lint
+lint: golangci-lint
+	$(GOLANGCI_LINT) run -v --config $(GOLANGCI_LINT_CONFIG) $(GOLANGCI_LINT_FLAGS)
 
 .PHONY: test.samples
 test.samples: kustomize

--- a/pkg/metadata/tags.go
+++ b/pkg/metadata/tags.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 )
 
+// ObjectWithAnnotations is an interface that provides a method to get annotations.
 type ObjectWithAnnotations interface {
 	GetAnnotations() map[string]string
 }

--- a/pkg/metadata/tags_test.go
+++ b/pkg/metadata/tags_test.go
@@ -3,9 +3,10 @@ package metadata
 import (
 	"testing"
 
-	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
 )
 
 func TestExtractTags(t *testing.T) {

--- a/test/crdsvalidation/kongconsumer/kongconsumer_test.go
+++ b/test/crdsvalidation/kongconsumer/kongconsumer_test.go
@@ -22,10 +22,8 @@ func TestKongConsumer(t *testing.T) {
 	require.NoError(t, err, "error creating configurationv1 client")
 
 	for _, tcsGroup := range testcases.TestCases {
-		tcsGroup := tcsGroup
 		t.Run(tcsGroup.Name, func(t *testing.T) {
 			for _, tc := range tcsGroup.TestCases {
-				tc := tc
 				t.Run(tc.Name, func(t *testing.T) {
 					cl := cl.KongConsumers(tc.KongConsumer.Namespace)
 					entity, err := cl.Create(ctx, &tc.KongConsumer, metav1.CreateOptions{})

--- a/test/crdsvalidation/kongconsumergroup/kongconsumergroup_test.go
+++ b/test/crdsvalidation/kongconsumergroup/kongconsumergroup_test.go
@@ -22,10 +22,8 @@ func TestKongConsumerGroup(t *testing.T) {
 	require.NoError(t, err, "error creating configurationv1 client")
 
 	for _, tcsGroup := range testcases.TestCases {
-		tcsGroup := tcsGroup
 		t.Run(tcsGroup.Name, func(t *testing.T) {
 			for _, tc := range tcsGroup.TestCases {
-				tc := tc
 				t.Run(tc.Name, func(t *testing.T) {
 					cl := cl.KongConsumerGroups(tc.KongConsumerGroup.Namespace)
 					entity, err := cl.Create(ctx, &tc.KongConsumerGroup, metav1.CreateOptions{})

--- a/test/crdsvalidation/kongpluginbindings/kongpluginbindings_test.go
+++ b/test/crdsvalidation/kongpluginbindings/kongpluginbindings_test.go
@@ -22,10 +22,8 @@ func TestKongPluginBindings(t *testing.T) {
 	require.NoError(t, err, "error creating configurationv1alpha1 client")
 
 	for _, tcsGroup := range testcases.TestCases {
-		tcsGroup := tcsGroup
 		t.Run(tcsGroup.Name, func(t *testing.T) {
 			for _, tc := range tcsGroup.TestCases {
-				tc := tc
 				t.Run(tc.Name, func(t *testing.T) {
 					cl := cl.KongPluginBindings(tc.KongPluginBinding.Namespace)
 					entity, err := cl.Create(ctx, &tc.KongPluginBinding, metav1.CreateOptions{})

--- a/test/crdsvalidation/kongroute/kongroute_test.go
+++ b/test/crdsvalidation/kongroute/kongroute_test.go
@@ -22,10 +22,8 @@ func TestKongRoute(t *testing.T) {
 	require.NoError(t, err, "error creating configurationv1alpha1 client")
 
 	for _, tcsGroup := range testcases.TestCases {
-		tcsGroup := tcsGroup
 		t.Run(tcsGroup.Name, func(t *testing.T) {
 			for _, tc := range tcsGroup.TestCases {
-				tc := tc
 				t.Run(tc.Name, func(t *testing.T) {
 					cl := cl.KongRoutes(tc.KongRoute.Namespace)
 					entity, err := cl.Create(ctx, &tc.KongRoute, metav1.CreateOptions{})

--- a/test/crdsvalidation/kongroute/testcases/protocols.go
+++ b/test/crdsvalidation/kongroute/testcases/protocols.go
@@ -1,9 +1,11 @@
 package testcases
 
 import (
-	"github.com/Kong/sdk-konnect-go/models/components"
-	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 	"github.com/samber/lo"
+
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 )
 
 var protocols = testCasesGroup{
@@ -34,7 +36,7 @@ var protocols = testCasesGroup{
 						NamespacedRef: &configurationv1alpha1.NamespacedServiceRef{Name: "svc"},
 					},
 					KongRouteAPISpec: configurationv1alpha1.KongRouteAPISpec{
-						Protocols: []components.RouteProtocols{"http"},
+						Protocols: []sdkkonnectcomp.RouteProtocols{"http"},
 						Hosts:     []string{"example.com"},
 					},
 				},
@@ -50,7 +52,7 @@ var protocols = testCasesGroup{
 						NamespacedRef: &configurationv1alpha1.NamespacedServiceRef{Name: "svc"},
 					},
 					KongRouteAPISpec: configurationv1alpha1.KongRouteAPISpec{
-						Protocols: []components.RouteProtocols{"http"},
+						Protocols: []sdkkonnectcomp.RouteProtocols{"http"},
 					},
 				},
 			},

--- a/test/crdsvalidation/kongroute/testcases/serviceref.go
+++ b/test/crdsvalidation/kongroute/testcases/serviceref.go
@@ -1,9 +1,10 @@
 package testcases
 
 import (
-	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 	"github.com/samber/lo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 )
 
 var serviceRef = testCasesGroup{

--- a/test/crdsvalidation/kongservice/kongservice_test.go
+++ b/test/crdsvalidation/kongservice/kongservice_test.go
@@ -22,10 +22,8 @@ func TestKongService(t *testing.T) {
 	require.NoError(t, err, "error creating configurationv1alpha1 client")
 
 	for _, tcsGroup := range testcases.TestCases {
-		tcsGroup := tcsGroup
 		t.Run(tcsGroup.Name, func(t *testing.T) {
 			for _, tc := range tcsGroup.TestCases {
-				tc := tc
 				t.Run(tc.Name, func(t *testing.T) {
 					cl := cl.KongServices(tc.KongService.Namespace)
 					entity, err := cl.Create(ctx, &tc.KongService, metav1.CreateOptions{})

--- a/test/crdsvalidation/kongservice/testcases/controlplaneref.go
+++ b/test/crdsvalidation/kongservice/testcases/controlplaneref.go
@@ -1,10 +1,10 @@
 package testcases
 
 import (
+	"github.com/samber/lo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
-	"github.com/samber/lo"
 )
 
 var cpRef = testCasesGroup{

--- a/test/crdsvalidation/kongtarget/testcases/kongtargetapispec.go
+++ b/test/crdsvalidation/kongtarget/testcases/kongtargetapispec.go
@@ -1,8 +1,9 @@
 package testcases
 
 import (
-	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 	"github.com/samber/lo"
+
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 )
 
 var kongTargetAPISpec = testCasesGroup{

--- a/test/crdsvalidation/kongtarget/testcases/upstreamref.go
+++ b/test/crdsvalidation/kongtarget/testcases/upstreamref.go
@@ -1,8 +1,9 @@
 package testcases
 
 import (
-	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 	"github.com/samber/lo"
+
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 )
 
 var upstreamRef = testCasesGroup{

--- a/test/crdsvalidation/kongupstream/kongupstream_test.go
+++ b/test/crdsvalidation/kongupstream/kongupstream_test.go
@@ -22,10 +22,8 @@ func TestKongUpstream(t *testing.T) {
 	require.NoError(t, err, "error creating configurationv1alpha1 client")
 
 	for _, tcsGroup := range testcases.TestCases {
-		tcsGroup := tcsGroup
 		t.Run(tcsGroup.Name, func(t *testing.T) {
 			for _, tc := range tcsGroup.TestCases {
-				tc := tc
 				t.Run(tc.Name, func(t *testing.T) {
 					cl := cl.KongUpstreams(tc.KongUpstream.Namespace)
 					entity, err := cl.Create(ctx, &tc.KongUpstream, metav1.CreateOptions{})

--- a/test/crdsvalidation/kongupstream/testcases/controlplaneref.go
+++ b/test/crdsvalidation/kongupstream/testcases/controlplaneref.go
@@ -1,10 +1,10 @@
 package testcases
 
 import (
+	"github.com/samber/lo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
-	"github.com/samber/lo"
 )
 
 var cpRef = testCasesGroup{

--- a/test/crdsvalidation/kongupstream/testcases/required_fields.go
+++ b/test/crdsvalidation/kongupstream/testcases/required_fields.go
@@ -1,9 +1,11 @@
 package testcases
 
 import (
-	"github.com/Kong/sdk-konnect-go/models/components"
-	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 	"github.com/samber/lo"
+
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 )
 
 var requiredFields = testCasesGroup{
@@ -21,7 +23,7 @@ var requiredFields = testCasesGroup{
 						},
 					},
 					KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
-						HashFallback:       lo.ToPtr(components.HashFallbackHeader),
+						HashFallback:       lo.ToPtr(sdkkonnectcomp.HashFallbackHeader),
 						HashFallbackHeader: lo.ToPtr("X-Hash-Fallback"),
 					},
 				},
@@ -39,7 +41,7 @@ var requiredFields = testCasesGroup{
 						},
 					},
 					KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
-						HashFallback: lo.ToPtr(components.HashFallbackHeader),
+						HashFallback: lo.ToPtr(sdkkonnectcomp.HashFallbackHeader),
 					},
 				},
 			},
@@ -57,7 +59,7 @@ var requiredFields = testCasesGroup{
 						},
 					},
 					KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
-						HashFallback:         lo.ToPtr(components.HashFallbackQueryArg),
+						HashFallback:         lo.ToPtr(sdkkonnectcomp.HashFallbackQueryArg),
 						HashFallbackQueryArg: lo.ToPtr("arg"),
 					},
 				},
@@ -75,7 +77,7 @@ var requiredFields = testCasesGroup{
 						},
 					},
 					KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
-						HashFallback: lo.ToPtr(components.HashFallbackQueryArg),
+						HashFallback: lo.ToPtr(sdkkonnectcomp.HashFallbackQueryArg),
 					},
 				},
 			},
@@ -93,7 +95,7 @@ var requiredFields = testCasesGroup{
 						},
 					},
 					KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
-						HashFallback:           lo.ToPtr(components.HashFallbackURICapture),
+						HashFallback:           lo.ToPtr(sdkkonnectcomp.HashFallbackURICapture),
 						HashFallbackURICapture: lo.ToPtr("arg"),
 					},
 				},
@@ -111,7 +113,7 @@ var requiredFields = testCasesGroup{
 						},
 					},
 					KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
-						HashFallback: lo.ToPtr(components.HashFallbackURICapture),
+						HashFallback: lo.ToPtr(sdkkonnectcomp.HashFallbackURICapture),
 					},
 				},
 			},
@@ -129,7 +131,7 @@ var requiredFields = testCasesGroup{
 						},
 					},
 					KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
-						HashOn:           lo.ToPtr(components.HashOnCookie),
+						HashOn:           lo.ToPtr(sdkkonnectcomp.HashOnCookie),
 						HashOnCookie:     lo.ToPtr("cookie"),
 						HashOnCookiePath: lo.ToPtr("X-Hash-On-Cookie-Path"),
 					},
@@ -148,7 +150,7 @@ var requiredFields = testCasesGroup{
 						},
 					},
 					KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
-						HashFallback:     lo.ToPtr(components.HashFallbackCookie),
+						HashFallback:     lo.ToPtr(sdkkonnectcomp.HashFallbackCookie),
 						HashOnCookie:     lo.ToPtr("cookie"),
 						HashOnCookiePath: lo.ToPtr("X-Hash-On-Cookie-Path"),
 					},
@@ -167,7 +169,7 @@ var requiredFields = testCasesGroup{
 						},
 					},
 					KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
-						HashOn:           lo.ToPtr(components.HashOnCookie),
+						HashOn:           lo.ToPtr(sdkkonnectcomp.HashOnCookie),
 						HashOnCookiePath: lo.ToPtr("X-Hash-On-Cookie-Path"),
 					},
 				},
@@ -186,7 +188,7 @@ var requiredFields = testCasesGroup{
 						},
 					},
 					KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
-						HashFallback:     lo.ToPtr(components.HashFallbackCookie),
+						HashFallback:     lo.ToPtr(sdkkonnectcomp.HashFallbackCookie),
 						HashOnCookiePath: lo.ToPtr("X-Hash-On-Cookie-Path"),
 					},
 				},
@@ -205,7 +207,7 @@ var requiredFields = testCasesGroup{
 						},
 					},
 					KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
-						HashOn:       lo.ToPtr(components.HashOnCookie),
+						HashOn:       lo.ToPtr(sdkkonnectcomp.HashOnCookie),
 						HashOnCookie: lo.ToPtr("cookie"),
 					},
 				},
@@ -224,7 +226,7 @@ var requiredFields = testCasesGroup{
 						},
 					},
 					KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
-						HashFallback: lo.ToPtr(components.HashFallbackCookie),
+						HashFallback: lo.ToPtr(sdkkonnectcomp.HashFallbackCookie),
 						HashOnCookie: lo.ToPtr("cookie"),
 					},
 				},
@@ -243,7 +245,7 @@ var requiredFields = testCasesGroup{
 						},
 					},
 					KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
-						HashFallback: lo.ToPtr(components.HashFallbackCookie),
+						HashFallback: lo.ToPtr(sdkkonnectcomp.HashFallbackCookie),
 					},
 				},
 			},
@@ -261,7 +263,7 @@ var requiredFields = testCasesGroup{
 						},
 					},
 					KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
-						HashOn: lo.ToPtr(components.HashOnCookie),
+						HashOn: lo.ToPtr(sdkkonnectcomp.HashOnCookie),
 					},
 				},
 			},
@@ -279,7 +281,7 @@ var requiredFields = testCasesGroup{
 						},
 					},
 					KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
-						HashOn: lo.ToPtr(components.HashOnHeader),
+						HashOn: lo.ToPtr(sdkkonnectcomp.HashOnHeader),
 					},
 				},
 			},
@@ -297,7 +299,7 @@ var requiredFields = testCasesGroup{
 						},
 					},
 					KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
-						HashOn:         lo.ToPtr(components.HashOnQueryArg),
+						HashOn:         lo.ToPtr(sdkkonnectcomp.HashOnQueryArg),
 						HashOnQueryArg: lo.ToPtr("arg"),
 					},
 				},
@@ -315,7 +317,7 @@ var requiredFields = testCasesGroup{
 						},
 					},
 					KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
-						HashOn: lo.ToPtr(components.HashOnQueryArg),
+						HashOn: lo.ToPtr(sdkkonnectcomp.HashOnQueryArg),
 					},
 				},
 			},
@@ -333,7 +335,7 @@ var requiredFields = testCasesGroup{
 						},
 					},
 					KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
-						HashOn:           lo.ToPtr(components.HashOnURICapture),
+						HashOn:           lo.ToPtr(sdkkonnectcomp.HashOnURICapture),
 						HashOnURICapture: lo.ToPtr("arg"),
 					},
 				},
@@ -351,7 +353,7 @@ var requiredFields = testCasesGroup{
 						},
 					},
 					KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{
-						HashOn: lo.ToPtr(components.HashOnURICapture),
+						HashOn: lo.ToPtr(sdkkonnectcomp.HashOnURICapture),
 					},
 				},
 			},

--- a/test/crdsvalidation/kongvault/testcases/vaultspec.go
+++ b/test/crdsvalidation/kongvault/testcases/vaultspec.go
@@ -1,8 +1,9 @@
 package testcases
 
 import (
-	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 	"github.com/samber/lo"
+
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
 )
 
 var vaultSpec = testCasesGroup{
@@ -38,7 +39,7 @@ var vaultSpec = testCasesGroup{
 				},
 			},
 			Update: func(v *configurationv1alpha1.KongVault) {
-				v.Spec.Prefix = v.Spec.Prefix + "-1"
+				v.Spec.Prefix += "-1"
 			},
 			ExpectedUpdateErrorMessage: lo.ToPtr("The spec.prefix field is immutable"),
 		},

--- a/test/crdsvalidation/konnectgatewaycontrolplane/konnectgatewaycontrolplane_test.go
+++ b/test/crdsvalidation/konnectgatewaycontrolplane/konnectgatewaycontrolplane_test.go
@@ -22,10 +22,8 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 	require.NoError(t, err, "error creating konnectv1alpha1client client")
 
 	for _, tcsGroup := range testcases.TestCases {
-		tcsGroup := tcsGroup
 		t.Run(tcsGroup.Name, func(t *testing.T) {
 			for _, tc := range tcsGroup.TestCases {
-				tc := tc
 				t.Run(tc.Name, func(t *testing.T) {
 					cl := cl.KonnectGatewayControlPlanes(tc.KonnectGatewayControlPlane.Namespace)
 					entity, err := cl.Create(ctx, &tc.KonnectGatewayControlPlane, metav1.CreateOptions{})

--- a/test/crdsvalidation/konnectgatewaycontrolplane/testcases/update-not-allowed-for-status.go
+++ b/test/crdsvalidation/konnectgatewaycontrolplane/testcases/update-not-allowed-for-status.go
@@ -1,9 +1,10 @@
 package testcases
 
 import (
-	"github.com/Kong/sdk-konnect-go/models/components"
 	"github.com/samber/lo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
@@ -18,9 +19,9 @@ var updatesNotAllowedForStatus = testCasesGroup{
 			KonnectGatewayControlPlane: konnectv1alpha1.KonnectGatewayControlPlane{
 				ObjectMeta: commonObjectMeta,
 				Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
-					CreateControlPlaneRequest: components.CreateControlPlaneRequest{
+					CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 						Name:        "cp-1",
-						ClusterType: lo.ToPtr(components.ClusterTypeClusterTypeControlPlane),
+						ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
 					},
 					KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
 						APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
@@ -49,9 +50,9 @@ var updatesNotAllowedForStatus = testCasesGroup{
 			KonnectGatewayControlPlane: konnectv1alpha1.KonnectGatewayControlPlane{
 				ObjectMeta: commonObjectMeta,
 				Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
-					CreateControlPlaneRequest: components.CreateControlPlaneRequest{
+					CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 						Name:        "cp-1",
-						ClusterType: lo.ToPtr(components.ClusterTypeClusterTypeControlPlane),
+						ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
 					},
 					KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
 						APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
@@ -80,9 +81,9 @@ var updatesNotAllowedForStatus = testCasesGroup{
 			KonnectGatewayControlPlane: konnectv1alpha1.KonnectGatewayControlPlane{
 				ObjectMeta: commonObjectMeta,
 				Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
-					CreateControlPlaneRequest: components.CreateControlPlaneRequest{
+					CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 						Name:        "cp-1",
-						ClusterType: lo.ToPtr(components.ClusterTypeClusterTypeControlPlane),
+						ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
 					},
 					KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
 						APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{


### PR DESCRIPTION
**What this PR does / why we need it**:

Add linter to enforce consistent code style.