### PR TITLE
feat(konnect): add namespace in KonnectNamespacedRef

### DIFF
--- a/api/configuration/v1/kongconsumer_types.go
+++ b/api/configuration/v1/kongconsumer_types.go
@@ -34,7 +34,6 @@ import (
 // +kubebuilder:printcolumn:name="Programmed",type=string,JSONPath=`.status.conditions[?(@.type=="Programmed")].status`
 // +kubebuilder:validation:XValidation:rule="has(self.username) || has(self.custom_id)", message="Need to provide either username or custom_id"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
-//  REVIEW: allow same namespace?
 // +kubebuilder:validation:XValidation:rule="!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
 // +kubebuilder:validation:XValidation:rule="(!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 

--- a/api/configuration/v1/kongconsumer_types.go
+++ b/api/configuration/v1/kongconsumer_types.go
@@ -34,6 +34,8 @@ import (
 // +kubebuilder:printcolumn:name="Programmed",type=string,JSONPath=`.status.conditions[?(@.type=="Programmed")].status`
 // +kubebuilder:validation:XValidation:rule="has(self.username) || has(self.custom_id)", message="Need to provide either username or custom_id"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
+//  REVIEW: allow same namespace?
+// +kubebuilder:validation:XValidation:rule="!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
 // +kubebuilder:validation:XValidation:rule="(!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 
 // KongConsumer is the Schema for the kongconsumers API.

--- a/api/configuration/v1alpha1/kong_ca_certificate.go
+++ b/api/configuration/v1alpha1/kong_ca_certificate.go
@@ -15,6 +15,7 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 type KongCACertificate struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/configuration/v1alpha1/kongservice_types.go
+++ b/api/configuration/v1alpha1/kongservice_types.go
@@ -35,6 +35,7 @@ import (
 // +kubebuilder:printcolumn:name="Protocol",type=string,JSONPath=`.spec.procol`,description="Protocol of the service"
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 type KongService struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/configuration/v1alpha1/kongupstream_types.go
+++ b/api/configuration/v1alpha1/kongupstream_types.go
@@ -33,6 +33,7 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 type KongUpstream struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/configuration/v1alpha1/konnect_controlplaneref_types.go
+++ b/api/configuration/v1alpha1/konnect_controlplaneref_types.go
@@ -41,8 +41,10 @@ type KonnectNamespacedRef struct {
 
 	// TODO: Implement cross namespace references:
 	// https://github.com/Kong/kubernetes-configuration/issues/36
-	// Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
+
 	// Namespace is the namespace where the Konnect Control Plane is in.
+	// Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
+	//
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
 }

--- a/api/configuration/v1alpha1/konnect_controlplaneref_types.go
+++ b/api/configuration/v1alpha1/konnect_controlplaneref_types.go
@@ -39,6 +39,7 @@ type KonnectNamespacedRef struct {
 	// +kubebuilder:validation:Required
 	Name string `json:"name"`
 
-	// TODO: Implement cross namespace references:
-	// https://github.com/Kong/kubernetes-configuration/issues/36
+	// Namespace is the namespace where the Konnect Control Plane is in.
+	// +optional
+	Namespace string `json:"namespace,omitempty"`
 }

--- a/api/configuration/v1alpha1/konnect_controlplaneref_types.go
+++ b/api/configuration/v1alpha1/konnect_controlplaneref_types.go
@@ -39,6 +39,9 @@ type KonnectNamespacedRef struct {
 	// +kubebuilder:validation:Required
 	Name string `json:"name"`
 
+	// TODO: Implement cross namespace references:
+	// https://github.com/Kong/kubernetes-configuration/issues/36
+	// Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
 	// Namespace is the namespace where the Konnect Control Plane is in.
 	// +optional
 	Namespace string `json:"namespace,omitempty"`

--- a/api/configuration/v1beta1/kongconsumergroup_types.go
+++ b/api/configuration/v1beta1/kongconsumergroup_types.go
@@ -32,6 +32,7 @@ import (
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age"
 // +kubebuilder:printcolumn:name="Programmed",type=string,JSONPath=`.status.conditions[?(@.type=="Programmed")].status`
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
+// +kubebuilder:validation:XValidation:rule="!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
 // +kubebuilder:validation:XValidation:rule="(!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 
 // KongConsumerGroup is the Schema for the kongconsumergroups API.

--- a/config/crd/bases/configuration.konghq.com_kongcacertificates.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongcacertificates.yaml
@@ -67,6 +67,10 @@ spec:
                       name:
                         description: Name is the name of the Konnect Control Plane.
                         type: string
+                      namespace:
+                        description: Namespace is the namespace where the Konnect
+                          Control Plane is in.
+                        type: string
                     required:
                     - name
                     type: object

--- a/config/crd/bases/configuration.konghq.com_kongcacertificates.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongcacertificates.yaml
@@ -68,8 +68,10 @@ spec:
                         description: Name is the name of the Konnect Control Plane.
                         type: string
                       namespace:
-                        description: Namespace is the namespace where the Konnect
-                          Control Plane is in.
+                        description: |-
+                          https://github.com/Kong/kubernetes-configuration/issues/36
+                          Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
+                          Namespace is the namespace where the Konnect Control Plane is in.
                         type: string
                     required:
                     - name
@@ -198,6 +200,8 @@ spec:
         x-kubernetes-validations:
         - message: controlPlaneRef is required once set
           rule: '!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)'
+        - message: spec.controlPlaneRef cannot specify namespace for namespaced resource
+          rule: '!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'
         - message: spec.controlPlaneRef is immutable when an entity is already Programmed
           rule: '(!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
             == ''True'')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef'

--- a/config/crd/bases/configuration.konghq.com_kongcacertificates.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongcacertificates.yaml
@@ -69,9 +69,8 @@ spec:
                         type: string
                       namespace:
                         description: |-
-                          https://github.com/Kong/kubernetes-configuration/issues/36
-                          Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
                           Namespace is the namespace where the Konnect Control Plane is in.
+                          Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
                         type: string
                     required:
                     - name

--- a/config/crd/bases/configuration.konghq.com_kongconsumergroups.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongconsumergroups.yaml
@@ -70,9 +70,8 @@ spec:
                         type: string
                       namespace:
                         description: |-
-                          https://github.com/Kong/kubernetes-configuration/issues/36
-                          Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
                           Namespace is the namespace where the Konnect Control Plane is in.
+                          Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
                         type: string
                     required:
                     - name

--- a/config/crd/bases/configuration.konghq.com_kongconsumergroups.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongconsumergroups.yaml
@@ -68,6 +68,10 @@ spec:
                       name:
                         description: Name is the name of the Konnect Control Plane.
                         type: string
+                      namespace:
+                        description: Namespace is the namespace where the Konnect
+                          Control Plane is in.
+                        type: string
                     required:
                     - name
                     type: object

--- a/config/crd/bases/configuration.konghq.com_kongconsumergroups.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongconsumergroups.yaml
@@ -69,8 +69,10 @@ spec:
                         description: Name is the name of the Konnect Control Plane.
                         type: string
                       namespace:
-                        description: Namespace is the namespace where the Konnect
-                          Control Plane is in.
+                        description: |-
+                          https://github.com/Kong/kubernetes-configuration/issues/36
+                          Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
+                          Namespace is the namespace where the Konnect Control Plane is in.
                         type: string
                     required:
                     - name
@@ -199,6 +201,8 @@ spec:
         x-kubernetes-validations:
         - message: controlPlaneRef is required once set
           rule: '!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)'
+        - message: spec.controlPlaneRef cannot specify namespace for namespaced resource
+          rule: '!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'
         - message: spec.controlPlaneRef is immutable when an entity is already Programmed
           rule: '(!has(self.status) || !self.status.conditions.exists(c, c.type ==
             ''Programmed'' && c.status == ''True'')) ? true : oldSelf.spec.controlPlaneRef

--- a/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
@@ -94,8 +94,10 @@ spec:
                         description: Name is the name of the Konnect Control Plane.
                         type: string
                       namespace:
-                        description: Namespace is the namespace where the Konnect
-                          Control Plane is in.
+                        description: |-
+                          https://github.com/Kong/kubernetes-configuration/issues/36
+                          Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
+                          Namespace is the namespace where the Konnect Control Plane is in.
                         type: string
                     required:
                     - name
@@ -226,6 +228,8 @@ spec:
           rule: has(self.username) || has(self.custom_id)
         - message: controlPlaneRef is required once set
           rule: '!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)'
+        - message: spec.controlPlaneRef cannot specify namespace for namespaced resource
+          rule: '!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'
         - message: spec.controlPlaneRef is immutable when an entity is already Programmed
           rule: '(!has(self.status) || !self.status.conditions.exists(c, c.type ==
             ''Programmed'' && c.status == ''True'')) ? true : oldSelf.spec.controlPlaneRef

