### PR TITLE
chore: enable linter for api directory

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -117,8 +117,12 @@ linters-settings:
 issues:
   max-same-issues: 0
   fix: true
+  exclude-files:
+    - zz_generated.+.go
   exclude-dirs:
     - pkg/clientset
-    - api
   include:
     - EXC0012
+    - EXC0013
+    - EXC0014
+    - EXC0015

--- a/api/configuration/v1/kongconsumer_types.go
+++ b/api/configuration/v1/kongconsumer_types.go
@@ -66,6 +66,7 @@ type KongConsumer struct {
 	Status KongConsumerStatus `json:"status,omitempty"`
 }
 
+// KongConsumerSpec defines the specification of the KongConsumer.
 type KongConsumerSpec struct {
 	// ControlPlaneRef is a reference to a ControlPlane this Consumer is associated with.
 	// +optional

--- a/api/configuration/v1alpha1/ingress_class_param_types.go
+++ b/api/configuration/v1alpha1/ingress_class_param_types.go
@@ -21,6 +21,7 @@ import (
 )
 
 const (
+	// IngressClassParametersKind is the kind name the IngressClassParameters resource.
 	IngressClassParametersKind = "IngressClassParameters"
 )
 
@@ -50,7 +51,6 @@ type IngressClassParameters struct {
 }
 
 // IngressClassParametersSpec defines the desired state of IngressClassParameters.
-
 type IngressClassParametersSpec struct {
 	// Offload load-balancing to kube-proxy or sidecar.
 	// +kubebuilder:default:=false

--- a/api/configuration/v1alpha1/kong_ca_certificate.go
+++ b/api/configuration/v1alpha1/kong_ca_certificate.go
@@ -1,8 +1,9 @@
 package v1alpha1
 
 import (
-	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
 
 // KongCACertificate is the schema for CACertificate API which defines a Kong CA Certificate.
@@ -43,6 +44,7 @@ type KongCACertificateAPISpec struct {
 	Tags []string `json:"tags,omitempty"`
 }
 
+// KongCACertificateStatus defines the observed state of KongCACertificate.
 type KongCACertificateStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional

--- a/api/configuration/v1alpha1/kong_certificate.go
+++ b/api/configuration/v1alpha1/kong_certificate.go
@@ -1,8 +1,9 @@
 package v1alpha1
 
 import (
-	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
 
 // KongCertificate is the schema for Certificate API which defines a Kong Certificate.
@@ -56,6 +57,7 @@ type KongCertificateAPISpec struct {
 	Tags []string `json:"tags,omitempty"`
 }
 
+// KongCertificateStatus defines the observed state of KongCertificate.
 type KongCertificateStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional

--- a/api/configuration/v1alpha1/kong_custom_entity_types.go
+++ b/api/configuration/v1alpha1/kong_custom_entity_types.go
@@ -6,9 +6,11 @@ import (
 )
 
 const (
+	// KongCustomEntityKind is the kind name for the KongCustomEntity resource.
 	KongCustomEntityKind = "KongCustomEntity"
 )
 
+// KongEntityScope defines the scope of the Kong entity.
 type KongEntityScope string
 
 // +genclient
@@ -34,6 +36,7 @@ type KongCustomEntity struct {
 	Status KongCustomEntityStatus `json:"status,omitempty"`
 }
 
+// KongCustomEntitySpec defines the specification of the KongCustomEntity.
 type KongCustomEntitySpec struct {
 	// EntityType is the type of the Kong entity. The type is used in generating declarative configuration.
 	EntityType string `json:"type"`
@@ -57,6 +60,7 @@ type ObjectReference struct {
 	Name      string  `json:"name"`
 }
 
+// KongCustomEntityStatus defines the status of the KongCustomEntity.
 type KongCustomEntityStatus struct {
 	// Conditions describe the current conditions of the KongCustomEntityStatus.
 	//

--- a/api/configuration/v1alpha1/kong_license_types.go
+++ b/api/configuration/v1alpha1/kong_license_types.go
@@ -78,6 +78,7 @@ type Namespace string
 // +kubebuilder:validation:MaxLength=253
 type ObjectName string
 
+// ControllerReference is a reference to a controller that reconciles the KongLicense.
 type ControllerReference struct {
 	// Group is the group of referent.
 	// It should be empty if the referent is in "core" group (like pod).
@@ -92,6 +93,7 @@ type ControllerReference struct {
 	Name ObjectName `json:"name"`
 }
 
+// KongLicensePhase is a string that represents the phase of the KongLicense.
 type KongLicensePhase string
 
 // +kubebuilder:object:root=true

--- a/api/configuration/v1alpha1/kong_target_types.go
+++ b/api/configuration/v1alpha1/kong_target_types.go
@@ -41,6 +41,7 @@ type KongTarget struct {
 	Status KongTargetStatus `json:"status,omitempty"`
 }
 
+// KongTargetSpec defines the desired state of KongTarget.
 type KongTargetSpec struct {
 	// UpstreamRef is a reference to a KongUpstream this KongTarget is attached to.
 	UpstreamRef TargetRef `json:"upstreamRef"`
@@ -48,6 +49,7 @@ type KongTargetSpec struct {
 	KongTargetAPISpec `json:",inline"`
 }
 
+// KongTargetAPISpec are the attributes of the Kong Target itself.
 type KongTargetAPISpec struct {
 	// Target is the target address of the upstream.
 	Target string `json:"target"`
@@ -60,6 +62,7 @@ type KongTargetAPISpec struct {
 	Tags []string `json:"tags,omitempty"`
 }
 
+// KongTargetStatus defines the observed state of KongTarget.
 type KongTargetStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional

--- a/api/configuration/v1alpha1/kong_vault_types.go
+++ b/api/configuration/v1alpha1/kong_vault_types.go
@@ -17,12 +17,14 @@ limitations under the License.
 package v1alpha1
 
 import (
-	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
 
 const (
+	// KongVaultKind is the kind name of KongVault resource.
 	KongVaultKind = "KongVault"
 )
 

--- a/api/configuration/v1alpha1/kongdataplanecertificate_types.go
+++ b/api/configuration/v1alpha1/kongdataplanecertificate_types.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1alpha1
 
 import (
-	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
 
 // KongDataplaneCertificate is the schema for KongDataplaneCertificate API which defines a KongDataplaneCertificate entity.

--- a/api/configuration/v1alpha1/kongkey_types.go
+++ b/api/configuration/v1alpha1/kongkey_types.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1alpha1
 
 import (
-	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
 
 // KongKey is the schema for KongKey API which defines a KongKey entity.

--- a/api/configuration/v1alpha1/kongkeyset_types.go
+++ b/api/configuration/v1alpha1/kongkeyset_types.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1alpha1
 
 import (
-	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
 
 // KongKeySet is the schema for KongKeySet API which defines a KongKeySet entity.

--- a/api/configuration/v1alpha1/kongroute_types.go
+++ b/api/configuration/v1alpha1/kongroute_types.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1alpha1
 
 import (
-	sdkkonnectgocomp "github.com/Kong/sdk-konnect-go/models/components"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
@@ -73,25 +74,25 @@ type KongRouteSpec struct {
 // to make the code generation required for Kubernetes CRDs work.
 type KongRouteAPISpec struct {
 	// A list of IP destinations of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
-	Destinations []sdkkonnectgocomp.Destinations `json:"destinations,omitempty"`
+	Destinations []sdkkonnectcomp.Destinations `json:"destinations,omitempty"`
 	// One or more lists of values indexed by header name that will cause this Route to match if present in the request. The `Host` header cannot be used with this attribute: hosts should be specified using the `hosts` attribute. When `headers` contains only one value and that value starts with the special prefix `~*`, the value is interpreted as a regular expression.
 	Headers map[string]string `json:"headers,omitempty"`
 	// A list of domain names that match this Route. Note that the hosts value is case sensitive.
 	Hosts []string `json:"hosts,omitempty"`
 	// The status code Kong responds with when all properties of a Route match except the protocol i.e. if the protocol of the request is `HTTP` instead of `HTTPS`. `Location` header is injected by Kong if the field is set to 301, 302, 307 or 308. Note: This config applies only if the Route is configured to only accept the `https` protocol.
-	HTTPSRedirectStatusCode *sdkkonnectgocomp.HTTPSRedirectStatusCode `json:"https_redirect_status_code,omitempty"`
+	HTTPSRedirectStatusCode *sdkkonnectcomp.HTTPSRedirectStatusCode `json:"https_redirect_status_code,omitempty"`
 	// A list of HTTP methods that match this Route.
 	Methods []string `json:"methods,omitempty"`
 	// The name of the Route. Route names must be unique, and they are case sensitive. For example, there can be two different Routes named "test" and "Test".
 	Name *string `json:"name,omitempty"`
 	// Controls how the Service path, Route path and requested path are combined when sending a request to the upstream. See above for a detailed description of each behavior.
-	PathHandling *sdkkonnectgocomp.PathHandling `json:"path_handling,omitempty"`
+	PathHandling *sdkkonnectcomp.PathHandling `json:"path_handling,omitempty"`
 	// A list of paths that match this Route.
 	Paths []string `json:"paths,omitempty"`
 	// When matching a Route via one of the `hosts` domain names, use the request `Host` header in the upstream request headers. If set to `false`, the upstream `Host` header will be that of the Service's `host`.
 	PreserveHost *bool `json:"preserve_host,omitempty"`
 	// An array of the protocols this Route should allow. See the [Route Object](#route-object) section for a list of accepted protocols. When set to only `"https"`, HTTP requests are answered with an upgrade error. When set to only `"http"`, HTTPS requests are answered with an error.
-	Protocols []sdkkonnectgocomp.RouteProtocols `json:"protocols,omitempty"`
+	Protocols []sdkkonnectcomp.RouteProtocols `json:"protocols,omitempty"`
 	// A number used to choose which route resolves a given request when several routes match it using regexes simultaneously. When two routes match the path and have the same `regex_priority`, the older one (lowest `created_at`) is used. Note that the priority for non-regex routes is different (longer non-regex routes are matched before shorter ones).
 	RegexPriority *int64 `json:"regex_priority,omitempty"`
 	// Whether to enable request body buffering or not. With HTTP 1.1, it may make sense to turn this off on services that receive data with chunked transfer encoding.
@@ -101,7 +102,7 @@ type KongRouteAPISpec struct {
 	// A list of SNIs that match this Route when using stream routing.
 	Snis []string `json:"snis,omitempty"`
 	// A list of IP sources of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
-	Sources []sdkkonnectgocomp.Sources `json:"sources,omitempty"`
+	Sources []sdkkonnectcomp.Sources `json:"sources,omitempty"`
 	// When matching a Route via one of the `paths`, strip the matching prefix from the upstream request URL.
 	StripPath *bool `json:"strip_path,omitempty"`
 	// An optional set of strings associated with the Route for grouping and filtering.

--- a/api/configuration/v1alpha1/kongservice_types.go
+++ b/api/configuration/v1alpha1/kongservice_types.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1alpha1
 
 import (
-	sdkkonnectgocomp "github.com/Kong/sdk-konnect-go/models/components"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
@@ -61,14 +62,14 @@ type KongServiceAPISpec struct {
 	// TODO(pmalek): client certificate implement ref
 	// TODO(pmalek): ca_certificates implement ref
 
-	// TODO(pmalek): field below are basically copy pasted from sdkkonnectgocomp.CreateService
+	// TODO(pmalek): field below are basically copy pasted from sdkkonnectcomp.CreateService
 	// The reason for this is that Service creation request contains a Konnect ID
 	// reference to a client certificate. This is not what we want to expose to the user.
 	// Instead we want to expose a namespaced reference to a client certificate.
 	// Even if the cross namespace reference is not planned, the structured reference
 	// type is preferred because it allows for easier extension in the future.
 	//
-	// sdkkonnectgocomp.CreateService `json:",inline"`
+	// sdkkonnectcomp.CreateService `json:",inline"`
 
 	// Helper field to set `protocol`, `host`, `port` and `path` using a URL. This field is write-only and is not returned in responses.
 	URL *string `json:"url,omitempty"`
@@ -86,7 +87,7 @@ type KongServiceAPISpec struct {
 	// The upstream server port.
 	Port *int64 `json:"port,omitempty"`
 	// The protocol used to communicate with the upstream.
-	Protocol *sdkkonnectgocomp.Protocol `json:"protocol,omitempty"`
+	Protocol *sdkkonnectcomp.Protocol `json:"protocol,omitempty"`
 	// The timeout in milliseconds between two successive read operations for transmitting a request to the upstream server.
 	ReadTimeout *int64 `json:"read_timeout,omitempty"`
 	// The number of retries to execute upon failure to proxy.

--- a/api/configuration/v1alpha1/kongsni_types.go
+++ b/api/configuration/v1alpha1/kongsni_types.go
@@ -60,7 +60,7 @@ type KongSNISpec struct {
 	KongSNIAPISpec `json:",inline"`
 }
 
-// KongKeyStatus defines the status for a KongSNI.
+// KongSNIStatus defines the status for a KongSNI.
 type KongSNIStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional

--- a/api/configuration/v1alpha1/kongupstream_types.go
+++ b/api/configuration/v1alpha1/kongupstream_types.go
@@ -17,8 +17,9 @@ limitations under the License.
 package v1alpha1
 
 import (
-	sdkkonnectgocomp "github.com/Kong/sdk-konnect-go/models/components"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
@@ -68,11 +69,11 @@ type KongUpstreamSpec struct {
 // +kubebuilder:validation:XValidation:rule="!has(self.hash_on) || (self.hash_on != 'uri_capture' || has(self.hash_on_uri_capture))", message="hash_on_uri_capture is required when `hash_on` is set to `uri_capture`."
 type KongUpstreamAPISpec struct {
 	// Which load balancing algorithm to use.
-	Algorithm *sdkkonnectgocomp.UpstreamAlgorithm `default:"round-robin" json:"algorithm,omitempty"`
+	Algorithm *sdkkonnectcomp.UpstreamAlgorithm `default:"round-robin" json:"algorithm,omitempty"`
 	// If set, the certificate to be used as client certificate while TLS handshaking to the upstream server.
-	ClientCertificate *sdkkonnectgocomp.UpstreamClientCertificate `json:"client_certificate,omitempty"`
+	ClientCertificate *sdkkonnectcomp.UpstreamClientCertificate `json:"client_certificate,omitempty"`
 	// What to use as hashing input if the primary `hash_on` does not return a hash (eg. header is missing, or no Consumer identified). Not available if `hash_on` is set to `cookie`.
-	HashFallback *sdkkonnectgocomp.HashFallback `default:"none" json:"hash_fallback,omitempty"`
+	HashFallback *sdkkonnectcomp.HashFallback `default:"none" json:"hash_fallback,omitempty"`
 	// The header name to take the value from as hash input. Only required when `hash_fallback` is set to `header`.
 	HashFallbackHeader *string `json:"hash_fallback_header,omitempty"`
 	// The name of the query string argument to take the value from as hash input. Only required when `hash_fallback` is set to `query_arg`.
@@ -80,7 +81,7 @@ type KongUpstreamAPISpec struct {
 	// The name of the route URI capture to take the value from as hash input. Only required when `hash_fallback` is set to `uri_capture`.
 	HashFallbackURICapture *string `json:"hash_fallback_uri_capture,omitempty"`
 	// What to use as hashing input. Using `none` results in a weighted-round-robin scheme with no hashing.
-	HashOn *sdkkonnectgocomp.HashOn `default:"none" json:"hash_on,omitempty"`
+	HashOn *sdkkonnectcomp.HashOn `default:"none" json:"hash_on,omitempty"`
 	// The cookie name to take the value from as hash input. Only required when `hash_on` or `hash_fallback` is set to `cookie`. If the specified cookie is not in the request, Kong will generate a value and set the cookie in the response.
 	HashOnCookie *string `json:"hash_on_cookie,omitempty"`
 	// The cookie path to set in the response headers. Only required when `hash_on` or `hash_fallback` is set to `cookie`.
@@ -90,8 +91,8 @@ type KongUpstreamAPISpec struct {
 	// The name of the query string argument to take the value from as hash input. Only required when `hash_on` is set to `query_arg`.
 	HashOnQueryArg *string `json:"hash_on_query_arg,omitempty"`
 	// The name of the route URI capture to take the value from as hash input. Only required when `hash_on` is set to `uri_capture`.
-	HashOnURICapture *string                        `json:"hash_on_uri_capture,omitempty"`
-	Healthchecks     *sdkkonnectgocomp.Healthchecks `json:"healthchecks,omitempty"`
+	HashOnURICapture *string                      `json:"hash_on_uri_capture,omitempty"`
+	Healthchecks     *sdkkonnectcomp.Healthchecks `json:"healthchecks,omitempty"`
 	// The hostname to be used as `Host` header when proxying requests through Kong.
 	HostHeader *string `json:"host_header,omitempty"`
 	// This is a hostname, which must be equal to the `host` of a Service.

--- a/api/configuration/v1beta1/kongconsumergroup_types.go
+++ b/api/configuration/v1beta1/kongconsumergroup_types.go
@@ -47,6 +47,7 @@ type KongConsumerGroup struct {
 	Status KongConsumerGroupStatus `json:"status,omitempty"`
 }
 
+// KongConsumerGroupSpec defines the desired state of KongConsumerGroup.
 type KongConsumerGroupSpec struct {
 	// Name is the name of the ConsumerGroup in Kong.
 	Name string `json:"name,omitempty"`

--- a/api/konnect/v1alpha1/konnect_apiauthconfiguration_types.go
+++ b/api/konnect/v1alpha1/konnect_apiauthconfiguration_types.go
@@ -34,10 +34,14 @@ type KonnectAPIAuthConfiguration struct {
 	Status KonnectAPIAuthConfigurationStatus `json:"status,omitempty"`
 }
 
+// KonnectAPIAuthType is the type of authentication used to authenticate with the Konnect API.
 type KonnectAPIAuthType string
 
 const (
-	KonnectAPIAuthTypeToken     KonnectAPIAuthType = "token"
+	// KonnectAPIAuthTypeToken is the token authentication type.
+	KonnectAPIAuthTypeToken KonnectAPIAuthType = "token"
+
+	// KonnectAPIAuthTypeSecretRef is the secret reference authentication type.
 	KonnectAPIAuthTypeSecretRef KonnectAPIAuthType = "secretRef"
 )
 
@@ -62,6 +66,7 @@ type KonnectAPIAuthConfigurationSpec struct {
 	ServerURL string `json:"serverURL"`
 }
 
+// KonnectAPIAuthConfigurationStatus is the status of the KonnectAPIAuthConfiguration resource.
 type KonnectAPIAuthConfigurationStatus struct {
 	// OrganizationID is the unique identifier of the organization in Konnect.
 	OrganizationID string `json:"organizationID,omitempty"`
@@ -78,6 +83,7 @@ type KonnectAPIAuthConfigurationStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
+// KonnectAPIAuthConfigurationRef is a reference to a KonnectAPIAuthConfiguration resource.
 type KonnectAPIAuthConfigurationRef struct {
 	// Name is the name of the KonnectAPIAuthConfiguration resource.
 	// +kubebuilder:validation:Required
@@ -87,6 +93,7 @@ type KonnectAPIAuthConfigurationRef struct {
 	// Namespace string `json:"namespace,omitempty"`
 }
 
+// KonnectAPIAuthConfigurationList contains a list of KonnectAPIAuthConfiguration resources.
 // +kubebuilder:object:root=true
 type KonnectAPIAuthConfigurationList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/api/konnect/v1alpha1/konnect_configuration.go
+++ b/api/konnect/v1alpha1/konnect_configuration.go
@@ -1,5 +1,6 @@
 package v1alpha1
 
+// KonnectConfiguration is the Schema for the KonnectConfiguration API.
 // +kubebuilder:object:generate=false
 type KonnectConfiguration struct {
 	// APIAuthConfigurationRef is the reference to the API Auth Configuration

--- a/api/konnect/v1alpha1/konnect_entity_status.go
+++ b/api/konnect/v1alpha1/konnect_entity_status.go
@@ -1,5 +1,6 @@
 package v1alpha1
 
+// KonnectEntityStatus represents the status of a Konnect entity.
 type KonnectEntityStatus struct {
 	// ID is the unique identifier of the Konnect entity as assigned by Konnect API.
 	// If it's unset (empty string), it means the Konnect entity hasn't been created yet.
@@ -51,6 +52,7 @@ func (in *KonnectEntityStatus) SetServerURL(s string) {
 	in.ServerURL = s
 }
 
+// KonnectEntityStatusWithControlPlaneRef represents the status of a Konnect entity with a reference to a ControlPlane.
 type KonnectEntityStatusWithControlPlaneRef struct {
 	KonnectEntityStatus `json:",inline"`
 
@@ -68,6 +70,7 @@ func (in *KonnectEntityStatusWithControlPlaneRef) GetControlPlaneID() string {
 	return in.ControlPlaneID
 }
 
+// KonnectEntityStatusWithControlPlaneAndConsumerRefs represents the status of a Konnect entity with references to a ControlPlane and a Consumer.
 type KonnectEntityStatusWithControlPlaneAndConsumerRefs struct {
 	KonnectEntityStatus `json:",inline"`
 
@@ -98,6 +101,7 @@ func (in *KonnectEntityStatusWithControlPlaneAndConsumerRefs) GetConsumerID() st
 	return in.ConsumerID
 }
 
+// KonnectEntityStatusWithControlPlaneAndServiceRefs represents the status of a Konnect entity with references to a ControlPlane and a Service.
 type KonnectEntityStatusWithControlPlaneAndServiceRefs struct {
 	KonnectEntityStatus `json:",inline"`
 
@@ -108,16 +112,17 @@ type KonnectEntityStatusWithControlPlaneAndServiceRefs struct {
 	ServiceID string `json:"serviceID,omitempty"`
 }
 
-// SetServerURL sets the server URL of the KonnectEntityStatus struct.
+// SetControlPlaneID sets the server URL of the KonnectEntityStatus struct.
 func (in *KonnectEntityStatusWithControlPlaneAndServiceRefs) SetControlPlaneID(id string) {
 	in.ControlPlaneID = id
 }
 
-// GetServerURL sets the server URL of the KonnectEntityStatus struct.
+// GetControlPlaneID sets the server URL of the KonnectEntityStatus struct.
 func (in *KonnectEntityStatusWithControlPlaneAndServiceRefs) GetControlPlaneID() string {
 	return in.ControlPlaneID
 }
 
+// KonnectEntityStatusWithControlPlaneAndUpstreamRefs represents the status of a Konnect entity with references to a ControlPlane and an Upstream.
 type KonnectEntityStatusWithControlPlaneAndUpstreamRefs struct {
 	KonnectEntityStatus `json:",inline"`
 
@@ -128,6 +133,7 @@ type KonnectEntityStatusWithControlPlaneAndUpstreamRefs struct {
 	UpstreamID string `json:"upstreamID,omitempty"`
 }
 
+// KonnectEntityStatusWithControlPlaneAndKeySetRef represents the status of a Konnect entity with references to a ControlPlane and a KeySet.
 type KonnectEntityStatusWithControlPlaneAndKeySetRef struct {
 	KonnectEntityStatus `json:",inline"`
 
@@ -158,6 +164,7 @@ func (in *KonnectEntityStatusWithControlPlaneAndKeySetRef) GetKeySetID() string 
 	return in.KeySetID
 }
 
+// KonnectEntityStatusWithControlPlaneAndCertificateRefs represents the status of a Konnect entity with references to a ControlPlane and a Certificate.
 type KonnectEntityStatusWithControlPlaneAndCertificateRefs struct {
 	KonnectEntityStatus `json:",inline"`
 

--- a/api/konnect/v1alpha1/konnect_gateway_controlplane_types.go
+++ b/api/konnect/v1alpha1/konnect_gateway_controlplane_types.go
@@ -1,8 +1,9 @@
 package v1alpha1
 
 import (
-	sdkkonnectgocomp "github.com/Kong/sdk-konnect-go/models/components"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 )
 
 func init() {
@@ -34,7 +35,7 @@ type KonnectGatewayControlPlane struct {
 
 // KonnectGatewayControlPlaneSpec defines the desired state of KonnectGatewayControlPlane.
 type KonnectGatewayControlPlaneSpec struct {
-	sdkkonnectgocomp.CreateControlPlaneRequest `json:",inline"`
+	sdkkonnectcomp.CreateControlPlaneRequest `json:",inline"`
 
 	KonnectConfiguration KonnectConfiguration `json:"konnect,omitempty"`
 }
@@ -71,6 +72,7 @@ func (c *KonnectGatewayControlPlane) GetKonnectAPIAuthConfigurationRef() Konnect
 	return c.Spec.KonnectConfiguration.APIAuthConfigurationRef
 }
 
+// KonnectGatewayControlPlaneList contains a list of KonnectGatewayControlPlane.
 // +kubebuilder:object:root=true
 type KonnectGatewayControlPlaneList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/config/crd/bases/configuration.konghq.com_kongcacertificates.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongcacertificates.yaml
@@ -110,6 +110,7 @@ spec:
                 reason: Pending
                 status: Unknown
                 type: Programmed
+            description: KongCACertificateStatus defines the observed state of KongCACertificate.
             properties:
               conditions:
                 description: Conditions describe the status of the Konnect entity.

--- a/config/crd/bases/configuration.konghq.com_kongcertificates.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongcertificates.yaml
@@ -127,6 +127,7 @@ spec:
                 reason: Pending
                 status: Unknown
                 type: Programmed
+            description: KongCertificateStatus defines the observed state of KongCertificate.
             properties:
               conditions:
                 description: Conditions describe the status of the Konnect entity.

--- a/config/crd/bases/configuration.konghq.com_kongconsumergroups.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongconsumergroups.yaml
@@ -49,6 +49,7 @@ spec:
           metadata:
             type: object
           spec:
+            description: KongConsumerGroupSpec defines the desired state of KongConsumerGroup.
             properties:
               controlPlaneRef:
                 description: ControlPlaneRef is a reference to a ControlPlane this

--- a/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
@@ -74,6 +74,7 @@ spec:
           metadata:
             type: object
           spec:
+            description: KongConsumerSpec defines the specification of the KongConsumer.
             properties:
               controlPlaneRef:
                 description: ControlPlaneRef is a reference to a ControlPlane this

--- a/config/crd/bases/configuration.konghq.com_kongcustomentities.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongcustomentities.yaml
@@ -54,6 +54,7 @@ spec:
           metadata:
             type: object
           spec:
+            description: KongCustomEntitySpec defines the specification of the KongCustomEntity.
             properties:
               controllerName:
                 description: ControllerName specifies the controller that should reconcile

--- a/config/crd/bases/configuration.konghq.com_kongsnis.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongsnis.yaml
@@ -81,7 +81,7 @@ spec:
                 reason: Pending
                 status: Unknown
                 type: Programmed
-            description: KongKeyStatus defines the status for a KongSNI.
+            description: KongSNIStatus defines the status for a KongSNI.
             properties:
               conditions:
                 description: Conditions describe the status of the Konnect entity.

--- a/config/crd/bases/configuration.konghq.com_kongtargets.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongtargets.yaml
@@ -43,6 +43,7 @@ spec:
           metadata:
             type: object
           spec:
+            description: KongTargetSpec defines the desired state of KongTarget.
             properties:
               tags:
                 description: Tags is an optional set of strings associated with the
@@ -83,6 +84,7 @@ spec:
                 reason: Pending
                 status: Unknown
                 type: Programmed
+            description: KongTargetStatus defines the observed state of KongTarget.
             properties:
               conditions:
                 description: Conditions describe the status of the Konnect entity.

--- a/config/crd/bases/konnect.konghq.com_konnectapiauthconfigurations.yaml
+++ b/config/crd/bases/konnect.konghq.com_konnectapiauthconfigurations.yaml
@@ -81,6 +81,8 @@ spec:
                   the Konnect API.
                 type: string
               type:
+                description: KonnectAPIAuthType is the type of authentication used
+                  to authenticate with the Konnect API.
                 enum:
                 - token
                 - secretRef

--- a/config/crd/bases/konnect.konghq.com_konnectgatewaycontrolplanes.yaml
+++ b/config/crd/bases/konnect.konghq.com_konnectgatewaycontrolplanes.yaml
@@ -68,6 +68,8 @@ spec:
                 description: The description of the control plane in Konnect.
                 type: string
               konnect:
+                description: KonnectConfiguration is the Schema for the KonnectConfiguration
+                  API.
                 properties:
                   authRef:
                     description: |-

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -148,7 +148,7 @@ _Appears in:_
 #### KongConsumerSpec
 
 
-
+KongConsumerSpec defines the specification of the KongConsumer.
 
 
 
@@ -706,7 +706,7 @@ _Appears in:_
 #### ControllerReference
 
 
-
+ControllerReference is a reference to a controller that reconciles the KongLicense.
 
 
 
@@ -737,7 +737,7 @@ _Appears in:_
 #### IngressClassParametersSpec
 
 
-
+IngressClassParametersSpec defines the desired state of IngressClassParameters.
 
 
 
@@ -1075,7 +1075,7 @@ _Appears in:_
 #### KongCustomEntitySpec
 
 
-
+KongCustomEntitySpec defines the specification of the KongCustomEntity.
 
 
 
@@ -1445,7 +1445,7 @@ _Appears in:_
 #### KongTargetAPISpec
 
 
-
+KongTargetAPISpec are the attributes of the Kong Target itself.
 
 
 
@@ -1462,7 +1462,7 @@ _Appears in:_
 #### KongTargetSpec
 
 
-
+KongTargetSpec defines the desired state of KongTarget.
 
 
 
@@ -1894,7 +1894,7 @@ _Appears in:_
 #### KongConsumerGroupSpec
 
 
-
+KongConsumerGroupSpec defines the desired state of KongConsumerGroup.
 
 
 

--- a/docs/konnect-api-reference.md
+++ b/docs/konnect-api-reference.md
@@ -48,7 +48,7 @@ In this section you will find types that the CRDs rely on.
 #### KonnectAPIAuthConfigurationRef
 
 
-
+KonnectAPIAuthConfigurationRef is a reference to a KonnectAPIAuthConfiguration resource.
 
 
 
@@ -83,7 +83,7 @@ _Appears in:_
 #### KonnectAPIAuthType
 _Underlying type:_ `string`
 
-
+KonnectAPIAuthType is the type of authentication used to authenticate with the Konnect API.
 
 
 
@@ -95,7 +95,7 @@ _Appears in:_
 #### KonnectConfiguration
 
 
-
+KonnectConfiguration is the Schema for the KonnectConfiguration API.
 
 
 
@@ -110,7 +110,7 @@ _Appears in:_
 #### KonnectEntityStatus
 
 
-
+KonnectEntityStatus represents the status of a Konnect entity.
 
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Turns the linter on for the `./api` directory, excluding only generated files. It also skips the default golanci-lint exclusions for `revive` comment rules (see: https://golangci-lint.run/usage/false-positives/#default-exclusions). 

Follow up to https://github.com/Kong/kubernetes-configuration/pull/110#discussion_r1785977244