### PR TITLE
fix: allow updating when programmed=true and cpRef is empty for KongConsumer and KongConsumerGroup

### DIFF
--- a/api/configuration/v1/kongconsumer_types.go
+++ b/api/configuration/v1/kongconsumer_types.go
@@ -35,9 +35,9 @@ import (
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age"
 // +kubebuilder:printcolumn:name="Programmed",type=string,JSONPath=`.status.conditions[?(@.type=="Programmed")].status`
 // +kubebuilder:validation:XValidation:rule="has(self.username) || has(self.custom_id)", message="Need to provide either username or custom_id"
-// +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
+// +kubebuilder:validation:XValidation:rule="(!has(oldSelf.spec) || !has(oldSelf.spec.controlPlaneRef)) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
 // +kubebuilder:validation:XValidation:rule="(!has(self.spec) || !has(self.spec.controlPlaneRef) || !has(self.spec.controlPlaneRef.konnectNamespacedRef)) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
-// +kubebuilder:validation:XValidation:rule="(!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
+// +kubebuilder:validation:XValidation:rule="(!has(self.spec) || !has(self.spec.controlPlaneRef)) ? true : (!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 // +apireference:kgo:include
 // +apireference:kic:include
 type KongConsumer struct {

--- a/api/configuration/v1beta1/kongconsumergroup_types.go
+++ b/api/configuration/v1beta1/kongconsumergroup_types.go
@@ -33,10 +33,9 @@ import (
 // +kubebuilder:resource:shortName=kcg,categories=kong-ingress-controller
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age"
 // +kubebuilder:printcolumn:name="Programmed",type=string,JSONPath=`.status.conditions[?(@.type=="Programmed")].status`
-// +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
+// +kubebuilder:validation:XValidation:rule="(!has(oldSelf.spec) || !has(oldSelf.spec.controlPlaneRef)) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
 // +kubebuilder:validation:XValidation:rule="(!has(self.spec) || !has(self.spec.controlPlaneRef) || !has(self.spec.controlPlaneRef.konnectNamespacedRef)) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
-// +kubebuilder:validation:XValidation:rule="(!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
-// +apireference:kgo:include
+// +kubebuilder:validation:XValidation:rule="(!has(oldSelf.spec) || !has(oldSelf.spec.controlPlaneRef)) ? true : (!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 // +apireference:kic:include
 type KongConsumerGroup struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/config/crd/bases/configuration.konghq.com_kongconsumergroups.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongconsumergroups.yaml
@@ -202,14 +202,14 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: controlPlaneRef is required once set
-          rule: '!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)'
+          rule: (!has(oldSelf.spec) || !has(oldSelf.spec.controlPlaneRef)) || has(self.spec.controlPlaneRef)
         - message: spec.controlPlaneRef cannot specify namespace for namespaced resource
           rule: '(!has(self.spec) || !has(self.spec.controlPlaneRef) || !has(self.spec.controlPlaneRef.konnectNamespacedRef))
             ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'
         - message: spec.controlPlaneRef is immutable when an entity is already Programmed
-          rule: '(!has(self.status) || !self.status.conditions.exists(c, c.type ==
-            ''Programmed'' && c.status == ''True'')) ? true : oldSelf.spec.controlPlaneRef
-            == self.spec.controlPlaneRef'
+          rule: '(!has(oldSelf.spec) || !has(oldSelf.spec.controlPlaneRef)) ? true
+            : (!has(self.status) || !self.status.conditions.exists(c, c.type == ''Programmed''
+            && c.status == ''True'')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef'
     served: true
     storage: true
     subresources:

--- a/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongconsumers.yaml
@@ -229,14 +229,14 @@ spec:
         - message: Need to provide either username or custom_id
           rule: has(self.username) || has(self.custom_id)
         - message: controlPlaneRef is required once set
-          rule: '!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)'
+          rule: (!has(oldSelf.spec) || !has(oldSelf.spec.controlPlaneRef)) || has(self.spec.controlPlaneRef)
         - message: spec.controlPlaneRef cannot specify namespace for namespaced resource
           rule: '(!has(self.spec) || !has(self.spec.controlPlaneRef) || !has(self.spec.controlPlaneRef.konnectNamespacedRef))
             ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'
         - message: spec.controlPlaneRef is immutable when an entity is already Programmed
-          rule: '(!has(self.status) || !self.status.conditions.exists(c, c.type ==
-            ''Programmed'' && c.status == ''True'')) ? true : oldSelf.spec.controlPlaneRef
-            == self.spec.controlPlaneRef'
+          rule: '(!has(self.spec) || !has(self.spec.controlPlaneRef)) ? true : (!has(self.status)
+            || !self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
+            == ''True'')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef'
     served: true
     storage: true
     subresources:

--- a/test/crdsvalidation/kongconsumer/testcases/cpref-update-not-allowed-for-status.go
+++ b/test/crdsvalidation/kongconsumer/testcases/cpref-update-not-allowed-for-status.go
@@ -73,5 +73,25 @@ var updatesNotAllowedForStatus = testCasesGroup{
 				c.Spec.ControlPlaneRef.KonnectNamespacedRef.Name = "new-konnect-control-plane"
 			},
 		},
+		{
+			Name: "updates with Programmed = True when no cpRef is allowed",
+			KongConsumer: configurationv1.KongConsumer{
+				ObjectMeta: commonObjectMeta,
+				Username:   "username-4",
+			},
+			KongConsumerStatus: &configurationv1.KongConsumerStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:               "Programmed",
+						Status:             metav1.ConditionFalse,
+						Reason:             "NotProgrammed",
+						LastTransitionTime: metav1.Now(),
+					},
+				},
+			},
+			Update: func(c *configurationv1.KongConsumer) {
+				c.Credentials = []string{"new-credentials"}
+			},
+		},
 	},
 }

--- a/test/crdsvalidation/kongconsumergroup/testcases/cpref-update-not-allowed-for-status.go
+++ b/test/crdsvalidation/kongconsumergroup/testcases/cpref-update-not-allowed-for-status.go
@@ -71,5 +71,27 @@ var updatesNotAllowedForStatus = testCasesGroup{
 				c.Spec.ControlPlaneRef.KonnectNamespacedRef.Name = "new-konnect-control-plane"
 			},
 		},
+		{
+			Name: "updates with Programmed = True when no cpRef is allowed",
+			KongConsumerGroup: configurationv1beta1.KongConsumerGroup{
+				ObjectMeta: commonObjectMeta,
+				Spec: configurationv1beta1.KongConsumerGroupSpec{
+					Name: "group1",
+				},
+			},
+			KongConsumerGroupStatus: &configurationv1beta1.KongConsumerGroupStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:               "Programmed",
+						Status:             metav1.ConditionFalse,
+						Reason:             "NotProgrammed",
+						LastTransitionTime: metav1.Now(),
+					},
+				},
+			},
+			Update: func(c *configurationv1beta1.KongConsumerGroup) {
+				c.Spec.Name = "group2"
+			},
+		},
 	},
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow updating `KongConsumer` and `KongConsumerGroup` when `Programmed=True` and `spec.ControlPlaneRef` is empty because `spec.ControlPlaneRef` is empty when we use them in KIC.
**Which issue this PR fixes**

Fixes #118

**Special notes for your reviewer**:

Note: Since `spec` of `KongConsumer` and `KongConsumerGroup`  are also optional, we need to add `!has(self.spec)`. This cannot be tested in our tests but it would fail when we run `kubectl apply` on them without `spec`.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
