### PR TITLE
fix: do not require controlPlaneRef in validation

### DIFF
--- a/api/configuration/v1/kongconsumer_types.go
+++ b/api/configuration/v1/kongconsumer_types.go
@@ -36,7 +36,7 @@ import (
 // +kubebuilder:printcolumn:name="Programmed",type=string,JSONPath=`.status.conditions[?(@.type=="Programmed")].status`
 // +kubebuilder:validation:XValidation:rule="has(self.username) || has(self.custom_id)", message="Need to provide either username or custom_id"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
-// +kubebuilder:validation:XValidation:rule="!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
+// +kubebuilder:validation:XValidation:rule="(!has(self.spec) || !has(self.spec.controlPlaneRef) || !has(self.spec.controlPlaneRef.konnectNamespacedRef)) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
 // +kubebuilder:validation:XValidation:rule="(!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 // +apireference:kgo:include
 // +apireference:kic:include

--- a/api/configuration/v1beta1/kongconsumergroup_types.go
+++ b/api/configuration/v1beta1/kongconsumergroup_types.go
@@ -34,7 +34,7 @@ import (
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age"
 // +kubebuilder:printcolumn:name="Programmed",type=string,JSONPath=`.status.conditions[?(@.type=="Programmed")].status`
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
-// +kubebuilder:validation:XValidation:rule="!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
+// +kubebuilder:validation:XValidation:rule="(!has(self.spec) || !has(self.spec.controlPlaneRef) || !has(self.spec.controlPlaneRef.konnectNamespacedRef)) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
 // +kubebuilder:validation:XValidation:rule="(!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 // +apireference:kgo:include
 // +apireference:kic:include

--- a/config/crd/bases/configuration.konghq.com_kongconsumergroups.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongconsumergroups.yaml
@@ -204,7 +204,8 @@ spec:
         - message: controlPlaneRef is required once set
           rule: '!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)'
         - message: spec.controlPlaneRef cannot specify namespace for namespaced resource
-          rule: '!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'
+          rule: '(!has(self.spec) || !has(self.spec.controlPlaneRef) || !has(self.spec.controlPlaneRef.konnectNamespacedRef))
+            ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'
         - message: spec.controlPlaneRef is immutable when an entity is already Programmed
           rule: '(!has(self.status) || !self.status.conditions.exists(c, c.type ==
             ''Programmed'' && c.status == ''True'')) ? true : oldSelf.spec.controlPlaneRef

--- a/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
@@ -231,7 +231,8 @@ spec:
         - message: controlPlaneRef is required once set
           rule: '!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)'
         - message: spec.controlPlaneRef cannot specify namespace for namespaced resource
-          rule: '!has(self.spec.controlPlaneRef.konnectNamespacedRef) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'
+          rule: '(!has(self.spec) || !has(self.spec.controlPlaneRef) || !has(self.spec.controlPlaneRef.konnectNamespacedRef))
+            ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'
         - message: spec.controlPlaneRef is immutable when an entity is already Programmed
           rule: '(!has(self.status) || !self.status.conditions.exists(c, c.type ==
             ''Programmed'' && c.status == ''True'')) ? true : oldSelf.spec.controlPlaneRef

--- a/test/crdsvalidation/kongconsumer/testcases/controlplaneref.go
+++ b/test/crdsvalidation/kongconsumer/testcases/controlplaneref.go
@@ -11,6 +11,14 @@ var controlPlaneRef = testCasesGroup{
 	Name: "fields of controlPlaneRef",
 	TestCases: []testCase{
 		{
+			// Since KongConsumers managed by KIC do not require spec.controlPlane, KongConsumers without spec.controlPlaneRef should be allowed.
+			Name: "no cpRef is valid",
+			KongConsumer: configurationv1.KongConsumer{
+				ObjectMeta: commonObjectMeta,
+				Username:   "username-1",
+			},
+		},
+		{
 			Name: "cpRef cannot have namespace",
 			KongConsumer: configurationv1.KongConsumer{
 				ObjectMeta: commonObjectMeta,

--- a/test/crdsvalidation/kongconsumergroup/testcases/controlplaneref.go
+++ b/test/crdsvalidation/kongconsumergroup/testcases/controlplaneref.go
@@ -11,6 +11,16 @@ var controlPlaneRef = testCasesGroup{
 	Name: "fields of controlPlaneRef",
 	TestCases: []testCase{
 		{
+			// Since KongConsumerGroups managed by KIC do not require spec.controlPlane, KongConsumerGroups without spec.controlPlaneRef should be allowed.
+			Name: "no CPRef is valid",
+			KongConsumerGroup: configurationv1beta1.KongConsumerGroup{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1beta1.KongConsumerGroupSpec{
+					Name: "test",
+				},
+			},
+		},
+		{
 			Name: "cpRef cannot have namespace",
 			KongConsumerGroup: configurationv1beta1.KongConsumerGroup{
 				ObjectMeta: commonObjectMeta,


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes validations to check namespaces in `controlPlaneRef` to allow empty `controlPlaneRef` and add related tests.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
