### PR TITLE
feat: add `kic` ControlPlaneRef type

### DIFF
--- a/api/configuration/v1alpha1/konnect_controlplaneref_types.go
+++ b/api/configuration/v1alpha1/konnect_controlplaneref_types.go
@@ -8,18 +8,26 @@ const (
 	// It is used to reference a Konnect Control Plane entity inside the cluster
 	// using a namespaced reference.
 	ControlPlaneRefKonnectNamespacedRef = "konnectNamespacedRef"
+	// ControlPlaneRefKIC is the type for KIC ControlPlaneRef.
+	// It is used to reference a KIC as Control Plane.
+	ControlPlaneRefKIC = "kic"
 )
 
 // ControlPlaneRef is the schema for the ControlPlaneRef type.
 // It is used to reference a Control Plane entity.
 // +kubebuilder:validation:XValidation:rule="self.type == 'konnectNamespacedRef' ? has(self.konnectNamespacedRef) : true", message="when type is konnectNamespacedRef, konnectNamespacedRef must be set"
+// +kubebuilder:validation:XValidation:rule="self.type == 'konnectNamespacedRef' ? !has(self.konnectID) : true", message="when type is konnectNamespacedRef, konnectID must not be set"
 // +kubebuilder:validation:XValidation:rule="self.type == 'konnectID' ? has(self.konnectID) : true", message="when type is konnectID, konnectID must be set"