--- a/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
@@ -93,6 +93,10 @@ spec:
                       name:
                         description: Name is the name of the Konnect Control Plane.
                         type: string
+                      namespace:
+                        description: Namespace is the namespace where the Konnect
+                          Control Plane is in.
+                        type: string
                     required:
                     - name
                     type: object

--- a/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
@@ -95,9 +95,8 @@ spec:
                         type: string
                       namespace:
                         description: |-
-                          https://github.com/Kong/kubernetes-configuration/issues/36
-                          Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
                           Namespace is the namespace where the Konnect Control Plane is in.
+                          Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
                         type: string
                     required:
                     - name

--- a/config/crd/bases/configuration.konghq.com_kongpluginbindings.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongpluginbindings.yaml
@@ -73,9 +73,8 @@ spec:
                         type: string
                       namespace:
                         description: |-
-                          https://github.com/Kong/kubernetes-configuration/issues/36
-                          Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
                           Namespace is the namespace where the Konnect Control Plane is in.
+                          Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
                         type: string
                     required:
                     - name

--- a/config/crd/bases/configuration.konghq.com_kongpluginbindings.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongpluginbindings.yaml
@@ -71,6 +71,10 @@ spec:
                       name:
                         description: Name is the name of the Konnect Control Plane.
                         type: string
