### PR TITLE
feat: disallow cross namespace services refs

### DIFF
--- a/api/configuration/v1alpha1/service_ref.go
+++ b/api/configuration/v1alpha1/service_ref.go
@@ -16,10 +16,13 @@ type ServiceRef struct {
 	NamespacedRef *NamespacedServiceRef `json:"namespacedRef,omitempty"`
 }
 
+// NamespacedServiceRef is a namespaced reference to a KongService.
+//
+// NOTE: currently cross namespace references are not supported.
 type NamespacedServiceRef struct {
 	// +kubebuilder:validation:Required
 	Name string `json:"name"`
 
-	// +kubebuilder:validation:Optional
-	Namespace string `json:"namespace,omitempty"`
+	// TODO: handle cross namespace references.
+	// https://github.com/Kong/kubernetes-configuration/issues/106
 }

--- a/config/crd/bases/configuration.konghq.com_kongroutes.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongroutes.yaml
@@ -194,8 +194,6 @@ spec:
                     properties:
                       name:
                         type: string
-                      namespace:
-                        type: string
                     required:
                     - name
                     type: object

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1543,14 +1543,14 @@ _Appears in:_
 #### NamespacedServiceRef
 
 
-
+NamespacedServiceRef is a namespaced reference to a KongService.<br /><br />
+NOTE: currently cross namespace references are not supported.
 
 
 
 | Field | Description |
 | --- | --- |
 | `name` _string_ |  |
-| `namespace` _string_ |  |
 
 
 _Appears in:_


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR disallows cross namespace references from `KongRoute` to `KongService`.

#106 will track the implementation of those.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