+// +kubebuilder:validation:XValidation:rule="self.type == 'konnectID' ? !has(self.konnectNamespacedRef) : true", message="when type is konnectID, konnectNamespacedRef must be set"
+// +kubebuilder:validation:XValidation:rule="self.type == 'kic' ? !has(self.konnectID) : true", message="when type is kic, konnectID must not be set"
+// +kubebuilder:validation:XValidation:rule="self.type == 'kic' ? !has(self.konnectNamespacedRef) : true", message="when type is kic, konnectNamespacedRef must not be set"
 // +apireference:kgo:include
 type ControlPlaneRef struct {
 	// Type can be one of:
 	// - konnectID
 	// - konnectNamespacedRef
-	// +kubebuilder:validation:Enum=konnectID;konnectNamespacedRef
+	// - kic
+	// +kubebuilder:validation:Enum=konnectID;konnectNamespacedRef;kic
 	Type string `json:"type"`
 
 	// KonnectID is the schema for the KonnectID type.

--- a/api/configuration/v1alpha1/konnect_controlplaneref_types.go
+++ b/api/configuration/v1alpha1/konnect_controlplaneref_types.go
@@ -18,7 +18,7 @@ const (
 // +kubebuilder:validation:XValidation:rule="self.type == 'konnectNamespacedRef' ? has(self.konnectNamespacedRef) : true", message="when type is konnectNamespacedRef, konnectNamespacedRef must be set"
 // +kubebuilder:validation:XValidation:rule="self.type == 'konnectNamespacedRef' ? !has(self.konnectID) : true", message="when type is konnectNamespacedRef, konnectID must not be set"
 // +kubebuilder:validation:XValidation:rule="self.type == 'konnectID' ? has(self.konnectID) : true", message="when type is konnectID, konnectID must be set"
-// +kubebuilder:validation:XValidation:rule="self.type == 'konnectID' ? !has(self.konnectNamespacedRef) : true", message="when type is konnectID, konnectNamespacedRef must be set"
+// +kubebuilder:validation:XValidation:rule="self.type == 'konnectID' ? !has(self.konnectNamespacedRef) : true", message="when type is konnectID, konnectNamespacedRef must not be set"
 // +kubebuilder:validation:XValidation:rule="self.type == 'kic' ? !has(self.konnectID) : true", message="when type is kic, konnectID must not be set"
 // +kubebuilder:validation:XValidation:rule="self.type == 'kic' ? !has(self.konnectNamespacedRef) : true", message="when type is kic, konnectNamespacedRef must not be set"
 // +apireference:kgo:include

--- a/config/crd/bases/configuration.konghq.com_kongcacertificates.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongcacertificates.yaml
@@ -80,9 +80,11 @@ spec:
                       Type can be one of:
                       - konnectID
                       - konnectNamespacedRef
+                      - kic
                     enum:
                     - konnectID
                     - konnectNamespacedRef
+                    - kic
                     type: string
                 required:
                 - type
@@ -92,8 +94,20 @@ spec:
                     must be set
                   rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
                     : true'
+                - message: when type is konnectNamespacedRef, konnectID must not be
+                    set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
+                    : true'
                 - message: when type is konnectID, konnectID must be set
                   rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                - message: when type is konnectID, konnectNamespacedRef must be set
+                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is kic, konnectID must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                - message: when type is kic, konnectNamespacedRef must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
+                    true'
               tags:
                 description: Tags is an optional set of tags applied to the certificate.
                 items:

--- a/config/crd/bases/configuration.konghq.com_kongcacertificates.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongcacertificates.yaml
@@ -100,7 +100,8 @@ spec:
                     : true'
                 - message: when type is konnectID, konnectID must be set
                   rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
-                - message: when type is konnectID, konnectNamespacedRef must be set
+                - message: when type is konnectID, konnectNamespacedRef must not be
+                    set
                   rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
                     : true'
                 - message: when type is kic, konnectID must not be set

--- a/config/crd/bases/configuration.konghq.com_kongcertificates.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongcertificates.yaml
@@ -86,9 +86,11 @@ spec:
                       Type can be one of:
                       - konnectID
                       - konnectNamespacedRef
+                      - kic
                     enum:
                     - konnectID
                     - konnectNamespacedRef
+                    - kic
                     type: string
                 required:
                 - type
@@ -98,8 +100,20 @@ spec:
                     must be set
                   rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
                     : true'
+                - message: when type is konnectNamespacedRef, konnectID must not be
+                    set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
+                    : true'
                 - message: when type is konnectID, konnectID must be set
                   rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                - message: when type is konnectID, konnectNamespacedRef must be set
+                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is kic, konnectID must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                - message: when type is kic, konnectNamespacedRef must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
+                    true'
               key:
                 description: Key is the PEM-encoded private key.
                 type: string

--- a/config/crd/bases/configuration.konghq.com_kongcertificates.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongcertificates.yaml
@@ -106,7 +106,8 @@ spec:
                     : true'
                 - message: when type is konnectID, konnectID must be set
                   rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
-                - message: when type is konnectID, konnectNamespacedRef must be set
+                - message: when type is konnectID, konnectNamespacedRef must not be
+                    set
                   rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
                     : true'
                 - message: when type is kic, konnectID must not be set

--- a/config/crd/bases/configuration.konghq.com_kongconsumergroups.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongconsumergroups.yaml
@@ -82,9 +82,11 @@ spec:
                       Type can be one of:
                       - konnectID
                       - konnectNamespacedRef
+                      - kic
                     enum:
                     - konnectID
                     - konnectNamespacedRef
+                    - kic
                     type: string
                 required:
                 - type
@@ -94,8 +96,20 @@ spec:
                     must be set
                   rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
                     : true'
+                - message: when type is konnectNamespacedRef, konnectID must not be
+                    set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
+                    : true'
                 - message: when type is konnectID, konnectID must be set
                   rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                - message: when type is konnectID, konnectNamespacedRef must be set
+                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is kic, konnectID must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                - message: when type is kic, konnectNamespacedRef must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
+                    true'
               name:
                 description: Name is the name of the ConsumerGroup in Kong.
                 type: string

--- a/config/crd/bases/configuration.konghq.com_kongconsumergroups.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongconsumergroups.yaml
@@ -102,7 +102,8 @@ spec:
                     : true'
                 - message: when type is konnectID, konnectID must be set
                   rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
-                - message: when type is konnectID, konnectNamespacedRef must be set
+                - message: when type is konnectID, konnectNamespacedRef must not be
+                    set
                   rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
                     : true'
                 - message: when type is kic, konnectID must not be set

--- a/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
@@ -107,9 +107,11 @@ spec:
                       Type can be one of:
                       - konnectID
                       - konnectNamespacedRef
+                      - kic
                     enum:
                     - konnectID
                     - konnectNamespacedRef
+                    - kic
                     type: string
                 required:
                 - type
@@ -119,8 +121,20 @@ spec:
                     must be set
                   rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
                     : true'
+                - message: when type is konnectNamespacedRef, konnectID must not be
+                    set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
+                    : true'
                 - message: when type is konnectID, konnectID must be set
                   rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                - message: when type is konnectID, konnectNamespacedRef must be set
+                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is kic, konnectID must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                - message: when type is kic, konnectNamespacedRef must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
+                    true'
             type: object
           status:
             default:

--- a/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
@@ -127,7 +127,8 @@ spec:
                     : true'
                 - message: when type is konnectID, konnectID must be set
                   rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
-                - message: when type is konnectID, konnectNamespacedRef must be set
+                - message: when type is konnectID, konnectNamespacedRef must not be
+                    set
                   rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
                     : true'
                 - message: when type is kic, konnectID must not be set

--- a/config/crd/bases/configuration.konghq.com_kongdataplaneclientcertificates.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongdataplaneclientcertificates.yaml
@@ -82,9 +82,11 @@ spec:
                       Type can be one of:
                       - konnectID
                       - konnectNamespacedRef
+                      - kic
                     enum:
                     - konnectID
                     - konnectNamespacedRef
+                    - kic
                     type: string
                 required:
                 - type
@@ -94,8 +96,20 @@ spec:
                     must be set
                   rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
                     : true'
+                - message: when type is konnectNamespacedRef, konnectID must not be
+                    set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
+                    : true'
                 - message: when type is konnectID, konnectID must be set
                   rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                - message: when type is konnectID, konnectNamespacedRef must be set
+                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is kic, konnectID must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                - message: when type is kic, konnectNamespacedRef must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
+                    true'
             required:
             - cert
             type: object

--- a/config/crd/bases/configuration.konghq.com_kongdataplaneclientcertificates.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongdataplaneclientcertificates.yaml
@@ -102,7 +102,8 @@ spec:
                     : true'
                 - message: when type is konnectID, konnectID must be set
                   rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
-                - message: when type is konnectID, konnectNamespacedRef must be set
+                - message: when type is konnectID, konnectNamespacedRef must not be
+                    set
                   rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
                     : true'
                 - message: when type is kic, konnectID must not be set

--- a/config/crd/bases/configuration.konghq.com_kongkeys.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongkeys.yaml
@@ -96,7 +96,8 @@ spec:
                     : true'
                 - message: when type is konnectID, konnectID must be set
                   rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
-                - message: when type is konnectID, konnectNamespacedRef must be set
+                - message: when type is konnectID, konnectNamespacedRef must not be
+                    set
                   rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
                     : true'
                 - message: when type is kic, konnectID must not be set

--- a/config/crd/bases/configuration.konghq.com_kongkeys.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongkeys.yaml
@@ -76,9 +76,11 @@ spec:
                       Type can be one of:
                       - konnectID
                       - konnectNamespacedRef
+                      - kic
                     enum:
                     - konnectID
                     - konnectNamespacedRef
+                    - kic
                     type: string
                 required:
                 - type
@@ -88,8 +90,20 @@ spec:
                     must be set
                   rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
                     : true'
+                - message: when type is konnectNamespacedRef, konnectID must not be
+                    set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
+                    : true'
                 - message: when type is konnectID, konnectID must be set
                   rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                - message: when type is konnectID, konnectNamespacedRef must be set
+                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is kic, konnectID must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                - message: when type is kic, konnectNamespacedRef must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
+                    true'
               jwk:
                 description: |-
                   JWK is a JSON Web Key represented as a string.

--- a/config/crd/bases/configuration.konghq.com_kongkeysets.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongkeysets.yaml
@@ -96,7 +96,8 @@ spec:
                     : true'
                 - message: when type is konnectID, konnectID must be set
                   rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
-                - message: when type is konnectID, konnectNamespacedRef must be set
+                - message: when type is konnectID, konnectNamespacedRef must not be
+                    set
                   rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
                     : true'
                 - message: when type is kic, konnectID must not be set

--- a/config/crd/bases/configuration.konghq.com_kongkeysets.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongkeysets.yaml
@@ -76,9 +76,11 @@ spec:
                       Type can be one of:
                       - konnectID
                       - konnectNamespacedRef
+                      - kic
                     enum:
                     - konnectID
                     - konnectNamespacedRef
+                    - kic
                     type: string
                 required:
                 - type
@@ -88,8 +90,20 @@ spec:
                     must be set
                   rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
                     : true'
+                - message: when type is konnectNamespacedRef, konnectID must not be
+                    set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
+                    : true'
                 - message: when type is konnectID, konnectID must be set
                   rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                - message: when type is konnectID, konnectNamespacedRef must be set
+                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is kic, konnectID must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                - message: when type is kic, konnectNamespacedRef must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
+                    true'
               name:
                 description: Name is a name of the KeySet.
                 minLength: 1

--- a/config/crd/bases/configuration.konghq.com_kongpluginbindings.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongpluginbindings.yaml
@@ -84,9 +84,11 @@ spec:
                       Type can be one of:
                       - konnectID
                       - konnectNamespacedRef
+                      - kic
                     enum:
                     - konnectID
                     - konnectNamespacedRef
+                    - kic
                     type: string
                 required:
                 - type
@@ -96,8 +98,20 @@ spec:
                     must be set
                   rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
                     : true'
+                - message: when type is konnectNamespacedRef, konnectID must not be
+                    set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
+                    : true'
                 - message: when type is konnectID, konnectID must be set
                   rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                - message: when type is konnectID, konnectNamespacedRef must be set
+                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is kic, konnectID must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                - message: when type is kic, konnectNamespacedRef must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
+                    true'
               pluginRef:
                 description: PluginReference is a reference to the KongPlugin or KongClusterPlugin
                   resource.

--- a/config/crd/bases/configuration.konghq.com_kongpluginbindings.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongpluginbindings.yaml
@@ -104,7 +104,8 @@ spec:
                     : true'
                 - message: when type is konnectID, konnectID must be set
                   rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
-                - message: when type is konnectID, konnectNamespacedRef must be set
+                - message: when type is konnectID, konnectNamespacedRef must not be
+                    set
                   rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
                     : true'
                 - message: when type is kic, konnectID must not be set

--- a/config/crd/bases/configuration.konghq.com_kongroutes.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongroutes.yaml
@@ -77,9 +77,11 @@ spec:
                       Type can be one of:
                       - konnectID
                       - konnectNamespacedRef
+                      - kic
                     enum:
                     - konnectID
                     - konnectNamespacedRef
+                    - kic
                     type: string
                 required:
                 - type
@@ -89,8 +91,20 @@ spec:
                     must be set
                   rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
                     : true'
+                - message: when type is konnectNamespacedRef, konnectID must not be
+                    set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
+                    : true'
                 - message: when type is konnectID, konnectID must be set
                   rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                - message: when type is konnectID, konnectNamespacedRef must be set
+                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is kic, konnectID must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                - message: when type is kic, konnectNamespacedRef must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
+                    true'
               destinations:
                 description: A list of IP destinations of incoming connections that
                   match this Route when using stream routing. Each entry is an object

--- a/config/crd/bases/configuration.konghq.com_kongroutes.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongroutes.yaml
@@ -97,7 +97,8 @@ spec:
                     : true'
                 - message: when type is konnectID, konnectID must be set
                   rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
-                - message: when type is konnectID, konnectNamespacedRef must be set
+                - message: when type is konnectID, konnectNamespacedRef must not be
+                    set
                   rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
                     : true'
                 - message: when type is kic, konnectID must not be set

--- a/config/crd/bases/configuration.konghq.com_kongservices.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongservices.yaml
@@ -89,9 +89,11 @@ spec:
                       Type can be one of:
                       - konnectID
                       - konnectNamespacedRef
+                      - kic
                     enum:
                     - konnectID
                     - konnectNamespacedRef
+                    - kic
                     type: string
                 required:
                 - type
@@ -101,8 +103,20 @@ spec:
                     must be set
                   rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
                     : true'
+                - message: when type is konnectNamespacedRef, konnectID must not be
+                    set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
+                    : true'
                 - message: when type is konnectID, konnectID must be set
                   rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                - message: when type is konnectID, konnectNamespacedRef must be set
+                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is kic, konnectID must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                - message: when type is kic, konnectNamespacedRef must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
+                    true'
               enabled:
                 description: 'Whether the Service is active. If set to `false`, the
                   proxy behavior will be as if any routes attached to it do not exist

--- a/config/crd/bases/configuration.konghq.com_kongservices.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongservices.yaml
@@ -109,7 +109,8 @@ spec:
                     : true'
                 - message: when type is konnectID, konnectID must be set
                   rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
-                - message: when type is konnectID, konnectNamespacedRef must be set
+                - message: when type is konnectID, konnectNamespacedRef must not be
+                    set
                   rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
                     : true'
                 - message: when type is kic, konnectID must not be set

--- a/config/crd/bases/configuration.konghq.com_kongupstreams.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongupstreams.yaml
@@ -86,9 +86,11 @@ spec:
                       Type can be one of:
                       - konnectID
                       - konnectNamespacedRef
+                      - kic
                     enum:
                     - konnectID
                     - konnectNamespacedRef
+                    - kic
                     type: string
                 required:
                 - type
@@ -98,8 +100,20 @@ spec:
                     must be set
                   rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
                     : true'
+                - message: when type is konnectNamespacedRef, konnectID must not be
+                    set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
+                    : true'
                 - message: when type is konnectID, konnectID must be set
                   rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                - message: when type is konnectID, konnectNamespacedRef must be set
+                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is kic, konnectID must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                - message: when type is kic, konnectNamespacedRef must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
+                    true'
               hash_fallback:
                 description: What to use as hashing input if the primary `hash_on`
                   does not return a hash (eg. header is missing, or no Consumer identified).

--- a/config/crd/bases/configuration.konghq.com_kongupstreams.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongupstreams.yaml
@@ -106,7 +106,8 @@ spec:
                     : true'
                 - message: when type is konnectID, konnectID must be set
                   rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
-                - message: when type is konnectID, konnectNamespacedRef must be set
+                - message: when type is konnectID, konnectNamespacedRef must not be
+                    set
                   rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
                     : true'
                 - message: when type is kic, konnectID must not be set

--- a/config/crd/bases/configuration.konghq.com_kongvaults.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongvaults.yaml
@@ -109,9 +109,11 @@ spec:
                       Type can be one of:
                       - konnectID
                       - konnectNamespacedRef
+                      - kic
                     enum:
                     - konnectID
                     - konnectNamespacedRef
+                    - kic
                     type: string
                 required:
                 - type
@@ -121,8 +123,20 @@ spec:
                     must be set
                   rule: 'self.type == ''konnectNamespacedRef'' ? has(self.konnectNamespacedRef)
                     : true'
+                - message: when type is konnectNamespacedRef, konnectID must not be
+                    set
+                  rule: 'self.type == ''konnectNamespacedRef'' ? !has(self.konnectID)
+                    : true'
                 - message: when type is konnectID, konnectID must be set
                   rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
+                - message: when type is konnectID, konnectNamespacedRef must be set
+                  rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
+                    : true'
+                - message: when type is kic, konnectID must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectID) : true'
+                - message: when type is kic, konnectNamespacedRef must not be set
+                  rule: 'self.type == ''kic'' ? !has(self.konnectNamespacedRef) :
+                    true'
               description:
                 description: Description is the additional information about the vault.
                 type: string

--- a/config/crd/bases/configuration.konghq.com_kongvaults.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongvaults.yaml
@@ -129,7 +129,8 @@ spec:
                     : true'
                 - message: when type is konnectID, konnectID must be set
                   rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
-                - message: when type is konnectID, konnectNamespacedRef must be set
+                - message: when type is konnectID, konnectNamespacedRef must not be
+                    set
                   rule: 'self.type == ''konnectID'' ? !has(self.konnectNamespacedRef)
                     : true'
                 - message: when type is kic, konnectID must not be set

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -684,7 +684,7 @@ It is used to reference a Control Plane entity.
 
 | Field | Description |
 | --- | --- |
-| `type` _string_ | Type can be one of: - konnectID - konnectNamespacedRef |
+| `type` _string_ | Type can be one of: - konnectID - konnectNamespacedRef - kic |
 | `konnectID` _string_ | KonnectID is the schema for the KonnectID type. This field is required when the Type is konnectID. |
 | `konnectNamespacedRef` _[KonnectNamespacedRef](#konnectnamespacedref)_ | KonnectNamespacedRef is a reference to a Konnect Control Plane entity inside the cluster. It contains the name of the Konnect Control Plane. This field is required when the Type is konnectNamespacedRef. |
 

--- a/test/crdsvalidation/kongconsumer/testcases/controlplaneref.go
+++ b/test/crdsvalidation/kongconsumer/testcases/controlplaneref.go
@@ -35,5 +35,66 @@ var controlPlaneRef = testCasesGroup{
 			},
 			ExpectedErrorMessage: lo.ToPtr("spec.controlPlaneRef cannot specify namespace for namespaced resource"),
 		},
+		{
+			Name: "providing konnectID when type is konnectNamespacedRef yields an error",
+			KongConsumer: configurationv1.KongConsumer{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1.KongConsumerSpec{
+					ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+						Type:      configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+						KonnectID: lo.ToPtr("123456"),
+					},
+				},
+			},
+			ExpectedErrorMessage: lo.ToPtr("when type is konnectNamespacedRef, konnectNamespacedRef must be set"),
+		},
+
+		{
+			Name: "providing konnectNamespacedRef when type is konnectID yields an error",
+			KongConsumer: configurationv1.KongConsumer{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1.KongConsumerSpec{
+					ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+						Type: configurationv1alpha1.ControlPlaneRefKonnectID,
+						KonnectNamespacedRef: &configurationv1alpha1.KonnectNamespacedRef{
+							Name: "test-konnect-control-plane",
+						},
+					},
+				},
+			},
+			ExpectedErrorMessage: lo.ToPtr("when type is konnectID, konnectID must be set"),
+		},
+		{
+			Name: "providing konnectNamespacedRef and konnectID when type is konnectID yields an error",
+			KongConsumer: configurationv1.KongConsumer{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1.KongConsumerSpec{
+					ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+						Type:      configurationv1alpha1.ControlPlaneRefKonnectID,
+						KonnectID: lo.ToPtr("123456"),
+						KonnectNamespacedRef: &configurationv1alpha1.KonnectNamespacedRef{
+							Name: "test-konnect-control-plane",
+						},
+					},
+				},
+			},
+			ExpectedErrorMessage: lo.ToPtr("when type is konnectID, konnectNamespacedRef must be set"),
+		},
+		{
+			Name: "providing konnectID and konnectNamespacedRef when type is konnectNamespacedRef yields an error",
+			KongConsumer: configurationv1.KongConsumer{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1.KongConsumerSpec{
+					ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+						Type:      configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+						KonnectID: lo.ToPtr("123456"),
+						KonnectNamespacedRef: &configurationv1alpha1.KonnectNamespacedRef{
+							Name: "test-konnect-control-plane",
+						},
+					},
+				},
+			},
+			ExpectedErrorMessage: lo.ToPtr("when type is konnectNamespacedRef, konnectID must not be set"),
+		},
 	},
 }

