### PR TITLE
chore: add KIC API reference markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,5 +68,8 @@ create a new tag and push it to the repository.
 |-----------------------------|------------|---------------------------------------------------------------------------------------------------------------|
 | `+apireference:kgo:exclude` | Fields     | Any field annotated with this marker will be excluded from the [KGO's generated CRDs reference][kgo-crd-ref]. |
 | `+apireference:kgo:include` | Types      | Any type annotated with this marker will be included in the [KGO's generated CRDs reference][kgo-crd-ref].    |
+| `+apireference:kic:exclude` | Fields     | Any type annotated with this marker will be excluded from the [KIC's generated CRDs reference][kic-crd-ref].  |
+| `+apireference:kic:include` | Types      | Any type annotated with this marker will be included in the [KIC's generated CRDs reference][kic-crd-ref].    |
 
 [kgo-crd-ref]: https://github.com/Kong/gateway-operator/blob/main/docs/api-reference.md
+[kic-crd-ref]: https://github.com/kong/kubernetes-ingress-controller/blob/main/docs/api-reference.md

--- a/api/configuration/v1/conditions.go
+++ b/api/configuration/v1/conditions.go
@@ -3,11 +3,13 @@ package v1
 // ConditionType is a type of condition associated with an object.
 // This type should be used with the object's Status.Conditions field.
 // +apireference:kgo:include
+// +apireference:kic:include
 type ConditionType string
 
 // ConditionReason defines the set of reasons that explain why a particular
 // condition type has been raised.
 // +apireference:kgo:include
+// +apireference:kic:include
 type ConditionReason string
 
 const (

--- a/api/configuration/v1/configsource.go
+++ b/api/configuration/v1/configsource.go
@@ -2,6 +2,7 @@ package v1
 
 // ConfigSource is a wrapper around SecretValueFromSource.
 // +kubebuilder:object:generate=true
+// +apireference:kic:include
 type ConfigSource struct {
 	// Specifies a name and a key of a secret to refer to. The namespace is implicitly set to the one of referring object.
 	SecretValue SecretValueFromSource `json:"secretKeyRef"`
@@ -11,6 +12,7 @@ type ConfigSource struct {
 // It is an equivalent of the following patch:
 // `{"op": "add", "path": {.Path}, "value": {.ComputedValueFrom}}`.
 // +kubebuilder:object:generate=true
+// +apireference:kic:include
 type ConfigPatch struct {
 	// Path is the JSON-Pointer value (RFC6901) that references a location within the target configuration.
 	Path string `json:"path"`
@@ -20,6 +22,7 @@ type ConfigPatch struct {
 
 // NamespacedConfigSource is a wrapper around NamespacedSecretValueFromSource.
 // +kubebuilder:object:generate=true
+// +apireference:kic:include
 type NamespacedConfigSource struct {
 	// Specifies a name, a namespace, and a key of a secret to refer to.
 	SecretValue NamespacedSecretValueFromSource `json:"secretKeyRef"`
@@ -28,6 +31,7 @@ type NamespacedConfigSource struct {
 // NamespacedConfigPatch is a JSON patch to add values from secrets to KongClusterPlugin
 // to the generated configuration of plugin in Kong.
 // +kubebuilder:object:generate=true
+// +apireference:kic:include
 type NamespacedConfigPatch struct {
 	// Path is the JSON path to add the patch.
 	Path string `json:"path"`
@@ -37,6 +41,7 @@ type NamespacedConfigPatch struct {
 
 // SecretValueFromSource represents the source of a secret value.
 // +kubebuilder:object:generate=true
+// +apireference:kic:include
 type SecretValueFromSource struct {
 	// The secret containing the key.
 	Secret string `json:"name"`
@@ -46,6 +51,7 @@ type SecretValueFromSource struct {
 
 // NamespacedSecretValueFromSource represents the source of a secret value specifying the secret namespace.
 // +kubebuilder:object:generate=true
+// +apireference:kic:include
 type NamespacedSecretValueFromSource struct {
 	// The namespace containing the secret.
 	Namespace string `json:"namespace"`

--- a/api/configuration/v1/kongclusterplugin_types.go
+++ b/api/configuration/v1/kongclusterplugin_types.go
@@ -39,6 +39,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="self.plugin == oldSelf.plugin", message="The plugin field is immutable"
 
 // KongClusterPlugin is the Schema for the kongclusterplugins API.
+// +apireference:kic:include
 type KongClusterPlugin struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -110,6 +111,7 @@ type KongClusterPluginList struct {
 }
 
 // KongClusterPluginStatus represents the current status of the KongClusterPlugin resource.
+// +apireference:kic:include
 type KongClusterPluginStatus struct {
 	// Conditions describe the current conditions of the KongClusterPluginStatus.
 	//

--- a/api/configuration/v1/kongconsumer_types.go
+++ b/api/configuration/v1/kongconsumer_types.go
@@ -39,6 +39,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
 // +kubebuilder:validation:XValidation:rule="(!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 // +apireference:kgo:include
+// +apireference:kic:include
 type KongConsumer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -69,6 +70,7 @@ type KongConsumer struct {
 
 // KongConsumerSpec defines the specification of the KongConsumer.
 // +apireference:kgo:include
+// +apireference:kic:include
 type KongConsumerSpec struct {
 	// ControlPlaneRef is a reference to a ControlPlane this Consumer is associated with.
 	// +optional
@@ -78,6 +80,7 @@ type KongConsumerSpec struct {
 // KongConsumerList contains a list of KongConsumer.
 // +kubebuilder:object:root=true
 // +apireference:kgo:include
+// +apireference:kic:include
 type KongConsumerList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -85,9 +88,12 @@ type KongConsumerList struct {
 }
 
 // KongConsumerStatus represents the current status of the KongConsumer resource.
+// +apireference:kgo:include
+// +apireference:kic:include
 type KongConsumerStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
+	// +apireference:kic:exclude
 	Konnect *konnectv1alpha1.KonnectEntityStatusWithControlPlaneRef `json:"konnect,omitempty"`
 
 	// Conditions describe the current conditions of the KongConsumer.

--- a/api/configuration/v1/kongingress_types.go
+++ b/api/configuration/v1/kongingress_types.go
@@ -31,6 +31,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="!has(self.route)", message="'route' field is no longer supported, use Ingress' annotations instead"
 
 // KongIngress is the Schema for the kongingresses API.
+// +apireference:kic:include
 type KongIngress struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -53,6 +54,7 @@ type KongIngress struct {
 // +kubebuilder:object:root=true
 
 // KongIngressList contains a list of KongIngress.
+// +apireference:kic:include
 type KongIngressList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -62,6 +64,7 @@ type KongIngressList struct {
 // KongIngressService contains KongIngress service configuration.
 // It contains the subset of go-kong.kong.Service fields supported by kongstate.Service.overrideByKongIngress.
 // Deprecated: use Service's annotations instead.
+// +apireference:kic:include
 type KongIngressService struct {
 	// The protocol used to communicate with the upstream.
 	// Deprecated: use Service's "konghq.com/protocol" annotation instead.
@@ -99,6 +102,7 @@ type KongIngressService struct {
 // KongIngressRoute contains KongIngress route configuration.
 // It contains the subset of `go-kong.kong.Route` fields supported by `kongstate.Route.overrideByKongIngress`.
 // Deprecated: use Ingress' annotations instead.
+// +apireference:kic:include
 type KongIngressRoute struct {
 	// Methods is a list of HTTP methods that match this Route.
 	// Deprecated: use Ingress' "konghq.com/methods" annotation instead.
@@ -157,6 +161,7 @@ type KongIngressRoute struct {
 
 // KongIngressUpstream contains KongIngress upstream configuration.
 // It contains the subset of `go-kong.kong.Upstream` fields supported by `kongstate.Upstream.overrideByKongIngress`.
+// +apireference:kic:include
 type KongIngressUpstream struct {
 	// HostHeader is The hostname to be used as Host header
 	// when proxying requests through Kong.

--- a/api/configuration/v1/kongplugin_types.go
+++ b/api/configuration/v1/kongplugin_types.go
@@ -39,6 +39,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="!(has(self.configFrom) && has(self.configPatches))", message="Using both configFrom and configPatches fields is not allowed."
 // +kubebuilder:validation:XValidation:rule="self.plugin == oldSelf.plugin", message="The plugin field is immutable"
 // +apireference:kgo:include
+// +apireference:kic:include
 type KongPlugin struct {
 	metav1.TypeMeta `json:",inline"`
 	// Setting a `global` label to `true` will apply the plugin to every request proxied by the Kong.
@@ -108,6 +109,7 @@ type KongPlugin struct {
 // KongPluginList contains a list of KongPlugin.
 // +kubebuilder:object:root=true
 // +apireference:kgo:include
+// +apireference:kic:include
 type KongPluginList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -116,6 +118,7 @@ type KongPluginList struct {
 
 // KongPluginStatus represents the current status of the KongPlugin resource.
 // +apireference:kgo:include
+// +apireference:kic:include
 type KongPluginStatus struct {
 	// Conditions describe the current conditions of the KongPluginStatus.
 	//

--- a/api/configuration/v1/kongprotocol_types.go
+++ b/api/configuration/v1/kongprotocol_types.go
@@ -5,6 +5,7 @@ package v1
 // +kubebuilder:validation:Enum=http;https;grpc;grpcs;tcp;tls;udp
 // +kubebuilder:object:generate=true
 // +apireference:kgo:include
+// +apireference:kic:include
 type KongProtocol string
 
 // KongProtocolsToStrings converts a slice of KongProtocol to plain strings.

--- a/api/configuration/v1alpha1/ingress_class_param_types.go
+++ b/api/configuration/v1alpha1/ingress_class_param_types.go
@@ -28,6 +28,7 @@ const (
 // +kubebuilder:object:root=true
 
 // IngressClassParametersList contains a list of IngressClassParameters.
+// +apireference:kic:include
 type IngressClassParametersList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -42,6 +43,7 @@ type IngressClassParametersList struct {
 // +kubebuilder:resource:path=ingressclassparameterses
 
 // IngressClassParameters is the Schema for the IngressClassParameters API.
+// +apireference:kic:include
 type IngressClassParameters struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -51,6 +53,7 @@ type IngressClassParameters struct {
 }
 
 // IngressClassParametersSpec defines the desired state of IngressClassParameters.
+// +apireference:kic:include
 type IngressClassParametersSpec struct {
 	// Offload load-balancing to kube-proxy or sidecar.
 	// +kubebuilder:default:=false

--- a/api/configuration/v1alpha1/kong_license_types.go
+++ b/api/configuration/v1alpha1/kong_license_types.go
@@ -83,10 +83,12 @@ type Namespace string
 // +kubebuilder:validation:MinLength=1
 // +kubebuilder:validation:MaxLength=253
 // +apireference:kgo:include
+// +apireference:kic:include
 type ObjectName string
 
 // ControllerReference is a reference to a controller that reconciles the KongLicense.
 // +apireference:kgo:include
+// +apireference:kic:include
 type ControllerReference struct {
 	// Group is the group of referent.
 	// It should be empty if the referent is in "core" group (like pod).
@@ -104,6 +106,7 @@ type ControllerReference struct {
 // KongLicenseList contains a list of KongLicense.
 // +kubebuilder:object:root=true
 // +apireference:kgo:include
+// +apireference:kic:include
 type KongLicenseList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kong_vault_types.go
+++ b/api/configuration/v1alpha1/kong_vault_types.go
@@ -48,6 +48,7 @@ const (
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
 // +kubebuilder:validation:XValidation:rule="(!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 // +apireference:kgo:include
+// +apireference:kic:include
 type KongVault struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -57,6 +58,7 @@ type KongVault struct {
 
 // KongVaultSpec defines specification of a custom Kong vault.
 // +apireference:kgo:include
+// +apireference:kic:include
 type KongVaultSpec struct {
 	// Backend is the type of the backend storing the secrets in the vault.
 	// The supported backends of Kong is listed here:
@@ -80,9 +82,11 @@ type KongVaultSpec struct {
 
 // KongVaultStatus represents the current status of the KongVault resource.
 // +apireference:kgo:include
+// +apireference:kic:include
 type KongVaultStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
+	// +apireference:kic:exclude
 	Konnect *konnectv1alpha1.KonnectEntityStatusWithControlPlaneRef `json:"konnect,omitempty"`
 
 	// Conditions describe the current conditions of the KongVaultStatus.
@@ -101,6 +105,7 @@ type KongVaultStatus struct {
 // KongVaultList contains a list of KongVault.
 // +kubebuilder:object:root=true
 // +apireference:kgo:include
+// +apireference:kic:include
 type KongVaultList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1beta1/ingress_rules.go
+++ b/api/configuration/v1beta1/ingress_rules.go
@@ -3,6 +3,7 @@ package v1beta1
 // UDPIngressRule represents a rule to apply against incoming requests
 // wherein no Host matching is available for request routing, only the port
 // is used to match requests.
+// +apireference:kic:include
 type UDPIngressRule struct {
 	// Port indicates the port for the Kong proxy to accept incoming traffic
 	// on, which will then be routed to the service Backend.
@@ -18,6 +19,7 @@ type UDPIngressRule struct {
 
 // IngressRule represents a rule to apply against incoming requests.
 // Matching is performed based on an (optional) SNI and port.
+// +apireference:kic:include
 type IngressRule struct {
 	// Host is the fully qualified domain name of a network host, as defined
 	// by RFC 3986.
@@ -45,6 +47,7 @@ type IngressRule struct {
 }
 
 // IngressBackend describes all endpoints for a given service and port.
+// +apireference:kic:include
 type IngressBackend struct {
 	// Specifies the name of the referenced service.
 	// +kubebuilder:validation:Required

--- a/api/configuration/v1beta1/kongconsumergroup_types.go
+++ b/api/configuration/v1beta1/kongconsumergroup_types.go
@@ -23,6 +23,8 @@ import (
 	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
 )
 
+// KongConsumerGroup is the Schema for the kongconsumergroups API.
+//
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
@@ -34,8 +36,8 @@ import (
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
 // +kubebuilder:validation:XValidation:rule="!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
 // +kubebuilder:validation:XValidation:rule="(!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
-
-// KongConsumerGroup is the Schema for the kongconsumergroups API.
+// +apireference:kgo:include
+// +apireference:kic:include
 type KongConsumerGroup struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -48,6 +50,7 @@ type KongConsumerGroup struct {
 }
 
 // KongConsumerGroupSpec defines the desired state of KongConsumerGroup.
+// +apireference:kic:include
 type KongConsumerGroupSpec struct {
 	// Name is the name of the ConsumerGroup in Kong.
 	Name string `json:"name,omitempty"`
@@ -57,9 +60,9 @@ type KongConsumerGroupSpec struct {
 	ControlPlaneRef *configurationv1alpha1.ControlPlaneRef `json:"controlPlaneRef,omitempty"`
 }
 
-// +kubebuilder:object:root=true
-
 // KongConsumerGroupList contains a list of KongConsumerGroups.
+// +kubebuilder:object:root=true
+// +apireference:kic:include
 type KongConsumerGroupList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -67,9 +70,11 @@ type KongConsumerGroupList struct {
 }
 
 // KongConsumerGroupStatus represents the current status of the KongConsumerGroup resource.
+// +apireference:kic:include
 type KongConsumerGroupStatus struct {
 	// Konnect contains the Konnect entity status.
 	// +optional
+	// +apireference:kic:exclude
 	Konnect *konnectv1alpha1.KonnectEntityStatusWithControlPlaneRef `json:"konnect,omitempty"`
 
 	// Conditions describe the current conditions of the KongConsumerGroup.

--- a/api/configuration/v1beta1/kongupstreampolicy_types.go
+++ b/api/configuration/v1beta1/kongupstreampolicy_types.go
@@ -52,6 +52,7 @@ func init() {
 // +kubebuilder:validation:XValidation:rule="has(self.spec.healthchecks) && has(self.spec.healthchecks.passive) && has(self.spec.healthchecks.passive.healthy) ? !has(self.spec.healthchecks.passive.healthy.interval) : true", message="spec.healthchecks.passive.healthy.interval must not be set."
 // +kubebuilder:validation:XValidation:rule="has(self.spec.healthchecks) && has(self.spec.healthchecks.passive) && has(self.spec.healthchecks.passive.unhealthy) ? !has(self.spec.healthchecks.passive.unhealthy.interval) : true", message="spec.healthchecks.passive.unhealthy.interval must not be set."
 // +kubebuilder:validation:XValidation:rule="has(self.spec.hashOn) && has(self.spec.hashOn.cookie) ? !has(self.spec.hashOnFallback) : true", message="spec.hashOnFallback must not be set when spec.hashOn.cookie is set."
+// +apireference:kic:include
 type KongUpstreamPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -65,6 +66,7 @@ type KongUpstreamPolicy struct {
 
 // KongUpstreamPolicyList contains a list of KongUpstreamPolicy.
 // +kubebuilder:object:root=true
+// +apireference:kic:include
 type KongUpstreamPolicyList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -72,6 +74,7 @@ type KongUpstreamPolicyList struct {
 }
 
 // KongUpstreamPolicySpec contains the specification for KongUpstreamPolicy.
+// +apireference:kic:include
 type KongUpstreamPolicySpec struct {
 	// Algorithm is the load balancing algorithm to use.
 	// Accepted values are: "round-robin", "consistent-hashing", "least-connections", "latency".
@@ -100,10 +103,12 @@ type KongUpstreamPolicySpec struct {
 // HashInput is the input for consistent-hashing load balancing algorithm.
 // Can be one of: "ip", "consumer", "path".
 // +kubebuilder:validation:Enum=ip;consumer;path
+// +apireference:kic:include
 type HashInput string
 
 // KongUpstreamHash defines how to calculate hash for consistent-hashing load balancing algorithm.
 // Only one of the fields must be set.
+// +apireference:kic:include
 type KongUpstreamHash struct {
 	// Input allows using one of the predefined inputs (ip, consumer, path).
 	// For other parametrized inputs, use one of the fields below.
@@ -126,6 +131,7 @@ type KongUpstreamHash struct {
 }
 
 // KongUpstreamHealthcheck represents a health-check config of an Upstream in Kong.
+// +apireference:kic:include
 type KongUpstreamHealthcheck struct {
 	// Active configures active health check probing.
 	Active *KongUpstreamActiveHealthcheck `json:"active,omitempty"`
@@ -139,6 +145,7 @@ type KongUpstreamHealthcheck struct {
 }
 
 // KongUpstreamActiveHealthcheck configures active health check probing.
+// +apireference:kic:include
 type KongUpstreamActiveHealthcheck struct {
 	// Type determines whether to perform active health checks using HTTP or HTTPS, or just attempt a TCP connection.
 	// Accepted values are "http", "https", "tcp", "grpc", "grpcs".
@@ -175,6 +182,7 @@ type KongUpstreamActiveHealthcheck struct {
 
 // KongUpstreamPassiveHealthcheck configures passive checks around
 // passive health checks.
+// +apireference:kic:include
 type KongUpstreamPassiveHealthcheck struct {
 	// Type determines whether to perform passive health checks interpreting HTTP/HTTPS statuses,
 	// or just check for TCP connection success.
@@ -192,9 +200,11 @@ type KongUpstreamPassiveHealthcheck struct {
 // HTTPStatus is an HTTP status code.
 // +kubebuilder:validation:Minimum=100
 // +kubebuilder:validation:Maximum=599
+// +apireference:kic:include
 type HTTPStatus int
 
 // KongUpstreamHealthcheckHealthy configures thresholds and HTTP status codes to mark targets healthy for an upstream.
+// +apireference:kic:include
 type KongUpstreamHealthcheckHealthy struct {
 	// HTTPStatuses is a list of HTTP status codes that Kong considers a success.
 	HTTPStatuses []HTTPStatus `json:"httpStatuses,omitempty"`
@@ -209,6 +219,7 @@ type KongUpstreamHealthcheckHealthy struct {
 }
 
 // KongUpstreamHealthcheckUnhealthy configures thresholds and HTTP status codes to mark targets unhealthy.
+// +apireference:kic:include
 type KongUpstreamHealthcheckUnhealthy struct {
 	// HTTPFailures is the number of failures to consider a target unhealthy.
 	// +kubebuilder:validation:Minimum=0

--- a/api/configuration/v1beta1/tcpingress_types.go
+++ b/api/configuration/v1beta1/tcpingress_types.go
@@ -21,6 +21,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// TCPIngress is the Schema for the tcpingresses API.
+//
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
@@ -29,8 +31,7 @@ import (
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Address",type=string,JSONPath=`.status.loadBalancer.ingress[*].ip`,description="Address of the load balancer"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age"
-
-// TCPIngress is the Schema for the tcpingresses API.
+// +apireference:kic:include
 type TCPIngress struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -40,9 +41,9 @@ type TCPIngress struct {
 	Status TCPIngressStatus `json:"status,omitempty"`
 }
 
-// +kubebuilder:object:root=true
-
 // TCPIngressList contains a list of TCPIngress.
+// +kubebuilder:object:root=true
+// +apireference:kic:include
 type TCPIngressList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -50,6 +51,7 @@ type TCPIngressList struct {
 }
 
 // TCPIngressSpec defines the desired state of TCPIngress.
+// +apireference:kic:include
 type TCPIngressSpec struct {
 	// A list of rules used to configure the Ingress.
 	Rules []IngressRule `json:"rules,omitempty"`
@@ -63,6 +65,7 @@ type TCPIngressSpec struct {
 }
 
 // IngressTLS describes the transport layer security.
+// +apireference:kic:include
 type IngressTLS struct {
 	// Hosts are a list of hosts included in the TLS certificate. The values in
 	// this list must match the name/s used in the tlsSecret. Defaults to the
@@ -74,6 +77,7 @@ type IngressTLS struct {
 }
 
 // TCPIngressStatus defines the observed state of TCPIngress.
+// +apireference:kic:include
 type TCPIngressStatus struct {
 	// LoadBalancer contains the current status of the load-balancer.
 	LoadBalancer corev1.LoadBalancerStatus `json:"loadBalancer,omitempty"`

--- a/api/configuration/v1beta1/udpingress_types.go
+++ b/api/configuration/v1beta1/udpingress_types.go
@@ -25,15 +25,18 @@ func init() {
 	SchemeBuilder.Register(&UDPIngress{}, &UDPIngressList{})
 }
 
-// +kubebuilder:object:root=true
-
 // UDPIngressList contains a list of UDPIngress.
+//
+// +kubebuilder:object:root=true
+// +apireference:kic:include
 type UDPIngressList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []UDPIngress `json:"items"`
 }
 
+// UDPIngress is the Schema for the udpingresses API.
+//
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
@@ -42,8 +45,7 @@ type UDPIngressList struct {
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Address",type=string,JSONPath=`.status.loadBalancer.ingress[*].ip`,description="Address of the load balancer"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age"
-
-// UDPIngress is the Schema for the udpingresses API.
+// +apireference:kic:include
 type UDPIngress struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -54,12 +56,14 @@ type UDPIngress struct {
 }
 
 // UDPIngressSpec defines the desired state of UDPIngress.
+// +apireference:kic:include
 type UDPIngressSpec struct {
 	// A list of rules used to configure the Ingress.
 	Rules []UDPIngressRule `json:"rules,omitempty"`
 }
 
 // UDPIngressStatus defines the observed state of UDPIngress.
+// +apireference:kic:include
 type UDPIngressStatus struct {
 	// LoadBalancer contains the current status of the load-balancer.
 	LoadBalancer corev1.LoadBalancerStatus `json:"loadBalancer,omitempty"`


### PR DESCRIPTION
**What this PR does / why we need it**:

Annotates KIC-supported `configuration` types with the new markers that are going to be used in KIC's `crd-ref-docs` templates.

**Which issue this PR fixes**

Part of https://github.com/Kong/kubernetes-configuration/issues/105.