+                      namespace:
+                        description: Namespace is the namespace where the Konnect
+                          Control Plane is in.
+                        type: string
                     required:
                     - name
                     type: object

--- a/config/crd/bases/configuration.konghq.com_kongpluginbindings.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongpluginbindings.yaml
@@ -72,8 +72,10 @@ spec:
                         description: Name is the name of the Konnect Control Plane.
                         type: string
                       namespace:
-                        description: Namespace is the namespace where the Konnect
-                          Control Plane is in.
+                        description: |-
+                          https://github.com/Kong/kubernetes-configuration/issues/36
+                          Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
+                          Namespace is the namespace where the Konnect Control Plane is in.
                         type: string
                     required:
                     - name

--- a/config/crd/bases/configuration.konghq.com_kongservices.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongservices.yaml
@@ -77,8 +77,10 @@ spec:
                         description: Name is the name of the Konnect Control Plane.
                         type: string
                       namespace:
-                        description: Namespace is the namespace where the Konnect
-                          Control Plane is in.
+                        description: |-
+                          https://github.com/Kong/kubernetes-configuration/issues/36
+                          Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
+                          Namespace is the namespace where the Konnect Control Plane is in.
                         type: string
                     required:
                     - name
@@ -259,6 +261,8 @@ spec:
         x-kubernetes-validations:
         - message: controlPlaneRef is required once set
           rule: '!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)'
+        - message: spec.controlPlaneRef cannot specify namespace for namespaced resource
+          rule: '!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'
         - message: spec.controlPlaneRef is immutable when an entity is already Programmed
           rule: '(!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
             == ''True'')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef'

--- a/config/crd/bases/configuration.konghq.com_kongservices.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongservices.yaml
@@ -78,9 +78,8 @@ spec:
                         type: string
                       namespace:
                         description: |-
-                          https://github.com/Kong/kubernetes-configuration/issues/36
-                          Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
                           Namespace is the namespace where the Konnect Control Plane is in.
+                          Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
                         type: string
                     required:
                     - name

--- a/config/crd/bases/configuration.konghq.com_kongservices.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongservices.yaml
@@ -76,6 +76,10 @@ spec:
                       name:
                         description: Name is the name of the Konnect Control Plane.
                         type: string
+                      namespace:
+                        description: Namespace is the namespace where the Konnect
+                          Control Plane is in.
+                        type: string
                     required:
                     - name
                     type: object

--- a/config/crd/bases/configuration.konghq.com_kongupstreams.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongupstreams.yaml
@@ -75,9 +75,8 @@ spec:
                         type: string
                       namespace:
                         description: |-
-                          https://github.com/Kong/kubernetes-configuration/issues/36
-                          Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
                           Namespace is the namespace where the Konnect Control Plane is in.
+                          Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
                         type: string
                     required:
                     - name

--- a/config/crd/bases/configuration.konghq.com_kongupstreams.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongupstreams.yaml
@@ -73,6 +73,10 @@ spec:
                       name:
                         description: Name is the name of the Konnect Control Plane.
                         type: string
+                      namespace:
+                        description: Namespace is the namespace where the Konnect
+                          Control Plane is in.
+                        type: string
                     required:
                     - name
                     type: object

--- a/config/crd/bases/configuration.konghq.com_kongupstreams.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongupstreams.yaml
@@ -74,8 +74,10 @@ spec:
                         description: Name is the name of the Konnect Control Plane.
                         type: string
                       namespace:
-                        description: Namespace is the namespace where the Konnect
-                          Control Plane is in.
+                        description: |-
+                          https://github.com/Kong/kubernetes-configuration/issues/36
+                          Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
+                          Namespace is the namespace where the Konnect Control Plane is in.
                         type: string
                     required:
                     - name