--- a/test/crdsvalidation/kongconsumer/testcases/controlplaneref.go
+++ b/test/crdsvalidation/kongconsumer/testcases/controlplaneref.go
@@ -78,7 +78,7 @@ var controlPlaneRef = testCasesGroup{
 					},
 				},
 			},
-			ExpectedErrorMessage: lo.ToPtr("when type is konnectID, konnectNamespacedRef must be set"),
+			ExpectedErrorMessage: lo.ToPtr("when type is konnectID, konnectNamespacedRef must not be set"),
 		},
 		{
 			Name: "providing konnectID and konnectNamespacedRef when type is konnectNamespacedRef yields an error",

--- a/test/crdsvalidation/kongconsumergroup/testcases/controlplaneref.go
+++ b/test/crdsvalidation/kongconsumergroup/testcases/controlplaneref.go
@@ -79,7 +79,7 @@ var controlPlaneRef = testCasesGroup{
 					},
 				},
 			},
-			ExpectedErrorMessage: lo.ToPtr("when type is konnectID, konnectNamespacedRef must be set"),
+			ExpectedErrorMessage: lo.ToPtr("when type is konnectID, konnectNamespacedRef must not be set"),
 		},
 		{
 			Name: "providing konnectID and konnectNamespacedRef when type is konnectNamespacedRef yields an error",

--- a/test/crdsvalidation/kongconsumergroup/testcases/controlplaneref.go
+++ b/test/crdsvalidation/kongconsumergroup/testcases/controlplaneref.go
@@ -36,5 +36,66 @@ var controlPlaneRef = testCasesGroup{
 			},
 			ExpectedErrorMessage: lo.ToPtr("spec.controlPlaneRef cannot specify namespace for namespaced resource"),
 		},
