### PR TITLE
feat(konnect): add KonnectControlPlane group members field

### DIFF
--- a/api/konnect/v1alpha1/konnect_gateway_controlplane_types.go
+++ b/api/konnect/v1alpha1/konnect_gateway_controlplane_types.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
@@ -22,6 +23,7 @@ func init() {
 // +kubebuilder:printcolumn:name="OrgID",description="Konnect Organization ID this resource belongs to.",type=string,JSONPath=`.status.organizationID`
 // +kubebuilder:validation:XValidation:rule="!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef", message="spec.konnect.authRef is immutable when an entity is already Programmed"
 // +kubebuilder:validation:XValidation:rule="!self.status.conditions.exists(c, c.type == 'APIAuthValid' && c.status == 'True') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef", message="spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration"
+// +kubebuilder:validation:XValidation:rule="(has(self.spec.cluster_type) && self.spec.cluster_type != 'CLUSTER_TYPE_CONTROL_PLANE_GROUP') ? !has(self.spec.members) : true", message="spec.members is only applicable for ControlPlanes that are created as groups"
 // +apireference:kgo:include
 type KonnectGatewayControlPlane struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -38,6 +40,10 @@ type KonnectGatewayControlPlane struct {
 // +apireference:kgo:include
 type KonnectGatewayControlPlaneSpec struct {
 	sdkkonnectcomp.CreateControlPlaneRequest `json:",inline"`
+
+	// Members is a list of references to the KonnectGatewayControlPlaneMembers that are part of this control plane group.
+	// Only applicable for ControlPlanes that are created as groups.
+	Members []corev1.LocalObjectReference `json:"members,omitempty"`
 
 	KonnectConfiguration KonnectConfiguration `json:"konnect,omitempty"`
 }

--- a/api/konnect/v1alpha1/zz_generated.deepcopy.go
+++ b/api/konnect/v1alpha1/zz_generated.deepcopy.go
@@ -316,6 +316,11 @@ func (in *KonnectGatewayControlPlaneList) DeepCopyObject() runtime.Object {
 func (in *KonnectGatewayControlPlaneSpec) DeepCopyInto(out *KonnectGatewayControlPlaneSpec) {
 	*out = *in
 	in.CreateControlPlaneRequest.DeepCopyInto(&out.CreateControlPlaneRequest)
+	if in.Members != nil {
+		in, out := &in.Members, &out.Members
+		*out = make([]v1.LocalObjectReference, len(*in))
+		copy(*out, *in)
+	}
 	out.KonnectConfiguration = in.KonnectConfiguration
 }
 

--- a/config/crd/bases/konnect.konghq.com_konnectgatewaycontrolplanes.yaml
+++ b/config/crd/bases/konnect.konghq.com_konnectgatewaycontrolplanes.yaml
@@ -94,6 +94,27 @@ spec:
 
                   Keys must be of length 1-63 characters, and cannot start with "kong", "konnect", "mesh", "kic", or "_".
                 type: object
+              members:
+                description: |-
+                  Members is a list of references to the KonnectGatewayControlPlaneMembers that are part of this control plane group.
+                  Only applicable for ControlPlanes that are created as groups.
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
               name:
                 description: The name of the control plane.
                 type: string
@@ -221,6 +242,10 @@ spec:
             API Auth Configuration
           rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status
             == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
+        - message: spec.members is only applicable for ControlPlanes that are created
+            as groups
+          rule: '(has(self.spec.cluster_type) && self.spec.cluster_type != ''CLUSTER_TYPE_CONTROL_PLANE_GROUP'')
+            ? !has(self.spec.members) : true'
     served: true
     storage: true
     subresources:

--- a/docs/konnect-api-reference.md
+++ b/docs/konnect-api-reference.md
@@ -158,6 +158,7 @@ KonnectGatewayControlPlaneSpec defines the desired state of KonnectGatewayContro
 | `cloud_gateway` _boolean_ | Whether this control-plane can be used for cloud-gateways. |
 | `proxy_urls` _[ProxyURL](#proxyurl) array_ | Array of proxy URLs associated with reaching the data-planes connected to a control-plane. |
 | `labels` _object (keys:string, values:string)_ | Labels store metadata of an entity that can be used for filtering an entity list or for searching across entity types.<br /><br /> Keys must be of length 1-63 characters, and cannot start with "kong", "konnect", "mesh", "kic", or "_". |
+| `members` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core) array_ | Members is a list of references to the KonnectGatewayControlPlaneMembers that are part of this control plane group. Only applicable for ControlPlanes that are created as groups. |
 | `konnect` _[KonnectConfiguration](#konnectconfiguration)_ |  |
 
 

--- a/test/crdsvalidation/konnectgatewaycontrolplane/testcases/common.go
+++ b/test/crdsvalidation/konnectgatewaycontrolplane/testcases/common.go
@@ -28,6 +28,7 @@ var TestCases = []testCasesGroup{}
 func init() {
 	TestCases = append(TestCases,
 		updatesNotAllowedForStatus,
+		membersCanOnlyBeSetForControlPlaneGroups,
 	)
 }
 

--- a/test/crdsvalidation/konnectgatewaycontrolplane/testcases/members-only-allowed-on-groups.go
+++ b/test/crdsvalidation/konnectgatewaycontrolplane/testcases/members-only-allowed-on-groups.go
@@ -13,7 +13,7 @@ var membersCanOnlyBeSetForControlPlaneGroups = testCasesGroup{
 	Name: "members can only be set on groups",
 	TestCases: []testCase{
 		{
-			Name: "members can be set on a control-plane group",
+			Name: "members can be set on control-plane group",
 			KonnectGatewayControlPlane: konnectv1alpha1.KonnectGatewayControlPlane{
 				ObjectMeta: commonObjectMeta,
 				Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
@@ -35,7 +35,7 @@ var membersCanOnlyBeSetForControlPlaneGroups = testCasesGroup{
 			},
 		},
 		{
-			Name: "members cannot be set on a regular control-planes",
+			Name: "members cannot be set on regular control-planes",
 			KonnectGatewayControlPlane: konnectv1alpha1.KonnectGatewayControlPlane{
 				ObjectMeta: commonObjectMeta,
 				Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
@@ -81,7 +81,7 @@ var membersCanOnlyBeSetForControlPlaneGroups = testCasesGroup{
 			ExpectedErrorMessage: lo.ToPtr("spec.members is only applicable for ControlPlanes that are created as groups"),
 		},
 		{
-			Name: "members cannot be set on a hybrid control-planes",
+			Name: "members cannot be set on hybrid control-planes",
 			KonnectGatewayControlPlane: konnectv1alpha1.KonnectGatewayControlPlane{
 				ObjectMeta: commonObjectMeta,
 				Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
@@ -104,7 +104,7 @@ var membersCanOnlyBeSetForControlPlaneGroups = testCasesGroup{
 			ExpectedErrorMessage: lo.ToPtr("spec.members is only applicable for ControlPlanes that are created as groups"),
 		},
 		{
-			Name: "members cannot be set on a hybrid control-planes",
+			Name: "members cannot be set on serverless control-planes",
 			KonnectGatewayControlPlane: konnectv1alpha1.KonnectGatewayControlPlane{
 				ObjectMeta: commonObjectMeta,
 				Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{

--- a/test/crdsvalidation/konnectgatewaycontrolplane/testcases/members-only-allowed-on-groups.go
+++ b/test/crdsvalidation/konnectgatewaycontrolplane/testcases/members-only-allowed-on-groups.go
@@ -1,0 +1,130 @@
+package testcases
+
+import (
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
+)
+
+var membersCanOnlyBeSetForControlPlaneGroups = testCasesGroup{
+	Name: "members can only be set on groups",
+	TestCases: []testCase{
+		{
+			Name: "members can be set on a control-plane group",
+			KonnectGatewayControlPlane: konnectv1alpha1.KonnectGatewayControlPlane{
+				ObjectMeta: commonObjectMeta,
+				Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+					CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
+						Name:        "cpg-1",
+						ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlaneGroup),
+					},
+					Members: []corev1.LocalObjectReference{
+						{
+							Name: "cp-1",
+						},
+					},
+					KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
+						APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
+							Name: "name-1",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "members cannot be set on a regular control-planes",
+			KonnectGatewayControlPlane: konnectv1alpha1.KonnectGatewayControlPlane{
+				ObjectMeta: commonObjectMeta,
+				Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+					CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
+						Name:        "cpg-1",
+						ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
+					},
+					Members: []corev1.LocalObjectReference{
+						{
+							Name: "cp-1",
+						},
+					},
+					KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
+						APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
+							Name: "name-1",
+						},
+					},
+				},
+			},
+			ExpectedErrorMessage: lo.ToPtr("spec.members is only applicable for ControlPlanes that are created as groups"),
+		},
+		{
+			Name: "members cannot be set on a KIC control-planes",
+			KonnectGatewayControlPlane: konnectv1alpha1.KonnectGatewayControlPlane{
+				ObjectMeta: commonObjectMeta,
+				Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+					CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
+						Name:        "cpg-1",
+						ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeK8SIngressController),
+					},
+					Members: []corev1.LocalObjectReference{
+						{
+							Name: "cp-1",
+						},
+					},
+					KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
+						APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
+							Name: "name-1",
+						},
+					},
+				},
+			},
+			ExpectedErrorMessage: lo.ToPtr("spec.members is only applicable for ControlPlanes that are created as groups"),
+		},
+		{
+			Name: "members cannot be set on a hybrid control-planes",
+			KonnectGatewayControlPlane: konnectv1alpha1.KonnectGatewayControlPlane{
+				ObjectMeta: commonObjectMeta,
+				Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+					CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
+						Name:        "cpg-1",
+						ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeHybrid),
+					},
+					Members: []corev1.LocalObjectReference{
+						{
+							Name: "cp-1",
+						},
+					},
+					KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
+						APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
+							Name: "name-1",
+						},
+					},
+				},
+			},
+			ExpectedErrorMessage: lo.ToPtr("spec.members is only applicable for ControlPlanes that are created as groups"),
+		},
+		{
+			Name: "members cannot be set on a hybrid control-planes",
+			KonnectGatewayControlPlane: konnectv1alpha1.KonnectGatewayControlPlane{
+				ObjectMeta: commonObjectMeta,
+				Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+					CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
+						Name:        "cpg-1",
+						ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeServerless),
+					},
+					Members: []corev1.LocalObjectReference{
+						{
+							Name: "cp-1",
+						},
+					},
+					KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
+						APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
+							Name: "name-1",
+						},
+					},
+				},
+			},
+			ExpectedErrorMessage: lo.ToPtr("spec.members is only applicable for ControlPlanes that are created as groups"),
+		},
+	},
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `members` field for `KonnectGatewayControlPlane` CRD to allow setting group members.

Required for https://github.com/Kong/gateway-operator/issues/449