@@ -415,6 +417,8 @@ spec:
         x-kubernetes-validations:
         - message: controlPlaneRef is required once set
           rule: '!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)'
+        - message: spec.controlPlaneRef cannot specify namespace for namespaced resource
+          rule: '!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'
         - message: spec.controlPlaneRef is immutable when an entity is already Programmed
           rule: '(!self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
             == ''True'')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef'

--- a/config/crd/bases/configuration.konghq.com_kongvaults.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongvaults.yaml
@@ -98,9 +98,8 @@ spec:
                         type: string
                       namespace:
                         description: |-
-                          https://github.com/Kong/kubernetes-configuration/issues/36
-                          Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
                           Namespace is the namespace where the Konnect Control Plane is in.
+                          Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
                         type: string
                     required:
                     - name

--- a/config/crd/bases/configuration.konghq.com_kongvaults.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongvaults.yaml
@@ -97,8 +97,10 @@ spec:
                         description: Name is the name of the Konnect Control Plane.
                         type: string
                       namespace:
-                        description: Namespace is the namespace where the Konnect
-                          Control Plane is in.
+                        description: |-
+                          https://github.com/Kong/kubernetes-configuration/issues/36
+                          Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`.
+                          Namespace is the namespace where the Konnect Control Plane is in.
                         type: string
                     required:
                     - name

--- a/config/crd/bases/configuration.konghq.com_kongvaults.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongvaults.yaml
@@ -96,6 +96,10 @@ spec:
                       name:
                         description: Name is the name of the Konnect Control Plane.
                         type: string
+                      namespace:
+                        description: Namespace is the namespace where the Konnect
+                          Control Plane is in.
+                        type: string
                     required:
                     - name
                     type: object

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1019,6 +1019,7 @@ KonnectNamespacedRef is the schema for the KonnectNamespacedRef type.
 | Field | Description |
 | --- | --- |
 | `name` _string_ | Name is the name of the Konnect Control Plane. |
+| `namespace` _string_ | Namespace is the namespace where the Konnect Control Plane is in. |
 
 
 _Appears in:_

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1019,7 +1019,7 @@ KonnectNamespacedRef is the schema for the KonnectNamespacedRef type.
 | Field | Description |
 | --- | --- |
 | `name` _string_ | Name is the name of the Konnect Control Plane. |
-| `namespace` _string_ | Namespace is the namespace where the Konnect Control Plane is in. |
+| `namespace` _string_ | TODO: Implement cross namespace references: https://github.com/Kong/kubernetes-configuration/issues/36 Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`. Namespace is the namespace where the Konnect Control Plane is in. |
 
 
 _Appears in:_

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1019,7 +1019,7 @@ KonnectNamespacedRef is the schema for the KonnectNamespacedRef type.
 | Field | Description |
 | --- | --- |
 | `name` _string_ | Name is the name of the Konnect Control Plane. |
-| `namespace` _string_ | TODO: Implement cross namespace references: https://github.com/Kong/kubernetes-configuration/issues/36 Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`. Namespace is the namespace where the Konnect Control Plane is in. |
+| `namespace` _string_ | Namespace is the namespace where the Konnect Control Plane is in. Currently only cluster scoped resources (KongVault) are allowed to set `konnectNamespacedRef.namespace`. |
 
 
 _Appears in:_

--- a/test/crdsvalidation/kongconsumer/testcases/common.go
+++ b/test/crdsvalidation/kongconsumer/testcases/common.go
@@ -28,6 +28,7 @@ var TestCases = []testCasesGroup{}
 
 func init() {
 	TestCases = append(TestCases,
+		controlPlaneRef,
 		requiredFields,
 		updatesNotAllowedForStatus,
 	)

--- a/test/crdsvalidation/kongconsumer/testcases/controlplaneref.go
+++ b/test/crdsvalidation/kongconsumer/testcases/controlplaneref.go
@@ -1,0 +1,31 @@
+package testcases
+
+import (
+	"github.com/samber/lo"
+
+	configurationv1 "github.com/kong/kubernetes-configuration/api/configuration/v1"
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+)
+
+var controlPlaneRef = testCasesGroup{
+	Name: "fields of controlPlaneRef",
+	TestCases: []testCase{
+		{
+			Name: "cpRef cannot have namespace",
+			KongConsumer: configurationv1.KongConsumer{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1.KongConsumerSpec{
+					ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+						Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+						KonnectNamespacedRef: &configurationv1alpha1.KonnectNamespacedRef{
+							Name:      "test-konnect-control-plane",
+							Namespace: "another-namespace",
+						},
+					},
+				},
+				Username: "username-1",
+			},
+			ExpectedErrorMessage: lo.ToPtr("spec.controlPlaneRef cannot specify namespace for namespaced resource"),
+		},
+	},
+}