+		{
+			Name: "providing konnectID when type is konnectNamespacedRef yields an error",
+			KongConsumerGroup: configurationv1beta1.KongConsumerGroup{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1beta1.KongConsumerGroupSpec{
+					ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+						Type:      configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+						KonnectID: lo.ToPtr("123456"),
+					},
+				},
+			},
+			ExpectedErrorMessage: lo.ToPtr("when type is konnectNamespacedRef, konnectNamespacedRef must be set"),
+		},
+
+		{
+			Name: "providing konnectNamespacedRef when type is konnectID yields an error",
+			KongConsumerGroup: configurationv1beta1.KongConsumerGroup{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1beta1.KongConsumerGroupSpec{
+					ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+						Type: configurationv1alpha1.ControlPlaneRefKonnectID,
+						KonnectNamespacedRef: &configurationv1alpha1.KonnectNamespacedRef{
+							Name: "test-konnect-control-plane",
+						},
+					},
+				},
+			},
+			ExpectedErrorMessage: lo.ToPtr("when type is konnectID, konnectID must be set"),
+		},
+		{
+			Name: "providing konnectNamespacedRef and konnectID when type is konnectID yields an error",
+			KongConsumerGroup: configurationv1beta1.KongConsumerGroup{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1beta1.KongConsumerGroupSpec{
+					ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+						Type:      configurationv1alpha1.ControlPlaneRefKonnectID,
+						KonnectID: lo.ToPtr("123456"),
+						KonnectNamespacedRef: &configurationv1alpha1.KonnectNamespacedRef{
+							Name: "test-konnect-control-plane",
+						},
+					},
+				},
+			},
+			ExpectedErrorMessage: lo.ToPtr("when type is konnectID, konnectNamespacedRef must be set"),
+		},
+		{
+			Name: "providing konnectID and konnectNamespacedRef when type is konnectNamespacedRef yields an error",
+			KongConsumerGroup: configurationv1beta1.KongConsumerGroup{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1beta1.KongConsumerGroupSpec{
+					ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+						Type:      configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+						KonnectID: lo.ToPtr("123456"),
+						KonnectNamespacedRef: &configurationv1alpha1.KonnectNamespacedRef{
+							Name: "test-konnect-control-plane",
+						},
+					},
+				},
+			},
+			ExpectedErrorMessage: lo.ToPtr("when type is konnectNamespacedRef, konnectID must not be set"),
+		},
 	},
 }

