### PR TITLE
chore: annotate KGO supported types

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ When you add a new CRD make sure to
 - Add CRD validation tests in [`test/crdsvalidation`][testcrdsvalidation]
 - If this CRD is meant to have Konnect helpers functions generated for it,
   add it in [konnect-funcs supported type list][konnect_funcs_gen].
+- Annotate the CRD and any new type it depends on with the right markers to make sure it will be included 
+  in the generated documentation. See [available markers](#Available custom markers).
 
 [crd_kustomization]: ./config/crd/kustomization.yaml
 [konnect_funcs_gen]: ./scripts/konnect-funcs/supportedtypes.go
@@ -59,3 +61,12 @@ When you add a new CRD make sure to
 
 Currently in order to make a new release/tag available for users to use is to
 create a new tag and push it to the repository.
+
+## Available custom markers
+
+| Name                        | Applies to | Meaning                                                                                                       |
+|-----------------------------|------------|---------------------------------------------------------------------------------------------------------------|
+| `+apireference:kgo:exclude` | Fields     | Any field annotated with this marker will be excluded from the [KGO's generated CRDs reference][kgo-crd-ref]. |
+| `+apireference:kgo:include` | Types      | Any type annotated with this marker will be included in the [KGO's generated CRDs reference][kgo-crd-ref].    |
+
+[kgo-crd-ref]: https://github.com/Kong/gateway-operator/blob/main/docs/api-reference.md

--- a/api/configuration/v1/conditions.go
+++ b/api/configuration/v1/conditions.go
@@ -2,12 +2,12 @@ package v1
 
 // ConditionType is a type of condition associated with an object.
 // This type should be used with the object's Status.Conditions field.
-// +kgosupported
+// +apireference:kgo:include
 type ConditionType string
 
 // ConditionReason defines the set of reasons that explain why a particular
 // condition type has been raised.
-// +kgosupported
+// +apireference:kgo:include
 type ConditionReason string
 
 const (

--- a/api/configuration/v1/conditions.go
+++ b/api/configuration/v1/conditions.go
@@ -2,10 +2,12 @@ package v1
 
 // ConditionType is a type of condition associated with an object.
 // This type should be used with the object's Status.Conditions field.
+// +kgosupported
 type ConditionType string
 
 // ConditionReason defines the set of reasons that explain why a particular
 // condition type has been raised.
+// +kgosupported
 type ConditionReason string
 
 const (

--- a/api/configuration/v1/configsource.go
+++ b/api/configuration/v1/configsource.go
@@ -2,7 +2,6 @@ package v1
 
 // ConfigSource is a wrapper around SecretValueFromSource.
 // +kubebuilder:object:generate=true
-// +kgosupported
 type ConfigSource struct {
 	// Specifies a name and a key of a secret to refer to. The namespace is implicitly set to the one of referring object.
 	SecretValue SecretValueFromSource `json:"secretKeyRef"`
@@ -12,7 +11,6 @@ type ConfigSource struct {
 // It is an equivalent of the following patch:
 // `{"op": "add", "path": {.Path}, "value": {.ComputedValueFrom}}`.
 // +kubebuilder:object:generate=true
-// +kgosupported
 type ConfigPatch struct {
 	// Path is the JSON-Pointer value (RFC6901) that references a location within the target configuration.
 	Path string `json:"path"`
@@ -22,7 +20,6 @@ type ConfigPatch struct {
 
 // NamespacedConfigSource is a wrapper around NamespacedSecretValueFromSource.
 // +kubebuilder:object:generate=true
-// +kgosupported
 type NamespacedConfigSource struct {
 	// Specifies a name, a namespace, and a key of a secret to refer to.
 	SecretValue NamespacedSecretValueFromSource `json:"secretKeyRef"`
@@ -31,7 +28,6 @@ type NamespacedConfigSource struct {
 // NamespacedConfigPatch is a JSON patch to add values from secrets to KongClusterPlugin
 // to the generated configuration of plugin in Kong.
 // +kubebuilder:object:generate=true
-// +kgosupported
 type NamespacedConfigPatch struct {
 	// Path is the JSON path to add the patch.
 	Path string `json:"path"`
@@ -41,7 +37,6 @@ type NamespacedConfigPatch struct {
 
 // SecretValueFromSource represents the source of a secret value.
 // +kubebuilder:object:generate=true
-// +kgosupported
 type SecretValueFromSource struct {
 	// The secret containing the key.
 	Secret string `json:"name"`
@@ -51,7 +46,6 @@ type SecretValueFromSource struct {
 
 // NamespacedSecretValueFromSource represents the source of a secret value specifying the secret namespace.
 // +kubebuilder:object:generate=true
-// +kgosupported
 type NamespacedSecretValueFromSource struct {
 	// The namespace containing the secret.
 	Namespace string `json:"namespace"`

--- a/api/configuration/v1/configsource.go
+++ b/api/configuration/v1/configsource.go
@@ -2,6 +2,7 @@ package v1
 
 // ConfigSource is a wrapper around SecretValueFromSource.
 // +kubebuilder:object:generate=true
+// +kgosupported
 type ConfigSource struct {
 	// Specifies a name and a key of a secret to refer to. The namespace is implicitly set to the one of referring object.
 	SecretValue SecretValueFromSource `json:"secretKeyRef"`
@@ -11,6 +12,7 @@ type ConfigSource struct {
 // It is an equivalent of the following patch:
 // `{"op": "add", "path": {.Path}, "value": {.ComputedValueFrom}}`.
 // +kubebuilder:object:generate=true
+// +kgosupported
 type ConfigPatch struct {
 	// Path is the JSON-Pointer value (RFC6901) that references a location within the target configuration.
 	Path string `json:"path"`
@@ -20,6 +22,7 @@ type ConfigPatch struct {
 
 // NamespacedConfigSource is a wrapper around NamespacedSecretValueFromSource.
 // +kubebuilder:object:generate=true
+// +kgosupported
 type NamespacedConfigSource struct {
 	// Specifies a name, a namespace, and a key of a secret to refer to.
 	SecretValue NamespacedSecretValueFromSource `json:"secretKeyRef"`
@@ -28,6 +31,7 @@ type NamespacedConfigSource struct {
 // NamespacedConfigPatch is a JSON patch to add values from secrets to KongClusterPlugin
 // to the generated configuration of plugin in Kong.
 // +kubebuilder:object:generate=true
+// +kgosupported
 type NamespacedConfigPatch struct {
 	// Path is the JSON path to add the patch.
 	Path string `json:"path"`
@@ -37,6 +41,7 @@ type NamespacedConfigPatch struct {
 
 // SecretValueFromSource represents the source of a secret value.
 // +kubebuilder:object:generate=true
+// +kgosupported
 type SecretValueFromSource struct {
 	// The secret containing the key.
 	Secret string `json:"name"`
@@ -46,6 +51,7 @@ type SecretValueFromSource struct {
 
 // NamespacedSecretValueFromSource represents the source of a secret value specifying the secret namespace.
 // +kubebuilder:object:generate=true
+// +kgosupported
 type NamespacedSecretValueFromSource struct {
 	// The namespace containing the secret.
 	Namespace string `json:"namespace"`

--- a/api/configuration/v1/kongconsumer_types.go
+++ b/api/configuration/v1/kongconsumer_types.go
@@ -23,6 +23,8 @@ import (
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
 
+// KongConsumer is the Schema for the kongconsumers API.
+//
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
@@ -36,8 +38,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
 // +kubebuilder:validation:XValidation:rule="!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
 // +kubebuilder:validation:XValidation:rule="(!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
-
-// KongConsumer is the Schema for the kongconsumers API.
+// +kgosupported
 type KongConsumer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -67,15 +68,16 @@ type KongConsumer struct {
 }
 
 // KongConsumerSpec defines the specification of the KongConsumer.
+// +kgosupported
 type KongConsumerSpec struct {
 	// ControlPlaneRef is a reference to a ControlPlane this Consumer is associated with.
 	// +optional
 	ControlPlaneRef *configurationv1alpha1.ControlPlaneRef `json:"controlPlaneRef,omitempty"`
 }
 
-// +kubebuilder:object:root=true
-
 // KongConsumerList contains a list of KongConsumer.
+// +kubebuilder:object:root=true
+// +kgosupported
 type KongConsumerList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1/kongconsumer_types.go
+++ b/api/configuration/v1/kongconsumer_types.go
@@ -38,7 +38,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
 // +kubebuilder:validation:XValidation:rule="!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
 // +kubebuilder:validation:XValidation:rule="(!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
-// +kgosupported
+// +apireference:kgo:include
 type KongConsumer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -68,7 +68,7 @@ type KongConsumer struct {
 }
 
 // KongConsumerSpec defines the specification of the KongConsumer.
-// +kgosupported
+// +apireference:kgo:include
 type KongConsumerSpec struct {
 	// ControlPlaneRef is a reference to a ControlPlane this Consumer is associated with.
 	// +optional
@@ -77,7 +77,7 @@ type KongConsumerSpec struct {
 
 // KongConsumerList contains a list of KongConsumer.
 // +kubebuilder:object:root=true
-// +kgosupported
+// +apireference:kgo:include
 type KongConsumerList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1/kongplugin_types.go
+++ b/api/configuration/v1/kongplugin_types.go
@@ -22,6 +22,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// KongPlugin is the Schema for the kongplugins API.
+//
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
@@ -36,8 +38,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="!(has(self.config) && has(self.configFrom))", message="Using both config and configFrom fields is not allowed."
 // +kubebuilder:validation:XValidation:rule="!(has(self.configFrom) && has(self.configPatches))", message="Using both configFrom and configPatches fields is not allowed."
 // +kubebuilder:validation:XValidation:rule="self.plugin == oldSelf.plugin", message="The plugin field is immutable"
-
-// KongPlugin is the Schema for the kongplugins API.
+// +kgosupported
 type KongPlugin struct {
 	metav1.TypeMeta `json:",inline"`
 	// Setting a `global` label to `true` will apply the plugin to every request proxied by the Kong.
@@ -100,9 +101,9 @@ type KongPlugin struct {
 	Status KongPluginStatus `json:"status,omitempty"`
 }
 
-// +kubebuilder:object:root=true
-
 // KongPluginList contains a list of KongPlugin.
+// +kubebuilder:object:root=true
+// +kgosupported
 type KongPluginList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -110,6 +111,7 @@ type KongPluginList struct {
 }
 
 // KongPluginStatus represents the current status of the KongPlugin resource.
+// +kgosupported
 type KongPluginStatus struct {
 	// Conditions describe the current conditions of the KongPluginStatus.
 	//

--- a/api/configuration/v1/kongplugin_types.go
+++ b/api/configuration/v1/kongplugin_types.go
@@ -38,7 +38,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="!(has(self.config) && has(self.configFrom))", message="Using both config and configFrom fields is not allowed."
 // +kubebuilder:validation:XValidation:rule="!(has(self.configFrom) && has(self.configPatches))", message="Using both configFrom and configPatches fields is not allowed."
 // +kubebuilder:validation:XValidation:rule="self.plugin == oldSelf.plugin", message="The plugin field is immutable"
-// +kgosupported
+// +apireference:kgo:include
 type KongPlugin struct {
 	metav1.TypeMeta `json:",inline"`
 	// Setting a `global` label to `true` will apply the plugin to every request proxied by the Kong.
@@ -63,6 +63,8 @@ type KongPlugin struct {
 	// This should be used when the plugin configuration contains sensitive information,
 	// such as AWS credentials in the Lambda plugin or the client secret in the OIDC plugin.
 	// Only one of `config` or `configFrom` may be used in a KongPlugin, not both at once.
+	//
+	// +apireference:kgo:exclude // KGO does not support this field.
 	ConfigFrom *ConfigSource `json:"configFrom,omitempty"`
 
 	// ConfigPatches represents JSON patches to the configuration of the plugin.
@@ -71,6 +73,8 @@ type KongPlugin struct {
 	// a key in a secret.
 	// When Config is specified, patches will be applied to the configuration in Config.
 	// Otherwise, patches will be applied to an empty object.
+	//
+	// +apireference:kgo:exclude // KGO does not support this field.
 	ConfigPatches []ConfigPatch `json:"configPatches,omitempty"`
 
 	// PluginName is the name of the plugin to which to apply the config.
@@ -103,7 +107,7 @@ type KongPlugin struct {
 
 // KongPluginList contains a list of KongPlugin.
 // +kubebuilder:object:root=true
-// +kgosupported
+// +apireference:kgo:include
 type KongPluginList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -111,7 +115,7 @@ type KongPluginList struct {
 }
 
 // KongPluginStatus represents the current status of the KongPlugin resource.
-// +kgosupported
+// +apireference:kgo:include
 type KongPluginStatus struct {
 	// Conditions describe the current conditions of the KongPluginStatus.
 	//

--- a/api/configuration/v1/kongplugin_types.go
+++ b/api/configuration/v1/kongplugin_types.go
@@ -64,7 +64,7 @@ type KongPlugin struct {
 	// such as AWS credentials in the Lambda plugin or the client secret in the OIDC plugin.
 	// Only one of `config` or `configFrom` may be used in a KongPlugin, not both at once.
 	//
-	// +apireference:kgo:exclude // KGO does not support this field.
+	// +apireference:kgo:exclude
 	ConfigFrom *ConfigSource `json:"configFrom,omitempty"`
 
 	// ConfigPatches represents JSON patches to the configuration of the plugin.
@@ -74,7 +74,7 @@ type KongPlugin struct {
 	// When Config is specified, patches will be applied to the configuration in Config.
 	// Otherwise, patches will be applied to an empty object.
 	//
-	// +apireference:kgo:exclude // KGO does not support this field.
+	// +apireference:kgo:exclude
 	ConfigPatches []ConfigPatch `json:"configPatches,omitempty"`
 
 	// PluginName is the name of the plugin to which to apply the config.

--- a/api/configuration/v1/kongprotocol_types.go
+++ b/api/configuration/v1/kongprotocol_types.go
@@ -4,6 +4,7 @@ package v1
 // This alias is necessary to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
 // +kubebuilder:validation:Enum=http;https;grpc;grpcs;tcp;tls;udp
 // +kubebuilder:object:generate=true
+// +kgosupported
 type KongProtocol string
 
 // KongProtocolsToStrings converts a slice of KongProtocol to plain strings.

--- a/api/configuration/v1/kongprotocol_types.go
+++ b/api/configuration/v1/kongprotocol_types.go
@@ -4,7 +4,7 @@ package v1
 // This alias is necessary to deal with https://github.com/kubernetes-sigs/controller-tools/issues/342
 // +kubebuilder:validation:Enum=http;https;grpc;grpcs;tcp;tls;udp
 // +kubebuilder:object:generate=true
-// +kgosupported
+// +apireference:kgo:include
 type KongProtocol string
 
 // KongProtocolsToStrings converts a slice of KongProtocol to plain strings.

--- a/api/configuration/v1alpha1/key_set_ref.go
+++ b/api/configuration/v1alpha1/key_set_ref.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 // KeySetRefType is the enum type for the KeySetRef.
 // +kubebuilder:validation:Enum=konnectID;namespacedRef
+// +kgosupported
 type KeySetRefType string
 
 const (
@@ -19,6 +20,7 @@ const (
 // It is used to reference a KeySet entity.
 // +kubebuilder:validation:XValidation:rule="self.type == 'namespacedRef' ? has(self.namespacedRef) : true", message="when type is namespacedRef, namespacedRef must be set"
 // +kubebuilder:validation:XValidation:rule="self.type == 'konnectID' ? has(self.konnectID) : true", message="when type is konnectID, konnectID must be set"
+// +kgosupported
 type KeySetRef struct {
 	// Type defines type of the KeySet object reference. It can be one of:
 	// - konnectID
@@ -37,6 +39,7 @@ type KeySetRef struct {
 }
 
 // KeySetNamespacedRef is the schema for the KeySetNamespacedRef type.
+// +kgosupported
 type KeySetNamespacedRef struct {
 	// Name is the name of the KeySet object.
 	// +kubebuilder:validation:MinLength=1

--- a/api/configuration/v1alpha1/key_set_ref.go
+++ b/api/configuration/v1alpha1/key_set_ref.go
@@ -2,7 +2,7 @@ package v1alpha1
 
 // KeySetRefType is the enum type for the KeySetRef.
 // +kubebuilder:validation:Enum=konnectID;namespacedRef
-// +kgosupported
+// +apireference:kgo:include
 type KeySetRefType string
 
 const (
@@ -20,7 +20,7 @@ const (
 // It is used to reference a KeySet entity.
 // +kubebuilder:validation:XValidation:rule="self.type == 'namespacedRef' ? has(self.namespacedRef) : true", message="when type is namespacedRef, namespacedRef must be set"
 // +kubebuilder:validation:XValidation:rule="self.type == 'konnectID' ? has(self.konnectID) : true", message="when type is konnectID, konnectID must be set"
-// +kgosupported
+// +apireference:kgo:include
 type KeySetRef struct {
 	// Type defines type of the KeySet object reference. It can be one of:
 	// - konnectID
@@ -39,7 +39,7 @@ type KeySetRef struct {
 }
 
 // KeySetNamespacedRef is the schema for the KeySetNamespacedRef type.
-// +kgosupported
+// +apireference:kgo:include
 type KeySetNamespacedRef struct {
 	// Name is the name of the KeySet object.
 	// +kubebuilder:validation:MinLength=1

--- a/api/configuration/v1alpha1/kong_ca_certificate.go
+++ b/api/configuration/v1alpha1/kong_ca_certificate.go
@@ -18,6 +18,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
 // +kubebuilder:validation:XValidation:rule="!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
+// +kgosupported
 type KongCACertificate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -29,6 +30,7 @@ type KongCACertificate struct {
 }
 
 // KongCACertificateSpec contains the specification for the KongCACertificate.
+// +kgosupported
 type KongCACertificateSpec struct {
 	// ControlPlaneRef references the Konnect Control Plane that this KongCACertificate should be created in.
 	ControlPlaneRef          *ControlPlaneRef `json:"controlPlaneRef,omitempty"`
@@ -36,6 +38,7 @@ type KongCACertificateSpec struct {
 }
 
 // KongCACertificateAPISpec contains the API specification for the KongCACertificate.
+// +kgosupported
 type KongCACertificateAPISpec struct {
 	// Cert is the PEM-encoded CA certificate.
 	// +kubebuilder:validation:Required
@@ -45,6 +48,7 @@ type KongCACertificateAPISpec struct {
 }
 
 // KongCACertificateStatus defines the observed state of KongCACertificate.
+// +kgosupported
 type KongCACertificateStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
@@ -60,6 +64,7 @@ type KongCACertificateStatus struct {
 
 // KongCACertificateList contains a list of KongCACertificates.
 // +kubebuilder:object:root=true
+// +kgosupported
 type KongCACertificateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kong_ca_certificate.go
+++ b/api/configuration/v1alpha1/kong_ca_certificate.go
@@ -18,7 +18,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
 // +kubebuilder:validation:XValidation:rule="!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
-// +kgosupported
+// +apireference:kgo:include
 type KongCACertificate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -30,7 +30,7 @@ type KongCACertificate struct {
 }
 
 // KongCACertificateSpec contains the specification for the KongCACertificate.
-// +kgosupported
+// +apireference:kgo:include
 type KongCACertificateSpec struct {
 	// ControlPlaneRef references the Konnect Control Plane that this KongCACertificate should be created in.
 	ControlPlaneRef          *ControlPlaneRef `json:"controlPlaneRef,omitempty"`
@@ -38,7 +38,7 @@ type KongCACertificateSpec struct {
 }
 
 // KongCACertificateAPISpec contains the API specification for the KongCACertificate.
-// +kgosupported
+// +apireference:kgo:include
 type KongCACertificateAPISpec struct {
 	// Cert is the PEM-encoded CA certificate.
 	// +kubebuilder:validation:Required
@@ -48,7 +48,7 @@ type KongCACertificateAPISpec struct {
 }
 
 // KongCACertificateStatus defines the observed state of KongCACertificate.
-// +kgosupported
+// +apireference:kgo:include
 type KongCACertificateStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
@@ -64,7 +64,7 @@ type KongCACertificateStatus struct {
 
 // KongCACertificateList contains a list of KongCACertificates.
 // +kubebuilder:object:root=true
-// +kgosupported
+// +apireference:kgo:include
 type KongCACertificateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kong_certificate.go
+++ b/api/configuration/v1alpha1/kong_certificate.go
@@ -17,7 +17,7 @@ import (
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
-// +kgosupported
+// +apireference:kgo:include
 type KongCertificate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -29,7 +29,7 @@ type KongCertificate struct {
 }
 
 // KongCertificateSpec contains the specification for the KongCertificate.
-// +kgosupported
+// +apireference:kgo:include
 type KongCertificateSpec struct {
 	// ControlPlaneRef references the Konnect Control Plane that this KongCertificate should be created in.
 	ControlPlaneRef        *ControlPlaneRef `json:"controlPlaneRef,omitempty"`
@@ -37,7 +37,7 @@ type KongCertificateSpec struct {
 }
 
 // KongCertificateAPISpec contains the API specification for the KongCertificate.
-// +kgosupported
+// +apireference:kgo:include
 type KongCertificateAPISpec struct {
 	// Cert is the PEM-encoded certificate.
 	// +kubebuilder:validation:Required
@@ -61,7 +61,7 @@ type KongCertificateAPISpec struct {
 }
 
 // KongCertificateStatus defines the observed state of KongCertificate.
-// +kgosupported
+// +apireference:kgo:include
 type KongCertificateStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
@@ -77,7 +77,7 @@ type KongCertificateStatus struct {
 
 // KongCertificateList contains a list of KongCertificates.
 // +kubebuilder:object:root=true
-// +kgosupported
+// +apireference:kgo:include
 type KongCertificateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kong_certificate.go
+++ b/api/configuration/v1alpha1/kong_certificate.go
@@ -17,6 +17,7 @@ import (
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
+// +kgosupported
 type KongCertificate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -28,6 +29,7 @@ type KongCertificate struct {
 }
 
 // KongCertificateSpec contains the specification for the KongCertificate.
+// +kgosupported
 type KongCertificateSpec struct {
 	// ControlPlaneRef references the Konnect Control Plane that this KongCertificate should be created in.
 	ControlPlaneRef        *ControlPlaneRef `json:"controlPlaneRef,omitempty"`
@@ -35,6 +37,7 @@ type KongCertificateSpec struct {
 }
 
 // KongCertificateAPISpec contains the API specification for the KongCertificate.
+// +kgosupported
 type KongCertificateAPISpec struct {
 	// Cert is the PEM-encoded certificate.
 	// +kubebuilder:validation:Required
@@ -58,6 +61,7 @@ type KongCertificateAPISpec struct {
 }
 
 // KongCertificateStatus defines the observed state of KongCertificate.
+// +kgosupported
 type KongCertificateStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
@@ -73,6 +77,7 @@ type KongCertificateStatus struct {
 
 // KongCertificateList contains a list of KongCertificates.
 // +kubebuilder:object:root=true
+// +kgosupported
 type KongCertificateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kong_license_types.go
+++ b/api/configuration/v1alpha1/kong_license_types.go
@@ -4,6 +4,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// KongLicense stores a Kong enterprise license to apply to managed Kong gateway instances.
+//
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -13,8 +15,7 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age"
 // +kubebuilder:printcolumn:name="Enabled",type=boolean,JSONPath=`.enabled`,description="Enabled to configure on Kong gateway instances"
-
-// KongLicense stores a Kong enterprise license to apply to managed Kong gateway instances.
+// +kgosupported
 type KongLicense struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -29,6 +30,7 @@ type KongLicense struct {
 }
 
 // KongLicenseStatus stores the status of the KongLicense being processesed in each controller that reconciles it.
+// +kgosupported
 type KongLicenseStatus struct {
 	// +listType=map
 	// +listMapKey=controllerName
@@ -37,6 +39,7 @@ type KongLicenseStatus struct {
 
 // KongLicenseControllerStatus is the status of owning KongLicense being processed
 // identified by the controllerName field.
+// +kgosupported
 type KongLicenseControllerStatus struct {
 	// ControllerName is an identifier of the controller to reconcile this KongLicense.
 	// Should be unique in the list of controller statuses.
@@ -56,18 +59,21 @@ type KongLicenseControllerStatus struct {
 // RFC 1123 subdomain.
 // +kubebuilder:validation:MaxLength=253
 // +kubebuilder:validation:Pattern=`^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
+// +kgosupported
 type Group string
 
 // Kind refers to a Kubernetes kind.
 // +kubebuilder:validation:MinLength=1
 // +kubebuilder:validation:MaxLength=63
 // +kubebuilder:validation:Pattern=`^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$`
+// +kgosupported
 type Kind string
 
 // Namespace refers to a Kubernetes namespace. It must be a RFC 1123 label.
 // +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
 // +kubebuilder:validation:MinLength=1
 // +kubebuilder:validation:MaxLength=63
+// +kgosupported
 type Namespace string
 
 // ObjectName refers to the name of a Kubernetes object.
@@ -76,9 +82,11 @@ type Namespace string
 //
 // +kubebuilder:validation:MinLength=1
 // +kubebuilder:validation:MaxLength=253
+// +kgosupported
 type ObjectName string
 
 // ControllerReference is a reference to a controller that reconciles the KongLicense.
+// +kgosupported
 type ControllerReference struct {
 	// Group is the group of referent.
 	// It should be empty if the referent is in "core" group (like pod).
@@ -93,12 +101,9 @@ type ControllerReference struct {
 	Name ObjectName `json:"name"`
 }
 
-// KongLicensePhase is a string that represents the phase of the KongLicense.
-type KongLicensePhase string
-
-// +kubebuilder:object:root=true
-
 // KongLicenseList contains a list of KongLicense.
+// +kubebuilder:object:root=true
+// +kgosupported
 type KongLicenseList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kong_license_types.go
+++ b/api/configuration/v1alpha1/kong_license_types.go
@@ -15,7 +15,7 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age"
 // +kubebuilder:printcolumn:name="Enabled",type=boolean,JSONPath=`.enabled`,description="Enabled to configure on Kong gateway instances"
-// +kgosupported
+// +apireference:kgo:include
 type KongLicense struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -30,7 +30,7 @@ type KongLicense struct {
 }
 
 // KongLicenseStatus stores the status of the KongLicense being processesed in each controller that reconciles it.
-// +kgosupported
+// +apireference:kgo:include
 type KongLicenseStatus struct {
 	// +listType=map
 	// +listMapKey=controllerName
@@ -39,7 +39,7 @@ type KongLicenseStatus struct {
 
 // KongLicenseControllerStatus is the status of owning KongLicense being processed
 // identified by the controllerName field.
-// +kgosupported
+// +apireference:kgo:include
 type KongLicenseControllerStatus struct {
 	// ControllerName is an identifier of the controller to reconcile this KongLicense.
 	// Should be unique in the list of controller statuses.
@@ -59,21 +59,21 @@ type KongLicenseControllerStatus struct {
 // RFC 1123 subdomain.
 // +kubebuilder:validation:MaxLength=253
 // +kubebuilder:validation:Pattern=`^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
-// +kgosupported
+// +apireference:kgo:include
 type Group string
 
 // Kind refers to a Kubernetes kind.
 // +kubebuilder:validation:MinLength=1
 // +kubebuilder:validation:MaxLength=63
 // +kubebuilder:validation:Pattern=`^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$`
-// +kgosupported
+// +apireference:kgo:include
 type Kind string
 
 // Namespace refers to a Kubernetes namespace. It must be a RFC 1123 label.
 // +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
 // +kubebuilder:validation:MinLength=1
 // +kubebuilder:validation:MaxLength=63
-// +kgosupported
+// +apireference:kgo:include
 type Namespace string
 
 // ObjectName refers to the name of a Kubernetes object.
@@ -82,11 +82,11 @@ type Namespace string
 //
 // +kubebuilder:validation:MinLength=1
 // +kubebuilder:validation:MaxLength=253
-// +kgosupported
+// +apireference:kgo:include
 type ObjectName string
 
 // ControllerReference is a reference to a controller that reconciles the KongLicense.
-// +kgosupported
+// +apireference:kgo:include
 type ControllerReference struct {
 	// Group is the group of referent.
 	// It should be empty if the referent is in "core" group (like pod).
@@ -103,7 +103,7 @@ type ControllerReference struct {
 
 // KongLicenseList contains a list of KongLicense.
 // +kubebuilder:object:root=true
-// +kgosupported
+// +apireference:kgo:include
 type KongLicenseList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kong_target_types.go
+++ b/api/configuration/v1alpha1/kong_target_types.go
@@ -32,7 +32,7 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="oldSelf.spec.upstreamRef == self.spec.upstreamRef", message="spec.upstreamRef is immutable"
-// +kgosupported
+// +apireference:kgo:include
 type KongTarget struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -42,8 +42,9 @@ type KongTarget struct {
 	Status KongTargetStatus `json:"status,omitempty"`
 }
 
+// KongTargetSpec defines the specification of a Kong Target.
 // KongTargetSpec defines the desired state of KongTarget.
-// +kgosupported
+// +apireference:kgo:include
 type KongTargetSpec struct {
 	// UpstreamRef is a reference to a KongUpstream this KongTarget is attached to.
 	UpstreamRef TargetRef `json:"upstreamRef"`
@@ -52,7 +53,7 @@ type KongTargetSpec struct {
 }
 
 // KongTargetAPISpec are the attributes of the Kong Target itself.
-// +kgosupported
+// +apireference:kgo:include
 type KongTargetAPISpec struct {
 	// Target is the target address of the upstream.
 	Target string `json:"target"`
@@ -66,7 +67,7 @@ type KongTargetAPISpec struct {
 }
 
 // KongTargetStatus defines the observed state of KongTarget.
-// +kgosupported
+// +apireference:kgo:include
 type KongTargetStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
@@ -82,7 +83,7 @@ type KongTargetStatus struct {
 
 // KongTargetList contains a list of Kong Targets.
 // +kubebuilder:object:root=true
-// +kgosupported
+// +apireference:kgo:include
 type KongTargetList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kong_target_types.go
+++ b/api/configuration/v1alpha1/kong_target_types.go
@@ -32,6 +32,7 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="oldSelf.spec.upstreamRef == self.spec.upstreamRef", message="spec.upstreamRef is immutable"
+// +kgosupported
 type KongTarget struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -42,6 +43,7 @@ type KongTarget struct {
 }
 
 // KongTargetSpec defines the desired state of KongTarget.
+// +kgosupported
 type KongTargetSpec struct {
 	// UpstreamRef is a reference to a KongUpstream this KongTarget is attached to.
 	UpstreamRef TargetRef `json:"upstreamRef"`
@@ -50,6 +52,7 @@ type KongTargetSpec struct {
 }
 
 // KongTargetAPISpec are the attributes of the Kong Target itself.
+// +kgosupported
 type KongTargetAPISpec struct {
 	// Target is the target address of the upstream.
 	Target string `json:"target"`
@@ -63,6 +66,7 @@ type KongTargetAPISpec struct {
 }
 
 // KongTargetStatus defines the observed state of KongTarget.
+// +kgosupported
 type KongTargetStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
@@ -76,9 +80,9 @@ type KongTargetStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
-// +kubebuilder:object:root=true
-
 // KongTargetList contains a list of Kong Targets.
+// +kubebuilder:object:root=true
+// +kgosupported
 type KongTargetList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kong_vault_types.go
+++ b/api/configuration/v1alpha1/kong_vault_types.go
@@ -47,7 +47,7 @@ const (
 // +kubebuilder:validation:XValidation:rule="self.spec.prefix == oldSelf.spec.prefix", message="The spec.prefix field is immutable"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
 // +kubebuilder:validation:XValidation:rule="(!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
-// +kgosupported
+// +apireference:kgo:include
 type KongVault struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -56,7 +56,7 @@ type KongVault struct {
 }
 
 // KongVaultSpec defines specification of a custom Kong vault.
-// +kgosupported
+// +apireference:kgo:include
 type KongVaultSpec struct {
 	// Backend is the type of the backend storing the secrets in the vault.
 	// The supported backends of Kong is listed here:
@@ -79,7 +79,7 @@ type KongVaultSpec struct {
 }
 
 // KongVaultStatus represents the current status of the KongVault resource.
-// +kgosupported
+// +apireference:kgo:include
 type KongVaultStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
@@ -100,7 +100,7 @@ type KongVaultStatus struct {
 
 // KongVaultList contains a list of KongVault.
 // +kubebuilder:object:root=true
-// +kgosupported
+// +apireference:kgo:include
 type KongVaultList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kong_vault_types.go
+++ b/api/configuration/v1alpha1/kong_vault_types.go
@@ -28,6 +28,10 @@ const (
 	KongVaultKind = "KongVault"
 )
 
+// KongVault is the schema for kongvaults API which defines a custom Kong vault.
+// A Kong vault is a storage to store sensitive data, where the values can be referenced in configuration of plugins.
+// See: https://docs.konghq.com/gateway/latest/kong-enterprise/secrets-management/
+//
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -43,10 +47,7 @@ const (
 // +kubebuilder:validation:XValidation:rule="self.spec.prefix == oldSelf.spec.prefix", message="The spec.prefix field is immutable"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
 // +kubebuilder:validation:XValidation:rule="(!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
-
-// KongVault is the schema for kongvaults API which defines a custom Kong vault.
-// A Kong vault is a storage to store sensitive data, where the values can be referenced in configuration of plugins.
-// See: https://docs.konghq.com/gateway/latest/kong-enterprise/secrets-management/
+// +kgosupported
 type KongVault struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -55,6 +56,7 @@ type KongVault struct {
 }
 
 // KongVaultSpec defines specification of a custom Kong vault.
+// +kgosupported
 type KongVaultSpec struct {
 	// Backend is the type of the backend storing the secrets in the vault.
 	// The supported backends of Kong is listed here:
@@ -77,6 +79,7 @@ type KongVaultSpec struct {
 }
 
 // KongVaultStatus represents the current status of the KongVault resource.
+// +kgosupported
 type KongVaultStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
@@ -95,9 +98,9 @@ type KongVaultStatus struct {
 	Conditions []metav1.Condition `json:"conditions"`
 }
 
-// +kubebuilder:object:root=true
-
 // KongVaultList contains a list of KongVault.
+// +kubebuilder:object:root=true
+// +kgosupported
 type KongVaultList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongcredential_acl_types.go
+++ b/api/configuration/v1alpha1/kongcredential_acl_types.go
@@ -33,7 +33,7 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.consumerRef == self.spec.consumerRef",message="spec.consumerRef is immutable when an entity is already Programmed"
-// +kgosupported
+// +apireference:kgo:include
 type KongCredentialACL struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -48,7 +48,7 @@ type KongCredentialACL struct {
 }
 
 // KongCredentialACLSpec defines specification of Kong ACL.
-// +kgosupported
+// +apireference:kgo:include
 type KongCredentialACLSpec struct {
 	// ConsumerRef is a reference to a Consumer this KongCredentialACL is associated with.
 	//
@@ -59,7 +59,7 @@ type KongCredentialACLSpec struct {
 }
 
 // KongCredentialACLAPISpec defines specification of an ACL credential.
-// +kgosupported
+// +apireference:kgo:include
 type KongCredentialACLAPISpec struct {
 	// Group is the name for the ACL credential.
 	//
@@ -71,7 +71,7 @@ type KongCredentialACLAPISpec struct {
 }
 
 // KongCredentialACLStatus represents the current status of the ACL credential resource.
-// +kgosupported
+// +apireference:kgo:include
 type KongCredentialACLStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
@@ -87,7 +87,7 @@ type KongCredentialACLStatus struct {
 
 // KongCredentialACLList contains a list of ACL credentials.
 // +kubebuilder:object:root=true
-// +kgosupported
+// +apireference:kgo:include
 type KongCredentialACLList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongcredential_acl_types.go
+++ b/api/configuration/v1alpha1/kongcredential_acl_types.go
@@ -33,6 +33,7 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.consumerRef == self.spec.consumerRef",message="spec.consumerRef is immutable when an entity is already Programmed"
+// +kgosupported
 type KongCredentialACL struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -47,6 +48,7 @@ type KongCredentialACL struct {
 }
 
 // KongCredentialACLSpec defines specification of Kong ACL.
+// +kgosupported
 type KongCredentialACLSpec struct {
 	// ConsumerRef is a reference to a Consumer this KongCredentialACL is associated with.
 	//
@@ -57,6 +59,7 @@ type KongCredentialACLSpec struct {
 }
 
 // KongCredentialACLAPISpec defines specification of an ACL credential.
+// +kgosupported
 type KongCredentialACLAPISpec struct {
 	// Group is the name for the ACL credential.
 	//
@@ -68,6 +71,7 @@ type KongCredentialACLAPISpec struct {
 }
 
 // KongCredentialACLStatus represents the current status of the ACL credential resource.
+// +kgosupported
 type KongCredentialACLStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
@@ -81,9 +85,9 @@ type KongCredentialACLStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
-// +kubebuilder:object:root=true
-
 // KongCredentialACLList contains a list of ACL credentials.
+// +kubebuilder:object:root=true
+// +kgosupported
 type KongCredentialACLList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongcredential_apikey_types.go
+++ b/api/configuration/v1alpha1/kongcredential_apikey_types.go
@@ -33,7 +33,7 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.consumerRef == self.spec.consumerRef",message="spec.consumerRef is immutable when an entity is already Programmed"
-// +kgosupported
+// +apireference:kgo:include
 type KongCredentialAPIKey struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -48,7 +48,7 @@ type KongCredentialAPIKey struct {
 }
 
 // KongCredentialAPIKeySpec defines specification of a Kong Route.
-// +kgosupported
+// +apireference:kgo:include
 type KongCredentialAPIKeySpec struct {
 	// ConsumerRef is a reference to a Consumer this KongCredentialAPIKey is associated with.
 	//
@@ -59,7 +59,7 @@ type KongCredentialAPIKeySpec struct {
 }
 
 // KongCredentialAPIKeyAPISpec defines specification of an API Key credential.
-// +kgosupported
+// +apireference:kgo:include
 type KongCredentialAPIKeyAPISpec struct {
 	// Key is the key for the API Key credential.
 	//
@@ -71,7 +71,7 @@ type KongCredentialAPIKeyAPISpec struct {
 }
 
 // KongCredentialAPIKeyStatus represents the current status of the API Key credential resource.
-// +kgosupported
+// +apireference:kgo:include
 type KongCredentialAPIKeyStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
@@ -87,7 +87,7 @@ type KongCredentialAPIKeyStatus struct {
 
 // KongCredentialAPIKeyList contains a list of API Key credentials.
 // +kubebuilder:object:root=true
-// +kgosupported
+// +apireference:kgo:include
 type KongCredentialAPIKeyList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongcredential_apikey_types.go
+++ b/api/configuration/v1alpha1/kongcredential_apikey_types.go
@@ -33,6 +33,7 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.consumerRef == self.spec.consumerRef",message="spec.consumerRef is immutable when an entity is already Programmed"
+// +kgosupported
 type KongCredentialAPIKey struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -47,6 +48,7 @@ type KongCredentialAPIKey struct {
 }
 
 // KongCredentialAPIKeySpec defines specification of a Kong Route.
+// +kgosupported
 type KongCredentialAPIKeySpec struct {
 	// ConsumerRef is a reference to a Consumer this KongCredentialAPIKey is associated with.
 	//
@@ -57,6 +59,7 @@ type KongCredentialAPIKeySpec struct {
 }
 
 // KongCredentialAPIKeyAPISpec defines specification of an API Key credential.
+// +kgosupported
 type KongCredentialAPIKeyAPISpec struct {
 	// Key is the key for the API Key credential.
 	//
@@ -68,6 +71,7 @@ type KongCredentialAPIKeyAPISpec struct {
 }
 
 // KongCredentialAPIKeyStatus represents the current status of the API Key credential resource.
+// +kgosupported
 type KongCredentialAPIKeyStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
@@ -81,9 +85,9 @@ type KongCredentialAPIKeyStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
-// +kubebuilder:object:root=true
-
 // KongCredentialAPIKeyList contains a list of API Key credentials.
+// +kubebuilder:object:root=true
+// +kgosupported
 type KongCredentialAPIKeyList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongcredential_basic_auth_types.go
+++ b/api/configuration/v1alpha1/kongcredential_basic_auth_types.go
@@ -33,6 +33,7 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.consumerRef == self.spec.consumerRef",message="spec.consumerRef is immutable when an entity is already Programmed"
+// +kgosupported
 type KongCredentialBasicAuth struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -47,6 +48,7 @@ type KongCredentialBasicAuth struct {
 }
 
 // KongCredentialBasicAuthSpec defines specification of a Kong Route.
+// +kgosupported
 type KongCredentialBasicAuthSpec struct {
 	// ConsumerRef is a reference to a Consumer this CredentialBasicAuth is associated with.
 	//
@@ -57,6 +59,7 @@ type KongCredentialBasicAuthSpec struct {
 }
 
 // KongCredentialBasicAuthAPISpec defines specification of a BasicAuth credential.
+// +kgosupported
 type KongCredentialBasicAuthAPISpec struct {
 	// Password is the password for the BasicAuth credential.
 	//
@@ -73,6 +76,7 @@ type KongCredentialBasicAuthAPISpec struct {
 }
 
 // KongCredentialBasicAuthStatus represents the current status of the BasicAuth credential resource.
+// +kgosupported
 type KongCredentialBasicAuthStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
@@ -86,9 +90,9 @@ type KongCredentialBasicAuthStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
-// +kubebuilder:object:root=true
-
 // KongCredentialBasicAuthList contains a list of BasicAuth credentials.
+// +kubebuilder:object:root=true
+// +kgosupported
 type KongCredentialBasicAuthList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongcredential_basic_auth_types.go
+++ b/api/configuration/v1alpha1/kongcredential_basic_auth_types.go
@@ -33,7 +33,7 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.consumerRef == self.spec.consumerRef",message="spec.consumerRef is immutable when an entity is already Programmed"
-// +kgosupported
+// +apireference:kgo:include
 type KongCredentialBasicAuth struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -48,7 +48,7 @@ type KongCredentialBasicAuth struct {
 }
 
 // KongCredentialBasicAuthSpec defines specification of a Kong Route.
-// +kgosupported
+// +apireference:kgo:include
 type KongCredentialBasicAuthSpec struct {
 	// ConsumerRef is a reference to a Consumer this CredentialBasicAuth is associated with.
 	//
@@ -59,7 +59,7 @@ type KongCredentialBasicAuthSpec struct {
 }
 
 // KongCredentialBasicAuthAPISpec defines specification of a BasicAuth credential.
-// +kgosupported
+// +apireference:kgo:include
 type KongCredentialBasicAuthAPISpec struct {
 	// Password is the password for the BasicAuth credential.
 	//
@@ -76,7 +76,7 @@ type KongCredentialBasicAuthAPISpec struct {
 }
 
 // KongCredentialBasicAuthStatus represents the current status of the BasicAuth credential resource.
-// +kgosupported
+// +apireference:kgo:include
 type KongCredentialBasicAuthStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
@@ -92,7 +92,7 @@ type KongCredentialBasicAuthStatus struct {
 
 // KongCredentialBasicAuthList contains a list of BasicAuth credentials.
 // +kubebuilder:object:root=true
-// +kgosupported
+// +apireference:kgo:include
 type KongCredentialBasicAuthList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongcredential_hmac_types.go
+++ b/api/configuration/v1alpha1/kongcredential_hmac_types.go
@@ -33,7 +33,7 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.consumerRef == self.spec.consumerRef",message="spec.consumerRef is immutable when an entity is already Programmed"
-// +kgosupported
+// +apireference:kgo:include
 type KongCredentialHMAC struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -48,7 +48,7 @@ type KongCredentialHMAC struct {
 }
 
 // KongCredentialHMACSpec defines specification of a Kong Route.
-// +kgosupported
+// +apireference:kgo:include
 type KongCredentialHMACSpec struct {
 	// ConsumerRef is a reference to a Consumer this KongCredentialHMAC is associated with.
 	//
@@ -59,7 +59,7 @@ type KongCredentialHMACSpec struct {
 }
 
 // KongCredentialHMACAPISpec defines specification of an HMAC credential.
-// +kgosupported
+// +apireference:kgo:include
 type KongCredentialHMACAPISpec struct {
 	// ID is the unique identifier for the HMAC credential.
 	ID *string `json:"id,omitempty"`
@@ -73,7 +73,7 @@ type KongCredentialHMACAPISpec struct {
 }
 
 // KongCredentialHMACStatus represents the current status of the HMAC credential resource.
-// +kgosupported
+// +apireference:kgo:include
 type KongCredentialHMACStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
@@ -89,7 +89,7 @@ type KongCredentialHMACStatus struct {
 
 // KongCredentialHMACList contains a list of HMAC credentials.
 // +kubebuilder:object:root=true
-// +kgosupported
+// +apireference:kgo:include
 type KongCredentialHMACList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongcredential_hmac_types.go
+++ b/api/configuration/v1alpha1/kongcredential_hmac_types.go
@@ -33,6 +33,7 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.consumerRef == self.spec.consumerRef",message="spec.consumerRef is immutable when an entity is already Programmed"
+// +kgosupported
 type KongCredentialHMAC struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -47,6 +48,7 @@ type KongCredentialHMAC struct {
 }
 
 // KongCredentialHMACSpec defines specification of a Kong Route.
+// +kgosupported
 type KongCredentialHMACSpec struct {
 	// ConsumerRef is a reference to a Consumer this KongCredentialHMAC is associated with.
 	//
@@ -57,6 +59,7 @@ type KongCredentialHMACSpec struct {
 }
 
 // KongCredentialHMACAPISpec defines specification of an HMAC credential.
+// +kgosupported
 type KongCredentialHMACAPISpec struct {
 	// ID is the unique identifier for the HMAC credential.
 	ID *string `json:"id,omitempty"`
@@ -70,6 +73,7 @@ type KongCredentialHMACAPISpec struct {
 }
 
 // KongCredentialHMACStatus represents the current status of the HMAC credential resource.
+// +kgosupported
 type KongCredentialHMACStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
@@ -83,9 +87,9 @@ type KongCredentialHMACStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
-// +kubebuilder:object:root=true
-
 // KongCredentialHMACList contains a list of HMAC credentials.
+// +kubebuilder:object:root=true
+// +kgosupported
 type KongCredentialHMACList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongcredential_jwt_types.go
+++ b/api/configuration/v1alpha1/kongcredential_jwt_types.go
@@ -34,6 +34,7 @@ import (
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.consumerRef == self.spec.consumerRef",message="spec.consumerRef is immutable when an entity is already Programmed"
 // +kubebuilder:validation:XValidation:rule="self.spec.algorithm in [ 'RS256','RS384','RS512','ES256','ES384','ES512','PS256','PS384','PS512','EdDSA', ] ? has(self.spec.rsa_public_key) : true",message="spec.rsa_public_key is required when algorithm is RS*, ES*, PS* or EdDSA*"
+// +kgosupported
 type KongCredentialJWT struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -48,6 +49,7 @@ type KongCredentialJWT struct {
 }
 
 // KongCredentialJWTSpec defines specification of a Kong Route.
+// +kgosupported
 type KongCredentialJWTSpec struct {
 	// ConsumerRef is a reference to a Consumer this KongCredentialJWT is associated with.
 	//
@@ -58,6 +60,7 @@ type KongCredentialJWTSpec struct {
 }
 
 // KongCredentialJWTAPISpec defines specification of an JWT credential.
+// +kgosupported
 type KongCredentialJWTAPISpec struct {
 	// Algorithm is the algorithm used to sign the JWT token.
 	// +kubebuilder:default=HS256
@@ -76,6 +79,7 @@ type KongCredentialJWTAPISpec struct {
 }
 
 // KongCredentialJWTStatus represents the current status of the JWT credential resource.
+// +kgosupported
 type KongCredentialJWTStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
@@ -89,9 +93,9 @@ type KongCredentialJWTStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
-// +kubebuilder:object:root=true
-
 // KongCredentialJWTList contains a list of JWT credentials.
+// +kubebuilder:object:root=true
+// +kgosupported
 type KongCredentialJWTList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongcredential_jwt_types.go
+++ b/api/configuration/v1alpha1/kongcredential_jwt_types.go
@@ -34,7 +34,7 @@ import (
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.consumerRef == self.spec.consumerRef",message="spec.consumerRef is immutable when an entity is already Programmed"
 // +kubebuilder:validation:XValidation:rule="self.spec.algorithm in [ 'RS256','RS384','RS512','ES256','ES384','ES512','PS256','PS384','PS512','EdDSA', ] ? has(self.spec.rsa_public_key) : true",message="spec.rsa_public_key is required when algorithm is RS*, ES*, PS* or EdDSA*"
-// +kgosupported
+// +apireference:kgo:include
 type KongCredentialJWT struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -49,7 +49,7 @@ type KongCredentialJWT struct {
 }
 
 // KongCredentialJWTSpec defines specification of a Kong Route.
-// +kgosupported
+// +apireference:kgo:include
 type KongCredentialJWTSpec struct {
 	// ConsumerRef is a reference to a Consumer this KongCredentialJWT is associated with.
 	//
@@ -60,7 +60,7 @@ type KongCredentialJWTSpec struct {
 }
 
 // KongCredentialJWTAPISpec defines specification of an JWT credential.
-// +kgosupported
+// +apireference:kgo:include
 type KongCredentialJWTAPISpec struct {
 	// Algorithm is the algorithm used to sign the JWT token.
 	// +kubebuilder:default=HS256
@@ -79,7 +79,7 @@ type KongCredentialJWTAPISpec struct {
 }
 
 // KongCredentialJWTStatus represents the current status of the JWT credential resource.
-// +kgosupported
+// +apireference:kgo:include
 type KongCredentialJWTStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
@@ -95,7 +95,7 @@ type KongCredentialJWTStatus struct {
 
 // KongCredentialJWTList contains a list of JWT credentials.
 // +kubebuilder:object:root=true
-// +kgosupported
+// +apireference:kgo:include
 type KongCredentialJWTList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongdataplanecertificate_types.go
+++ b/api/configuration/v1alpha1/kongdataplanecertificate_types.go
@@ -35,7 +35,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="!has(self.spec.controlPlaneRef) ? true : (!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.cert == self.spec.cert", message="spec.cert is immutable when an entity is already Programmed"
 // +kubebuilder:validation:XValidation:rule="!has(self.spec.controlPlaneRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource - it's not supported yet"
-// +kgosupported
+// +apireference:kgo:include
 type KongDataplaneCertificate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -47,7 +47,7 @@ type KongDataplaneCertificate struct {
 }
 
 // KongDataplaneCertificateSpec defines the spec for a KongDataplaneCertificate.
-// +kgosupported
+// +apireference:kgo:include
 type KongDataplaneCertificateSpec struct {
 	// ControlPlaneRef is a reference to a Konnect ControlPlane this KongDataplaneCertificate is associated with.
 	// +optional
@@ -58,7 +58,7 @@ type KongDataplaneCertificateSpec struct {
 }
 
 // KongDataplaneCertificateAPISpec defines the attributes of a Kong DP certificate.
-// +kgosupported
+// +apireference:kgo:include
 type KongDataplaneCertificateAPISpec struct {
 	// Cert is the certificate in PEM format. Once the certificate gets programmed this field becomes immutable.
 	// +kubebuilder:validation:MinLength=1
@@ -66,7 +66,7 @@ type KongDataplaneCertificateAPISpec struct {
 }
 
 // KongDataplaneCertificateStatus defines the status for a KongDataplaneCertificate.
-// +kgosupported
+// +apireference:kgo:include
 type KongDataplaneCertificateStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
@@ -82,7 +82,7 @@ type KongDataplaneCertificateStatus struct {
 
 // KongDataplaneCertificateList contains a list of Kong Keys.
 // +kubebuilder:object:root=true
-// +kgosupported
+// +apireference:kgo:include
 type KongDataplaneCertificateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongdataplanecertificate_types.go
+++ b/api/configuration/v1alpha1/kongdataplanecertificate_types.go
@@ -35,6 +35,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="!has(self.spec.controlPlaneRef) ? true : (!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.cert == self.spec.cert", message="spec.cert is immutable when an entity is already Programmed"
 // +kubebuilder:validation:XValidation:rule="!has(self.spec.controlPlaneRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource - it's not supported yet"
+// +kgosupported
 type KongDataplaneCertificate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -46,6 +47,7 @@ type KongDataplaneCertificate struct {
 }
 
 // KongDataplaneCertificateSpec defines the spec for a KongDataplaneCertificate.
+// +kgosupported
 type KongDataplaneCertificateSpec struct {
 	// ControlPlaneRef is a reference to a Konnect ControlPlane this KongDataplaneCertificate is associated with.
 	// +optional
@@ -56,6 +58,7 @@ type KongDataplaneCertificateSpec struct {
 }
 
 // KongDataplaneCertificateAPISpec defines the attributes of a Kong DP certificate.
+// +kgosupported
 type KongDataplaneCertificateAPISpec struct {
 	// Cert is the certificate in PEM format. Once the certificate gets programmed this field becomes immutable.
 	// +kubebuilder:validation:MinLength=1
@@ -63,6 +66,7 @@ type KongDataplaneCertificateAPISpec struct {
 }
 
 // KongDataplaneCertificateStatus defines the status for a KongDataplaneCertificate.
+// +kgosupported
 type KongDataplaneCertificateStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
@@ -76,9 +80,9 @@ type KongDataplaneCertificateStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
-// +kubebuilder:object:root=true
-
 // KongDataplaneCertificateList contains a list of Kong Keys.
+// +kubebuilder:object:root=true
+// +kgosupported
 type KongDataplaneCertificateList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongkey_types.go
+++ b/api/configuration/v1alpha1/kongkey_types.go
@@ -34,7 +34,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 // +kubebuilder:validation:XValidation:rule="!has(self.spec.controlPlaneRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource - it's not supported yet"
-// +kgosupported
+// +apireference:kgo:include
 type KongKey struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -46,7 +46,7 @@ type KongKey struct {
 }
 
 // KongKeySpec defines the spec for a KongKey.
-// +kgosupported
+// +apireference:kgo:include
 type KongKeySpec struct {
 	// ControlPlaneRef is a reference to a Konnect ControlPlane this KongKey is associated with.
 	// +optional
@@ -63,7 +63,7 @@ type KongKeySpec struct {
 
 // KongKeyAPISpec defines the attributes of a Kong Key.
 // +kubebuilder:validation:XValidation:rule="has(self.jwk) || has(self.pem)", message="Either 'jwk' or 'pem' must be set"
-// +kgosupported
+// +apireference:kgo:include
 type KongKeyAPISpec struct {
 	// KID is a unique identifier for a key.
 	// When JWK is provided, KID has to match the KID in the JWK.
@@ -91,7 +91,7 @@ type KongKeyAPISpec struct {
 }
 
 // PEMKeyPair defines a keypair in PEM format.
-// +kgosupported
+// +apireference:kgo:include
 type PEMKeyPair struct {
 	// The private key in PEM format.
 	// +kubebuilder:validation:MinLength=1
@@ -103,7 +103,7 @@ type PEMKeyPair struct {
 }
 
 // KongKeyStatus defines the status for a KongKey.
-// +kgosupported
+// +apireference:kgo:include
 type KongKeyStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
@@ -119,7 +119,7 @@ type KongKeyStatus struct {
 
 // KongKeyList contains a list of Kong Keys.
 // +kubebuilder:object:root=true
-// +kgosupported
+// +apireference:kgo:include
 type KongKeyList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongkey_types.go
+++ b/api/configuration/v1alpha1/kongkey_types.go
@@ -34,6 +34,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 // +kubebuilder:validation:XValidation:rule="!has(self.spec.controlPlaneRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource - it's not supported yet"
+// +kgosupported
 type KongKey struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -45,6 +46,7 @@ type KongKey struct {
 }
 
 // KongKeySpec defines the spec for a KongKey.
+// +kgosupported
 type KongKeySpec struct {
 	// ControlPlaneRef is a reference to a Konnect ControlPlane this KongKey is associated with.
 	// +optional
@@ -61,6 +63,7 @@ type KongKeySpec struct {
 
 // KongKeyAPISpec defines the attributes of a Kong Key.
 // +kubebuilder:validation:XValidation:rule="has(self.jwk) || has(self.pem)", message="Either 'jwk' or 'pem' must be set"
+// +kgosupported
 type KongKeyAPISpec struct {
 	// KID is a unique identifier for a key.
 	// When JWK is provided, KID has to match the KID in the JWK.
@@ -88,6 +91,7 @@ type KongKeyAPISpec struct {
 }
 
 // PEMKeyPair defines a keypair in PEM format.
+// +kgosupported
 type PEMKeyPair struct {
 	// The private key in PEM format.
 	// +kubebuilder:validation:MinLength=1
@@ -99,6 +103,7 @@ type PEMKeyPair struct {
 }
 
 // KongKeyStatus defines the status for a KongKey.
+// +kgosupported
 type KongKeyStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
@@ -112,9 +117,9 @@ type KongKeyStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
-// +kubebuilder:object:root=true
-
 // KongKeyList contains a list of Kong Keys.
+// +kubebuilder:object:root=true
+// +kgosupported
 type KongKeyList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongkeyset_types.go
+++ b/api/configuration/v1alpha1/kongkeyset_types.go
@@ -33,6 +33,7 @@ import (
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 // +kubebuilder:validation:XValidation:rule="!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource - it's not supported yet"
+// +kgosupported
 type KongKeySet struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -44,6 +45,7 @@ type KongKeySet struct {
 }
 
 // KongKeySetSpec defines the spec for a KongKeySet.
+// +kgosupported
 type KongKeySetSpec struct {
 	// ControlPlaneRef is a reference to a Konnect ControlPlane with which KongKeySet is associated.
 	// +optional
@@ -54,6 +56,7 @@ type KongKeySetSpec struct {
 }
 
 // KongKeySetAPISpec defines the attributes of a Kong KeySet.
+// +kgosupported
 type KongKeySetAPISpec struct {
 	// Name is a name of the KeySet.
 	// +kubebuilder:validation:MinLength=1
@@ -65,6 +68,7 @@ type KongKeySetAPISpec struct {
 }
 
 // KongKeySetStatus defines the status for a KongKeySet.
+// +kgosupported
 type KongKeySetStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
@@ -78,9 +82,9 @@ type KongKeySetStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
-// +kubebuilder:object:root=true
-
 // KongKeySetList contains a list of Kong Keys.
+// +kubebuilder:object:root=true
+// +kgosupported
 type KongKeySetList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongkeyset_types.go
+++ b/api/configuration/v1alpha1/kongkeyset_types.go
@@ -33,7 +33,7 @@ import (
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 // +kubebuilder:validation:XValidation:rule="!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource - it's not supported yet"
-// +kgosupported
+// +apireference:kgo:include
 type KongKeySet struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -45,7 +45,7 @@ type KongKeySet struct {
 }
 
 // KongKeySetSpec defines the spec for a KongKeySet.
-// +kgosupported
+// +apireference:kgo:include
 type KongKeySetSpec struct {
 	// ControlPlaneRef is a reference to a Konnect ControlPlane with which KongKeySet is associated.
 	// +optional
@@ -56,7 +56,7 @@ type KongKeySetSpec struct {
 }
 
 // KongKeySetAPISpec defines the attributes of a Kong KeySet.
-// +kgosupported
+// +apireference:kgo:include
 type KongKeySetAPISpec struct {
 	// Name is a name of the KeySet.
 	// +kubebuilder:validation:MinLength=1
@@ -68,7 +68,7 @@ type KongKeySetAPISpec struct {
 }
 
 // KongKeySetStatus defines the status for a KongKeySet.
-// +kgosupported
+// +apireference:kgo:include
 type KongKeySetStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
@@ -84,7 +84,7 @@ type KongKeySetStatus struct {
 
 // KongKeySetList contains a list of Kong Keys.
 // +kubebuilder:object:root=true
-// +kgosupported
+// +apireference:kgo:include
 type KongKeySetList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongpluginbinding_types.go
+++ b/api/configuration/v1alpha1/kongpluginbinding_types.go
@@ -35,6 +35,7 @@ import (
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
+// +kgosupported
 type KongPluginBinding struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -46,6 +47,7 @@ type KongPluginBinding struct {
 }
 
 // KongPluginBindingSpec defines specification of a KongPluginBinding.
+// +kgosupported
 type KongPluginBindingSpec struct {
 	// PluginReference is a reference to the KongPlugin or KongClusterPlugin resource.
 	// +kubebuilder:validation:XValidation:message="pluginRef name must be set",rule="self.name != ''"
@@ -80,6 +82,7 @@ type KongPluginBindingSpec struct {
 }
 
 // KongPluginBindingTargets contains the targets references.
+// +kgosupported
 type KongPluginBindingTargets struct {
 	// RouteReference can be used to reference one of the following resouces:
 	// - networking.k8s.io/Ingress
@@ -109,6 +112,7 @@ type KongPluginBindingTargets struct {
 }
 
 // PluginRef is a reference to a KongPlugin or KongClusterPlugin resource.
+// +kgosupported
 type PluginRef struct {
 	// TODO(mattia): cross-namespace references are not supported yet.
 	// https://github.com/Kong/kubernetes-configuration/issues/9
@@ -124,6 +128,7 @@ type PluginRef struct {
 }
 
 // TargetRef is a reference based on the object's name.
+// +kgosupported
 type TargetRef struct {
 	// Name is the name of the entity.
 	// +kubebuilder:validation:Required
@@ -131,6 +136,7 @@ type TargetRef struct {
 }
 
 // TargetRefWithGroupKind is a reference based on the object's group, kind, and name.
+// +kgosupported
 type TargetRefWithGroupKind struct {
 	// Name is the name of the entity.
 	// +kubebuilder:validation:Required
@@ -144,6 +150,7 @@ type TargetRefWithGroupKind struct {
 }
 
 // KongPluginBindingStatus represents the current status of the KongBinding resource.
+// +kgosupported
 type KongPluginBindingStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
@@ -157,9 +164,9 @@ type KongPluginBindingStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
-// +kubebuilder:object:root=true
-
 // KongPluginBindingList contains a list of KongPluginBindings.
+// +kubebuilder:object:root=true
+// +kgosupported
 type KongPluginBindingList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongpluginbinding_types.go
+++ b/api/configuration/v1alpha1/kongpluginbinding_types.go
@@ -35,7 +35,7 @@ import (
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
-// +kgosupported
+// +apireference:kgo:include
 type KongPluginBinding struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -47,7 +47,7 @@ type KongPluginBinding struct {
 }
 
 // KongPluginBindingSpec defines specification of a KongPluginBinding.
-// +kgosupported
+// +apireference:kgo:include
 type KongPluginBindingSpec struct {
 	// PluginReference is a reference to the KongPlugin or KongClusterPlugin resource.
 	// +kubebuilder:validation:XValidation:message="pluginRef name must be set",rule="self.name != ''"
@@ -82,7 +82,7 @@ type KongPluginBindingSpec struct {
 }
 
 // KongPluginBindingTargets contains the targets references.
-// +kgosupported
+// +apireference:kgo:include
 type KongPluginBindingTargets struct {
 	// RouteReference can be used to reference one of the following resouces:
 	// - networking.k8s.io/Ingress
@@ -112,7 +112,7 @@ type KongPluginBindingTargets struct {
 }
 
 // PluginRef is a reference to a KongPlugin or KongClusterPlugin resource.
-// +kgosupported
+// +apireference:kgo:include
 type PluginRef struct {
 	// TODO(mattia): cross-namespace references are not supported yet.
 	// https://github.com/Kong/kubernetes-configuration/issues/9
@@ -128,7 +128,7 @@ type PluginRef struct {
 }
 
 // TargetRef is a reference based on the object's name.
-// +kgosupported
+// +apireference:kgo:include
 type TargetRef struct {
 	// Name is the name of the entity.
 	// +kubebuilder:validation:Required
@@ -136,7 +136,7 @@ type TargetRef struct {
 }
 
 // TargetRefWithGroupKind is a reference based on the object's group, kind, and name.
-// +kgosupported
+// +apireference:kgo:include
 type TargetRefWithGroupKind struct {
 	// Name is the name of the entity.
 	// +kubebuilder:validation:Required
@@ -150,7 +150,7 @@ type TargetRefWithGroupKind struct {
 }
 
 // KongPluginBindingStatus represents the current status of the KongBinding resource.
-// +kgosupported
+// +apireference:kgo:include
 type KongPluginBindingStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
@@ -166,7 +166,7 @@ type KongPluginBindingStatus struct {
 
 // KongPluginBindingList contains a list of KongPluginBindings.
 // +kubebuilder:object:root=true
-// +kgosupported
+// +apireference:kgo:include
 type KongPluginBindingList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongroute_types.go
+++ b/api/configuration/v1alpha1/kongroute_types.go
@@ -42,7 +42,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="!has(self.spec.controlPlaneRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
 // +kubebuilder:validation:XValidation:rule="!has(self.spec.serviceRef) ? true : (!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.serviceRef == self.spec.serviceRef", message="spec.serviceRef is immutable when an entity is already Programmed"
 // +kubebuilder:validation:XValidation:rule="!has(self.spec.controlPlaneRef) ? true :(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
-// +kgosupported
+// +apireference:kgo:include
 type KongRoute struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -54,7 +54,7 @@ type KongRoute struct {
 }
 
 // KongRouteSpec defines specification of a Kong Route.
-// +kgosupported
+// +apireference:kgo:include
 type KongRouteSpec struct {
 	// ControlPlaneRef is a reference to a ControlPlane this KongRoute is associated with.
 	// Route can either specify a ControlPlaneRef and be 'serviceless' route or
@@ -74,7 +74,7 @@ type KongRouteSpec struct {
 //
 // These fields are mostly copied from sdk-konnect-go but some modifications have been made
 // to make the code generation required for Kubernetes CRDs work.
-// +kgosupported
+// +apireference:kgo:include
 type KongRouteAPISpec struct {
 	// A list of IP destinations of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
 	Destinations []sdkkonnectcomp.Destinations `json:"destinations,omitempty"`
@@ -113,7 +113,7 @@ type KongRouteAPISpec struct {
 }
 
 // KongRouteStatus represents the current status of the Kong Route resource.
-// +kgosupported
+// +apireference:kgo:include
 type KongRouteStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
@@ -129,7 +129,7 @@ type KongRouteStatus struct {
 
 // KongRouteList contains a list of Kong Routes.
 // +kubebuilder:object:root=true
-// +kgosupported
+// +apireference:kgo:include
 type KongRouteList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongroute_types.go
+++ b/api/configuration/v1alpha1/kongroute_types.go
@@ -42,6 +42,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="!has(self.spec.controlPlaneRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
 // +kubebuilder:validation:XValidation:rule="!has(self.spec.serviceRef) ? true : (!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.serviceRef == self.spec.serviceRef", message="spec.serviceRef is immutable when an entity is already Programmed"
 // +kubebuilder:validation:XValidation:rule="!has(self.spec.controlPlaneRef) ? true :(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
+// +kgosupported
 type KongRoute struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -53,6 +54,7 @@ type KongRoute struct {
 }
 
 // KongRouteSpec defines specification of a Kong Route.
+// +kgosupported
 type KongRouteSpec struct {
 	// ControlPlaneRef is a reference to a ControlPlane this KongRoute is associated with.
 	// Route can either specify a ControlPlaneRef and be 'serviceless' route or
@@ -72,6 +74,7 @@ type KongRouteSpec struct {
 //
 // These fields are mostly copied from sdk-konnect-go but some modifications have been made
 // to make the code generation required for Kubernetes CRDs work.
+// +kgosupported
 type KongRouteAPISpec struct {
 	// A list of IP destinations of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
 	Destinations []sdkkonnectcomp.Destinations `json:"destinations,omitempty"`
@@ -110,6 +113,7 @@ type KongRouteAPISpec struct {
 }
 
 // KongRouteStatus represents the current status of the Kong Route resource.
+// +kgosupported
 type KongRouteStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
@@ -123,9 +127,9 @@ type KongRouteStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
-// +kubebuilder:object:root=true
-
 // KongRouteList contains a list of Kong Routes.
+// +kubebuilder:object:root=true
+// +kgosupported
 type KongRouteList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongservice_types.go
+++ b/api/configuration/v1alpha1/kongservice_types.go
@@ -38,6 +38,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
 // +kubebuilder:validation:XValidation:rule="!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
+// +kgosupported
 type KongService struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -49,6 +50,7 @@ type KongService struct {
 }
 
 // KongServiceSpec defines specification of a Kong Route.
+// +kgosupported
 type KongServiceSpec struct {
 	// ControlPlaneRef is a reference to a ControlPlane this KongService is associated with.
 	// +optional
@@ -58,6 +60,7 @@ type KongServiceSpec struct {
 }
 
 // KongServiceAPISpec defines specification of a Kong Service.
+// +kgosupported
 type KongServiceAPISpec struct {
 	// TODO(pmalek): client certificate implement ref
 	// TODO(pmalek): ca_certificates implement ref
@@ -103,6 +106,7 @@ type KongServiceAPISpec struct {
 }
 
 // KongServiceStatus represents the current status of the Kong Service resource.
+// +kgosupported
 type KongServiceStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
@@ -116,9 +120,9 @@ type KongServiceStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
-// +kubebuilder:object:root=true
-
 // KongServiceList contains a list of Kong Services.
+// +kubebuilder:object:root=true
+// +kgosupported
 type KongServiceList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongservice_types.go
+++ b/api/configuration/v1alpha1/kongservice_types.go
@@ -38,7 +38,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
 // +kubebuilder:validation:XValidation:rule="!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
-// +kgosupported
+// +apireference:kgo:include
 type KongService struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -50,7 +50,7 @@ type KongService struct {
 }
 
 // KongServiceSpec defines specification of a Kong Route.
-// +kgosupported
+// +apireference:kgo:include
 type KongServiceSpec struct {
 	// ControlPlaneRef is a reference to a ControlPlane this KongService is associated with.
 	// +optional
@@ -60,7 +60,7 @@ type KongServiceSpec struct {
 }
 
 // KongServiceAPISpec defines specification of a Kong Service.
-// +kgosupported
+// +apireference:kgo:include
 type KongServiceAPISpec struct {
 	// TODO(pmalek): client certificate implement ref
 	// TODO(pmalek): ca_certificates implement ref
@@ -106,7 +106,7 @@ type KongServiceAPISpec struct {
 }
 
 // KongServiceStatus represents the current status of the Kong Service resource.
-// +kgosupported
+// +apireference:kgo:include
 type KongServiceStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
@@ -122,7 +122,7 @@ type KongServiceStatus struct {
 
 // KongServiceList contains a list of Kong Services.
 // +kubebuilder:object:root=true
-// +kgosupported
+// +apireference:kgo:include
 type KongServiceList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongsni_types.go
+++ b/api/configuration/v1alpha1/kongsni_types.go
@@ -32,6 +32,7 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.certificateRef == self.spec.certificateRef", message="spec.certificateRef is immutable when programmed"
+// +kgosupported
 type KongSNI struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -43,6 +44,7 @@ type KongSNI struct {
 }
 
 // KongSNIAPISpec defines specification of an SNI.
+// +kgosupported
 type KongSNIAPISpec struct {
 	// Name is the name of the SNI. Required and must be a host or wildcard host.
 	// +kubebuilder:validation:MinLength=1
@@ -53,6 +55,7 @@ type KongSNIAPISpec struct {
 }
 
 // KongSNISpec defines specification of a Kong SNI.
+// +kgosupported
 type KongSNISpec struct {
 	// CertificateRef is the reference to the certificate to which the KongSNI is attached.
 	CertificateRef KongObjectRef `json:"certificateRef"`
@@ -61,6 +64,7 @@ type KongSNISpec struct {
 }
 
 // KongSNIStatus defines the status for a KongSNI.
+// +kgosupported
 type KongSNIStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
@@ -74,9 +78,9 @@ type KongSNIStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
-// +kubebuilder:object:root=true
-
 // KongSNIList contains a list of Kong SNIs.
+// +kubebuilder:object:root=true
+// +kgosupported
 type KongSNIList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongsni_types.go
+++ b/api/configuration/v1alpha1/kongsni_types.go
@@ -32,7 +32,7 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.certificateRef == self.spec.certificateRef", message="spec.certificateRef is immutable when programmed"
-// +kgosupported
+// +apireference:kgo:include
 type KongSNI struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -44,7 +44,7 @@ type KongSNI struct {
 }
 
 // KongSNIAPISpec defines specification of an SNI.
-// +kgosupported
+// +apireference:kgo:include
 type KongSNIAPISpec struct {
 	// Name is the name of the SNI. Required and must be a host or wildcard host.
 	// +kubebuilder:validation:MinLength=1
@@ -55,7 +55,7 @@ type KongSNIAPISpec struct {
 }
 
 // KongSNISpec defines specification of a Kong SNI.
-// +kgosupported
+// +apireference:kgo:include
 type KongSNISpec struct {
 	// CertificateRef is the reference to the certificate to which the KongSNI is attached.
 	CertificateRef KongObjectRef `json:"certificateRef"`
@@ -64,7 +64,7 @@ type KongSNISpec struct {
 }
 
 // KongSNIStatus defines the status for a KongSNI.
-// +kgosupported
+// +apireference:kgo:include
 type KongSNIStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
@@ -80,7 +80,7 @@ type KongSNIStatus struct {
 
 // KongSNIList contains a list of Kong SNIs.
 // +kubebuilder:object:root=true
-// +kgosupported
+// +apireference:kgo:include
 type KongSNIList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongupstream_types.go
+++ b/api/configuration/v1alpha1/kongupstream_types.go
@@ -36,6 +36,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
 // +kubebuilder:validation:XValidation:rule="!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
+// +kgosupported
 type KongUpstream struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -47,6 +48,7 @@ type KongUpstream struct {
 }
 
 // KongUpstreamSpec defines specification of a Kong Upstream.
+// +kgosupported
 type KongUpstreamSpec struct {
 	// ControlPlaneRef is a reference to a ControlPlane this KongUpstream is associated with.
 	// +optional
@@ -67,6 +69,7 @@ type KongUpstreamSpec struct {
 // +kubebuilder:validation:XValidation:rule="!has(self.hash_on) || (self.hash_on != 'header' || has(self.hash_on_header))", message="hash_on_header is required when hash_on is set to `header`."
 // +kubebuilder:validation:XValidation:rule="!has(self.hash_on) || (self.hash_on != 'query_arg' || has(self.hash_on_query_arg))", message="hash_on_query_arg is required when `hash_on` is set to `query_arg`."
 // +kubebuilder:validation:XValidation:rule="!has(self.hash_on) || (self.hash_on != 'uri_capture' || has(self.hash_on_uri_capture))", message="hash_on_uri_capture is required when `hash_on` is set to `uri_capture`."
+// +kgosupported
 type KongUpstreamAPISpec struct {
 	// Which load balancing algorithm to use.
 	Algorithm *sdkkonnectcomp.UpstreamAlgorithm `default:"round-robin" json:"algorithm,omitempty"`
@@ -108,6 +111,7 @@ type KongUpstreamAPISpec struct {
 }
 
 // KongUpstreamStatus represents the current status of the Kong Upstream resource.
+// +kgosupported
 type KongUpstreamStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
@@ -121,9 +125,9 @@ type KongUpstreamStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
-// +kubebuilder:object:root=true
-
 // KongUpstreamList contains a list of Kong Upstreams.
+// +kubebuilder:object:root=true
+// +kgosupported
 type KongUpstreamList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kongupstream_types.go
+++ b/api/configuration/v1alpha1/kongupstream_types.go
@@ -36,7 +36,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
 // +kubebuilder:validation:XValidation:rule="!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
 // +kubebuilder:validation:XValidation:rule="(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
-// +kgosupported
+// +apireference:kgo:include
 type KongUpstream struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -48,7 +48,7 @@ type KongUpstream struct {
 }
 
 // KongUpstreamSpec defines specification of a Kong Upstream.
-// +kgosupported
+// +apireference:kgo:include
 type KongUpstreamSpec struct {
 	// ControlPlaneRef is a reference to a ControlPlane this KongUpstream is associated with.
 	// +optional
@@ -69,7 +69,7 @@ type KongUpstreamSpec struct {
 // +kubebuilder:validation:XValidation:rule="!has(self.hash_on) || (self.hash_on != 'header' || has(self.hash_on_header))", message="hash_on_header is required when hash_on is set to `header`."
 // +kubebuilder:validation:XValidation:rule="!has(self.hash_on) || (self.hash_on != 'query_arg' || has(self.hash_on_query_arg))", message="hash_on_query_arg is required when `hash_on` is set to `query_arg`."
 // +kubebuilder:validation:XValidation:rule="!has(self.hash_on) || (self.hash_on != 'uri_capture' || has(self.hash_on_uri_capture))", message="hash_on_uri_capture is required when `hash_on` is set to `uri_capture`."
-// +kgosupported
+// +apireference:kgo:include
 type KongUpstreamAPISpec struct {
 	// Which load balancing algorithm to use.
 	Algorithm *sdkkonnectcomp.UpstreamAlgorithm `default:"round-robin" json:"algorithm,omitempty"`
@@ -111,7 +111,7 @@ type KongUpstreamAPISpec struct {
 }
 
 // KongUpstreamStatus represents the current status of the Kong Upstream resource.
-// +kgosupported
+// +apireference:kgo:include
 type KongUpstreamStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
@@ -127,7 +127,7 @@ type KongUpstreamStatus struct {
 
 // KongUpstreamList contains a list of Kong Upstreams.
 // +kubebuilder:object:root=true
-// +kgosupported
+// +apireference:kgo:include
 type KongUpstreamList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/konnect_controlplaneref_types.go
+++ b/api/configuration/v1alpha1/konnect_controlplaneref_types.go
@@ -14,7 +14,7 @@ const (
 // It is used to reference a Control Plane entity.
 // +kubebuilder:validation:XValidation:rule="self.type == 'konnectNamespacedRef' ? has(self.konnectNamespacedRef) : true", message="when type is konnectNamespacedRef, konnectNamespacedRef must be set"
 // +kubebuilder:validation:XValidation:rule="self.type == 'konnectID' ? has(self.konnectID) : true", message="when type is konnectID, konnectID must be set"
-// +kgosupported
+// +apireference:kgo:include
 type ControlPlaneRef struct {
 	// Type can be one of:
 	// - konnectID
@@ -35,7 +35,7 @@ type ControlPlaneRef struct {
 }
 
 // KonnectNamespacedRef is the schema for the KonnectNamespacedRef type.
-// +kgosupported
+// +apireference:kgo:include
 type KonnectNamespacedRef struct {
 	// Name is the name of the Konnect Control Plane.
 	// +kubebuilder:validation:Required

--- a/api/configuration/v1alpha1/konnect_controlplaneref_types.go
+++ b/api/configuration/v1alpha1/konnect_controlplaneref_types.go
@@ -14,6 +14,7 @@ const (
 // It is used to reference a Control Plane entity.
 // +kubebuilder:validation:XValidation:rule="self.type == 'konnectNamespacedRef' ? has(self.konnectNamespacedRef) : true", message="when type is konnectNamespacedRef, konnectNamespacedRef must be set"
 // +kubebuilder:validation:XValidation:rule="self.type == 'konnectID' ? has(self.konnectID) : true", message="when type is konnectID, konnectID must be set"
+// +kgosupported
 type ControlPlaneRef struct {
 	// Type can be one of:
 	// - konnectID
@@ -34,6 +35,7 @@ type ControlPlaneRef struct {
 }
 
 // KonnectNamespacedRef is the schema for the KonnectNamespacedRef type.
+// +kgosupported
 type KonnectNamespacedRef struct {
 	// Name is the name of the Konnect Control Plane.
 	// +kubebuilder:validation:Required

--- a/api/configuration/v1alpha1/object_ref.go
+++ b/api/configuration/v1alpha1/object_ref.go
@@ -4,7 +4,7 @@ package v1alpha1
 //
 // TODO: https://github.com/Kong/kubernetes-configuration/issues/96
 // change other types to use the generic `KongObjectRef` and move it to a common package to prevent possible import cycles.
-// +kgosupported
+// +apireference:kgo:include
 type KongObjectRef struct {
 	// Name is the name of the entity.
 	//

--- a/api/configuration/v1alpha1/object_ref.go
+++ b/api/configuration/v1alpha1/object_ref.go
@@ -4,6 +4,7 @@ package v1alpha1
 //
 // TODO: https://github.com/Kong/kubernetes-configuration/issues/96
 // change other types to use the generic `KongObjectRef` and move it to a common package to prevent possible import cycles.
+// +kgosupported
 type KongObjectRef struct {
 	// Name is the name of the entity.
 	//

--- a/api/configuration/v1alpha1/service_ref.go
+++ b/api/configuration/v1alpha1/service_ref.go
@@ -7,7 +7,7 @@ const (
 
 // ServiceRef is a reference to a KongService.
 // +kubebuilder:validation:XValidation:rule="self.type == 'namespacedRef' ? has(self.namespacedRef) : true", message="when type is namespacedRef, namespacedRef must be set"
-// +kgosupported
+// +apireference:kgo:include
 type ServiceRef struct {
 	// Type can be one of:
 	// - namespacedRef
@@ -20,7 +20,7 @@ type ServiceRef struct {
 // NamespacedServiceRef is a namespaced reference to a KongService.
 //
 // NOTE: currently cross namespace references are not supported.
-// +kgosupported
+// +apireference:kgo:include
 type NamespacedServiceRef struct {
 	// +kubebuilder:validation:Required
 	Name string `json:"name"`

--- a/api/configuration/v1alpha1/service_ref.go
+++ b/api/configuration/v1alpha1/service_ref.go
@@ -7,6 +7,7 @@ const (
 
 // ServiceRef is a reference to a KongService.
 // +kubebuilder:validation:XValidation:rule="self.type == 'namespacedRef' ? has(self.namespacedRef) : true", message="when type is namespacedRef, namespacedRef must be set"
+// +kgosupported
 type ServiceRef struct {
 	// Type can be one of:
 	// - namespacedRef
@@ -19,6 +20,7 @@ type ServiceRef struct {
 // NamespacedServiceRef is a namespaced reference to a KongService.
 //
 // NOTE: currently cross namespace references are not supported.
+// +kgosupported
 type NamespacedServiceRef struct {
 	// +kubebuilder:validation:Required
 	Name string `json:"name"`

--- a/api/konnect/v1alpha1/konnect_apiauthconfiguration_types.go
+++ b/api/konnect/v1alpha1/konnect_apiauthconfiguration_types.go
@@ -23,7 +23,7 @@ func init() {
 // +kubebuilder:validation:XValidation:rule="self.spec.type != 'token' || (self.spec.token.startsWith('spat_') || self.spec.token.startsWith('kpat_'))", message="Konnect tokens have to start with spat_ or kpat_"
 // +kubebuilder:validation:XValidation:rule="self.spec.type != 'token' || (!has(oldSelf.spec.token) || has(self.spec.token))", message="Token is required once set"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.serverURL) || has(self.spec.serverURL)", message="Server URL is required once set"
-// +kgosupported
+// +apireference:kgo:include
 type KonnectAPIAuthConfiguration struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -36,7 +36,7 @@ type KonnectAPIAuthConfiguration struct {
 }
 
 // KonnectAPIAuthType is the type of authentication used to authenticate with the Konnect API.
-// +kgosupported
+// +apireference:kgo:include
 type KonnectAPIAuthType string
 
 const (
@@ -50,7 +50,7 @@ const (
 // KonnectAPIAuthConfigurationSpec is the specification of the KonnectAPIAuthConfiguration resource.
 //
 // +kubebuilder:validation:XValidation:rule="(self.type == 'token' && has(self.token)) || (self.type == 'secretRef' && has(self.secretRef))", message="Token is required if auth type is set to token or secretRef is required if auth type is set to secretRef"
-// +kgosupported
+// +apireference:kgo:include
 type KonnectAPIAuthConfigurationSpec struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Enum=token;secretRef
@@ -70,7 +70,7 @@ type KonnectAPIAuthConfigurationSpec struct {
 }
 
 // KonnectAPIAuthConfigurationStatus is the status of the KonnectAPIAuthConfiguration resource.
-// +kgosupported
+// +apireference:kgo:include
 type KonnectAPIAuthConfigurationStatus struct {
 	// OrganizationID is the unique identifier of the organization in Konnect.
 	OrganizationID string `json:"organizationID,omitempty"`
@@ -88,7 +88,7 @@ type KonnectAPIAuthConfigurationStatus struct {
 }
 
 // KonnectAPIAuthConfigurationRef is a reference to a KonnectAPIAuthConfiguration resource.
-// +kgosupported
+// +apireference:kgo:include
 type KonnectAPIAuthConfigurationRef struct {
 	// Name is the name of the KonnectAPIAuthConfiguration resource.
 	// +kubebuilder:validation:Required
@@ -100,7 +100,7 @@ type KonnectAPIAuthConfigurationRef struct {
 
 // KonnectAPIAuthConfigurationList contains a list of KonnectAPIAuthConfiguration resources.
 // +kubebuilder:object:root=true
-// +kgosupported
+// +apireference:kgo:include
 type KonnectAPIAuthConfigurationList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/konnect/v1alpha1/konnect_apiauthconfiguration_types.go
+++ b/api/konnect/v1alpha1/konnect_apiauthconfiguration_types.go
@@ -23,6 +23,7 @@ func init() {
 // +kubebuilder:validation:XValidation:rule="self.spec.type != 'token' || (self.spec.token.startsWith('spat_') || self.spec.token.startsWith('kpat_'))", message="Konnect tokens have to start with spat_ or kpat_"
 // +kubebuilder:validation:XValidation:rule="self.spec.type != 'token' || (!has(oldSelf.spec.token) || has(self.spec.token))", message="Token is required once set"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.serverURL) || has(self.spec.serverURL)", message="Server URL is required once set"
+// +kgosupported
 type KonnectAPIAuthConfiguration struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -35,6 +36,7 @@ type KonnectAPIAuthConfiguration struct {
 }
 
 // KonnectAPIAuthType is the type of authentication used to authenticate with the Konnect API.
+// +kgosupported
 type KonnectAPIAuthType string
 
 const (
@@ -48,6 +50,7 @@ const (
 // KonnectAPIAuthConfigurationSpec is the specification of the KonnectAPIAuthConfiguration resource.
 //
 // +kubebuilder:validation:XValidation:rule="(self.type == 'token' && has(self.token)) || (self.type == 'secretRef' && has(self.secretRef))", message="Token is required if auth type is set to token or secretRef is required if auth type is set to secretRef"
+// +kgosupported
 type KonnectAPIAuthConfigurationSpec struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Enum=token;secretRef
@@ -67,6 +70,7 @@ type KonnectAPIAuthConfigurationSpec struct {
 }
 
 // KonnectAPIAuthConfigurationStatus is the status of the KonnectAPIAuthConfiguration resource.
+// +kgosupported
 type KonnectAPIAuthConfigurationStatus struct {
 	// OrganizationID is the unique identifier of the organization in Konnect.
 	OrganizationID string `json:"organizationID,omitempty"`
@@ -84,6 +88,7 @@ type KonnectAPIAuthConfigurationStatus struct {
 }
 
 // KonnectAPIAuthConfigurationRef is a reference to a KonnectAPIAuthConfiguration resource.
+// +kgosupported
 type KonnectAPIAuthConfigurationRef struct {
 	// Name is the name of the KonnectAPIAuthConfiguration resource.
 	// +kubebuilder:validation:Required
@@ -95,6 +100,7 @@ type KonnectAPIAuthConfigurationRef struct {
 
 // KonnectAPIAuthConfigurationList contains a list of KonnectAPIAuthConfiguration resources.
 // +kubebuilder:object:root=true
+// +kgosupported
 type KonnectAPIAuthConfigurationList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/konnect/v1alpha1/konnect_configuration.go
+++ b/api/konnect/v1alpha1/konnect_configuration.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 // KonnectConfiguration is the Schema for the KonnectConfiguration API.
 // +kubebuilder:object:generate=false
+// +kgosupported
 type KonnectConfiguration struct {
 	// APIAuthConfigurationRef is the reference to the API Auth Configuration
 	// that should be used for this Konnect Configuration.

--- a/api/konnect/v1alpha1/konnect_configuration.go
+++ b/api/konnect/v1alpha1/konnect_configuration.go
@@ -2,7 +2,7 @@ package v1alpha1
 
 // KonnectConfiguration is the Schema for the KonnectConfiguration API.
 // +kubebuilder:object:generate=false
-// +kgosupported
+// +apireference:kgo:include
 type KonnectConfiguration struct {
 	// APIAuthConfigurationRef is the reference to the API Auth Configuration
 	// that should be used for this Konnect Configuration.

--- a/api/konnect/v1alpha1/konnect_entity_status.go
+++ b/api/konnect/v1alpha1/konnect_entity_status.go
@@ -1,7 +1,7 @@
 package v1alpha1
 
 // KonnectEntityStatus represents the status of a Konnect entity.
-// +kgosupported
+// +apireference:kgo:include
 type KonnectEntityStatus struct {
 	// ID is the unique identifier of the Konnect entity as assigned by Konnect API.
 	// If it's unset (empty string), it means the Konnect entity hasn't been created yet.
@@ -54,7 +54,7 @@ func (in *KonnectEntityStatus) SetServerURL(s string) {
 }
 
 // KonnectEntityStatusWithControlPlaneRef represents the status of a Konnect entity with a reference to a ControlPlane.
-// +kgosupported
+// +apireference:kgo:include
 type KonnectEntityStatusWithControlPlaneRef struct {
 	KonnectEntityStatus `json:",inline"`
 
@@ -73,7 +73,7 @@ func (in *KonnectEntityStatusWithControlPlaneRef) GetControlPlaneID() string {
 }
 
 // KonnectEntityStatusWithControlPlaneAndConsumerRefs represents the status of a Konnect entity with references to a ControlPlane and a Consumer.
-// +kgosupported
+// +apireference:kgo:include
 type KonnectEntityStatusWithControlPlaneAndConsumerRefs struct {
 	KonnectEntityStatus `json:",inline"`
 
@@ -105,7 +105,7 @@ func (in *KonnectEntityStatusWithControlPlaneAndConsumerRefs) GetConsumerID() st
 }
 
 // KonnectEntityStatusWithControlPlaneAndServiceRefs represents the status of a Konnect entity with references to a ControlPlane and a Service.
-// +kgosupported
+// +apireference:kgo:include
 type KonnectEntityStatusWithControlPlaneAndServiceRefs struct {
 	KonnectEntityStatus `json:",inline"`
 
@@ -127,7 +127,7 @@ func (in *KonnectEntityStatusWithControlPlaneAndServiceRefs) GetControlPlaneID()
 }
 
 // KonnectEntityStatusWithControlPlaneAndUpstreamRefs represents the status of a Konnect entity with references to a ControlPlane and an Upstream.
-// +kgosupported
+// +apireference:kgo:include
 type KonnectEntityStatusWithControlPlaneAndUpstreamRefs struct {
 	KonnectEntityStatus `json:",inline"`
 
@@ -139,7 +139,7 @@ type KonnectEntityStatusWithControlPlaneAndUpstreamRefs struct {
 }
 
 // KonnectEntityStatusWithControlPlaneAndKeySetRef represents the status of a Konnect entity with references to a ControlPlane and a KeySet.
-// +kgosupported
+// +apireference:kgo:include
 type KonnectEntityStatusWithControlPlaneAndKeySetRef struct {
 	KonnectEntityStatus `json:",inline"`
 
@@ -171,7 +171,7 @@ func (in *KonnectEntityStatusWithControlPlaneAndKeySetRef) GetKeySetID() string 
 }
 
 // KonnectEntityStatusWithControlPlaneAndCertificateRefs represents the status of a Konnect entity with references to a ControlPlane and a Certificate.
-// +kgosupported
+// +apireference:kgo:include
 type KonnectEntityStatusWithControlPlaneAndCertificateRefs struct {
 	KonnectEntityStatus `json:",inline"`
 

--- a/api/konnect/v1alpha1/konnect_entity_status.go
+++ b/api/konnect/v1alpha1/konnect_entity_status.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 // KonnectEntityStatus represents the status of a Konnect entity.
+// +kgosupported
 type KonnectEntityStatus struct {
 	// ID is the unique identifier of the Konnect entity as assigned by Konnect API.
 	// If it's unset (empty string), it means the Konnect entity hasn't been created yet.
@@ -53,6 +54,7 @@ func (in *KonnectEntityStatus) SetServerURL(s string) {
 }
 
 // KonnectEntityStatusWithControlPlaneRef represents the status of a Konnect entity with a reference to a ControlPlane.
+// +kgosupported
 type KonnectEntityStatusWithControlPlaneRef struct {
 	KonnectEntityStatus `json:",inline"`
 
@@ -71,6 +73,7 @@ func (in *KonnectEntityStatusWithControlPlaneRef) GetControlPlaneID() string {
 }
 
 // KonnectEntityStatusWithControlPlaneAndConsumerRefs represents the status of a Konnect entity with references to a ControlPlane and a Consumer.
+// +kgosupported
 type KonnectEntityStatusWithControlPlaneAndConsumerRefs struct {
 	KonnectEntityStatus `json:",inline"`
 
@@ -102,6 +105,7 @@ func (in *KonnectEntityStatusWithControlPlaneAndConsumerRefs) GetConsumerID() st
 }
 
 // KonnectEntityStatusWithControlPlaneAndServiceRefs represents the status of a Konnect entity with references to a ControlPlane and a Service.
+// +kgosupported
 type KonnectEntityStatusWithControlPlaneAndServiceRefs struct {
 	KonnectEntityStatus `json:",inline"`
 
@@ -123,6 +127,7 @@ func (in *KonnectEntityStatusWithControlPlaneAndServiceRefs) GetControlPlaneID()
 }
 
 // KonnectEntityStatusWithControlPlaneAndUpstreamRefs represents the status of a Konnect entity with references to a ControlPlane and an Upstream.
+// +kgosupported
 type KonnectEntityStatusWithControlPlaneAndUpstreamRefs struct {
 	KonnectEntityStatus `json:",inline"`
 
@@ -134,6 +139,7 @@ type KonnectEntityStatusWithControlPlaneAndUpstreamRefs struct {
 }
 
 // KonnectEntityStatusWithControlPlaneAndKeySetRef represents the status of a Konnect entity with references to a ControlPlane and a KeySet.
+// +kgosupported
 type KonnectEntityStatusWithControlPlaneAndKeySetRef struct {
 	KonnectEntityStatus `json:",inline"`
 
@@ -165,6 +171,7 @@ func (in *KonnectEntityStatusWithControlPlaneAndKeySetRef) GetKeySetID() string 
 }
 
 // KonnectEntityStatusWithControlPlaneAndCertificateRefs represents the status of a Konnect entity with references to a ControlPlane and a Certificate.
+// +kgosupported
 type KonnectEntityStatusWithControlPlaneAndCertificateRefs struct {
 	KonnectEntityStatus `json:",inline"`
 

--- a/api/konnect/v1alpha1/konnect_gateway_controlplane_types.go
+++ b/api/konnect/v1alpha1/konnect_gateway_controlplane_types.go
@@ -22,6 +22,7 @@ func init() {
 // +kubebuilder:printcolumn:name="OrgID",description="Konnect Organization ID this resource belongs to.",type=string,JSONPath=`.status.organizationID`
 // +kubebuilder:validation:XValidation:rule="!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef", message="spec.konnect.authRef is immutable when an entity is already Programmed"
 // +kubebuilder:validation:XValidation:rule="!self.status.conditions.exists(c, c.type == 'APIAuthValid' && c.status == 'True') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef", message="spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration"
+// +kgosupported
 type KonnectGatewayControlPlane struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -34,6 +35,7 @@ type KonnectGatewayControlPlane struct {
 }
 
 // KonnectGatewayControlPlaneSpec defines the desired state of KonnectGatewayControlPlane.
+// +kgosupported
 type KonnectGatewayControlPlaneSpec struct {
 	sdkkonnectcomp.CreateControlPlaneRequest `json:",inline"`
 
@@ -41,6 +43,7 @@ type KonnectGatewayControlPlaneSpec struct {
 }
 
 // KonnectGatewayControlPlaneStatus defines the observed state of KonnectGatewayControlPlane.
+// +kgosupported
 type KonnectGatewayControlPlaneStatus struct {
 	KonnectEntityStatus `json:",inline"`
 
@@ -74,6 +77,7 @@ func (c *KonnectGatewayControlPlane) GetKonnectAPIAuthConfigurationRef() Konnect
 
 // KonnectGatewayControlPlaneList contains a list of KonnectGatewayControlPlane.
 // +kubebuilder:object:root=true
+// +kgosupported
 type KonnectGatewayControlPlaneList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/konnect/v1alpha1/konnect_gateway_controlplane_types.go
+++ b/api/konnect/v1alpha1/konnect_gateway_controlplane_types.go
@@ -22,7 +22,7 @@ func init() {
 // +kubebuilder:printcolumn:name="OrgID",description="Konnect Organization ID this resource belongs to.",type=string,JSONPath=`.status.organizationID`
 // +kubebuilder:validation:XValidation:rule="!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef", message="spec.konnect.authRef is immutable when an entity is already Programmed"
 // +kubebuilder:validation:XValidation:rule="!self.status.conditions.exists(c, c.type == 'APIAuthValid' && c.status == 'True') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef", message="spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration"
-// +kgosupported
+// +apireference:kgo:include
 type KonnectGatewayControlPlane struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -35,7 +35,7 @@ type KonnectGatewayControlPlane struct {
 }
 
 // KonnectGatewayControlPlaneSpec defines the desired state of KonnectGatewayControlPlane.
-// +kgosupported
+// +apireference:kgo:include
 type KonnectGatewayControlPlaneSpec struct {
 	sdkkonnectcomp.CreateControlPlaneRequest `json:",inline"`
 
@@ -43,7 +43,7 @@ type KonnectGatewayControlPlaneSpec struct {
 }
 
 // KonnectGatewayControlPlaneStatus defines the observed state of KonnectGatewayControlPlane.
-// +kgosupported
+// +apireference:kgo:include
 type KonnectGatewayControlPlaneStatus struct {
 	KonnectEntityStatus `json:",inline"`
 
@@ -77,7 +77,7 @@ func (c *KonnectGatewayControlPlane) GetKonnectAPIAuthConfigurationRef() Konnect
 
 // KonnectGatewayControlPlaneList contains a list of KonnectGatewayControlPlane.
 // +kubebuilder:object:root=true
-// +kgosupported
+// +apireference:kgo:include
 type KonnectGatewayControlPlaneList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/configuration.konghq.com_kongtargets.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongtargets.yaml
@@ -43,7 +43,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: KongTargetSpec defines the desired state of KongTarget.
+            description: |-
+              KongTargetSpec defines the specification of a Kong Target.
+              KongTargetSpec defines the desired state of KongTarget.
             properties:
               tags:
                 description: Tags is an optional set of strings associated with the

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1224,8 +1224,6 @@ _Appears in:_
 
 
 
-
-
 #### KongObjectRef
 
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1460,6 +1460,7 @@ _Appears in:_
 #### KongTargetSpec
 
 
+KongTargetSpec defines the specification of a Kong Target.
 KongTargetSpec defines the desired state of KongTarget.
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Annotates all the types that should be included in the KGO docs with the new `+apireference:kgo:include` marker. Also, annotates fields that are not supported by KGO and should not be included in the docs with `+apireference:kgo:exclude`. The markers will be used to determine whether a type/field should be included in KGO's CRDs reference.

https://github.com/Kong/gateway-operator/pull/689 uses the markers.

**Which issue this PR fixes**

Part of https://github.com/Kong/kubernetes-configuration/issues/105. 