--- a/test/crdsvalidation/kongconsumergroup/testcases/common.go
+++ b/test/crdsvalidation/kongconsumergroup/testcases/common.go
@@ -29,6 +29,7 @@ var TestCases = []testCasesGroup{}
 func init() {
 	TestCases = append(TestCases,
 		fields,
+		controlPlaneRef,
 		updatesNotAllowedForStatus,
 	)
 }

--- a/test/crdsvalidation/kongconsumergroup/testcases/controlplaneref.go
+++ b/test/crdsvalidation/kongconsumergroup/testcases/controlplaneref.go
@@ -1,0 +1,30 @@
+package testcases
+
+import (
+	"github.com/samber/lo"
+
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+	configurationv1beta1 "github.com/kong/kubernetes-configuration/api/configuration/v1beta1"
+)
+
+var controlPlaneRef = testCasesGroup{
+	Name: "fields of controlPlaneRef",
+	TestCases: []testCase{
+		{
+			Name: "cpRef cannot have namespace",
+			KongConsumerGroup: configurationv1beta1.KongConsumerGroup{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1beta1.KongConsumerGroupSpec{
+					ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+						Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+						KonnectNamespacedRef: &configurationv1alpha1.KonnectNamespacedRef{
+							Name:      "test-konnect-control-plane",
+							Namespace: "another-namespace",
+						},
+					},
+				},
+			},
+			ExpectedErrorMessage: lo.ToPtr("spec.controlPlaneRef cannot specify namespace for namespaced resource"),
+		},
+	},
+}

--- a/test/crdsvalidation/kongservice/testcases/controlplaneref.go
+++ b/test/crdsvalidation/kongservice/testcases/controlplaneref.go
@@ -58,6 +58,25 @@ var cpRef = testCasesGroup{
 			ExpectedErrorMessage: lo.ToPtr("when type is konnectID, konnectID must be set"),
 		},
 		{
+			Name: "providing namespace in konnectNamespacedRef yields an error",
+			KongService: configurationv1alpha1.KongService{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1alpha1.KongServiceSpec{
+					ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+						Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+						KonnectNamespacedRef: &configurationv1alpha1.KonnectNamespacedRef{
+							Name:      "test-konnect-control-plane",
+							Namespace: "another-namespace",
+						},
+					},
+					KongServiceAPISpec: configurationv1alpha1.KongServiceAPISpec{
+						Host: "example.com",
+					},
+				},
+			},
+			ExpectedErrorMessage: lo.ToPtr("spec.controlPlaneRef cannot specify namespace for namespaced resource"),
+		},
+		{
 			Name: "konnectNamespacedRef reference name cannot be changed when an entity is Programmed",
 			KongService: configurationv1alpha1.KongService{
 				ObjectMeta: commonObjectMeta,

--- a/test/crdsvalidation/kongupstream/testcases/controlplaneref.go
+++ b/test/crdsvalidation/kongupstream/testcases/controlplaneref.go
@@ -52,6 +52,23 @@ var cpRef = testCasesGroup{
 			ExpectedErrorMessage: lo.ToPtr("when type is konnectID, konnectID must be set"),
 		},
 		{
+			Name: "providing namespace in konnectNamespacedRef yields an error",
+			KongUpstream: configurationv1alpha1.KongUpstream{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1alpha1.KongUpstreamSpec{
+					ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+						Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+						KonnectNamespacedRef: &configurationv1alpha1.KonnectNamespacedRef{
+							Name:      "test-konnect-control-plane",
+							Namespace: "another-namespace",
+						},
+					},
+					KongUpstreamAPISpec: configurationv1alpha1.KongUpstreamAPISpec{},
+				},
+			},
+			ExpectedErrorMessage: lo.ToPtr("spec.controlPlaneRef cannot specify namespace for namespaced resource"),
+		},
+		{
 			Name: "konnectNamespacedRef reference name cannot be changed when an entity is Programmed",
 			KongUpstream: configurationv1alpha1.KongUpstream{
 				ObjectMeta: commonObjectMeta,


### PR DESCRIPTION
**What this PR does / why we need it**:
Add `namespace` in `konnectNamespacedRef` because some of Kong entities like `KongVault` and `KongClusterPlugin` are cluster scoped and they require the namespace for referring to a Konnect gateway controlplane.
**Which issue this PR fixes**

#36

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