--- a/test/crdsvalidation/kongroute/testcases/controlplaneref.go
+++ b/test/crdsvalidation/kongroute/testcases/controlplaneref.go
@@ -91,6 +91,67 @@ var cpRef = testCasesGroup{
 			ExpectedErrorMessage: lo.ToPtr("spec.controlPlaneRef cannot specify namespace for namespaced resource"),
 		},
 		{
+			Name: "providing konnectID when type is konnectNamespacedRef yields an error",
+			KongRoute: configurationv1alpha1.KongRoute{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1alpha1.KongRouteSpec{
+					ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+						Type:      configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+						KonnectID: lo.ToPtr("123456"),
+					},
+				},
+			},
+			ExpectedErrorMessage: lo.ToPtr("when type is konnectNamespacedRef, konnectNamespacedRef must be set"),
+		},
+
+		{
+			Name: "providing konnectNamespacedRef when type is konnectID yields an error",
+			KongRoute: configurationv1alpha1.KongRoute{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1alpha1.KongRouteSpec{
+					ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+						Type: configurationv1alpha1.ControlPlaneRefKonnectID,
+						KonnectNamespacedRef: &configurationv1alpha1.KonnectNamespacedRef{
+							Name: "test-konnect-control-plane",
+						},
+					},
+				},
+			},
+			ExpectedErrorMessage: lo.ToPtr("when type is konnectID, konnectID must be set"),
+		},
+		{
+			Name: "providing konnectNamespacedRef and konnectID when type is konnectID yields an error",
+			KongRoute: configurationv1alpha1.KongRoute{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1alpha1.KongRouteSpec{
+					ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+						Type:      configurationv1alpha1.ControlPlaneRefKonnectID,
+						KonnectID: lo.ToPtr("123456"),
+						KonnectNamespacedRef: &configurationv1alpha1.KonnectNamespacedRef{
+							Name: "test-konnect-control-plane",
+						},
+					},
+				},
+			},
+			ExpectedErrorMessage: lo.ToPtr("when type is konnectID, konnectNamespacedRef must be set"),
+		},
+		{
+			Name: "providing konnectID and konnectNamespacedRef when type is konnectNamespacedRef yields an error",
+			KongRoute: configurationv1alpha1.KongRoute{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1alpha1.KongRouteSpec{
+					ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+						Type:      configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+						KonnectID: lo.ToPtr("123456"),
+						KonnectNamespacedRef: &configurationv1alpha1.KonnectNamespacedRef{
+							Name: "test-konnect-control-plane",
+						},
+					},
+				},
+			},
+			ExpectedErrorMessage: lo.ToPtr("when type is konnectNamespacedRef, konnectID must not be set"),
+		},
+		{
 			Name: "konnectNamespacedRef reference name cannot be changed when an entity is Programmed",
 			KongRoute: configurationv1alpha1.KongRoute{
 				ObjectMeta: commonObjectMeta,

--- a/test/crdsvalidation/kongroute/testcases/controlplaneref.go
+++ b/test/crdsvalidation/kongroute/testcases/controlplaneref.go
@@ -133,7 +133,7 @@ var cpRef = testCasesGroup{
 					},
 				},
 			},
-			ExpectedErrorMessage: lo.ToPtr("when type is konnectID, konnectNamespacedRef must be set"),
+			ExpectedErrorMessage: lo.ToPtr("when type is konnectID, konnectNamespacedRef must not be set"),
 		},
 		{
 			Name: "providing konnectID and konnectNamespacedRef when type is konnectNamespacedRef yields an error",

--- a/test/crdsvalidation/kongservice/testcases/controlplaneref.go
+++ b/test/crdsvalidation/kongservice/testcases/controlplaneref.go
@@ -58,6 +58,79 @@ var cpRef = testCasesGroup{
 			ExpectedErrorMessage: lo.ToPtr("when type is konnectID, konnectID must be set"),
 		},
 		{
+			Name: "providing konnectID when type is konnectNamespacedRef yields an error",
+			KongService: configurationv1alpha1.KongService{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1alpha1.KongServiceSpec{
+					ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+						Type:      configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+						KonnectID: lo.ToPtr("123456"),
+					},
+					KongServiceAPISpec: configurationv1alpha1.KongServiceAPISpec{
+						Host: "example.com",
+					},
+				},
+			},
+			ExpectedErrorMessage: lo.ToPtr("when type is konnectNamespacedRef, konnectNamespacedRef must be set"),
+		},
+
+		{
+			Name: "providing konnectNamespacedRef when type is konnectID yields an error",
+			KongService: configurationv1alpha1.KongService{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1alpha1.KongServiceSpec{
+					ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+						Type: configurationv1alpha1.ControlPlaneRefKonnectID,
+						KonnectNamespacedRef: &configurationv1alpha1.KonnectNamespacedRef{
+							Name: "test-konnect-control-plane",
+						},
+					},
+					KongServiceAPISpec: configurationv1alpha1.KongServiceAPISpec{
+						Host: "example.com",
+					},
+				},
+			},
+			ExpectedErrorMessage: lo.ToPtr("when type is konnectID, konnectID must be set"),
+		},
+		{
+			Name: "providing konnectNamespacedRef and konnectID when type is konnectID yields an error",
+			KongService: configurationv1alpha1.KongService{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1alpha1.KongServiceSpec{
+					ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+						Type:      configurationv1alpha1.ControlPlaneRefKonnectID,
+						KonnectID: lo.ToPtr("123456"),
+						KonnectNamespacedRef: &configurationv1alpha1.KonnectNamespacedRef{
+							Name: "test-konnect-control-plane",
+						},
+					},
+					KongServiceAPISpec: configurationv1alpha1.KongServiceAPISpec{
+						Host: "example.com",
+					},
+				},
+			},
+			ExpectedErrorMessage: lo.ToPtr("when type is konnectID, konnectNamespacedRef must be set"),
+		},
+		{
+			Name: "providing konnectID and konnectNamespacedRef when type is konnectNamespacedRef yields an error",
+			KongService: configurationv1alpha1.KongService{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1alpha1.KongServiceSpec{
+					ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+						Type:      configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+						KonnectID: lo.ToPtr("123456"),
+						KonnectNamespacedRef: &configurationv1alpha1.KonnectNamespacedRef{
+							Name: "test-konnect-control-plane",
+						},
+					},
+					KongServiceAPISpec: configurationv1alpha1.KongServiceAPISpec{
+						Host: "example.com",
+					},
+				},
+			},
+			ExpectedErrorMessage: lo.ToPtr("when type is konnectNamespacedRef, konnectID must not be set"),
+		},
+		{
 			Name: "providing namespace in konnectNamespacedRef yields an error",
 			KongService: configurationv1alpha1.KongService{
 				ObjectMeta: commonObjectMeta,

--- a/test/crdsvalidation/kongservice/testcases/controlplaneref.go
+++ b/test/crdsvalidation/kongservice/testcases/controlplaneref.go
@@ -109,7 +109,7 @@ var cpRef = testCasesGroup{
 					},
 				},
 			},
-			ExpectedErrorMessage: lo.ToPtr("when type is konnectID, konnectNamespacedRef must be set"),
+			ExpectedErrorMessage: lo.ToPtr("when type is konnectID, konnectNamespacedRef must not be set"),
 		},
 		{
 			Name: "providing konnectID and konnectNamespacedRef when type is konnectNamespacedRef yields an error",


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds `kic` ControlPlaneRef type and adds some more CEL validation to the `ControlPlaneRef` struct.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
