### PR TITLE
chore: cover KonnectAPIAuthConfiguration CEL rules in tests

### DIFF
--- a/config/crd/bases/konnect.konghq.com_konnectapiauthconfigurations.yaml
+++ b/config/crd/bases/konnect.konghq.com_konnectapiauthconfigurations.yaml
@@ -58,7 +58,7 @@ spec:
               secretRef:
                 description: |-
                   SecretRef is a reference to a Kubernetes Secret containing the Konnect token.
-                  This secret is required to has the konghq.com/credential label set to "konnect".
+                  This secret is required to have the konghq.com/credential label set to "konnect".
                 properties:
                   name:
                     description: name is unique within a namespace to reference a
@@ -71,11 +71,22 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               serverURL:
-                description: ServerURL is the URL of the Konnect server.
+                description: |-
+                  ServerURL is the URL of the Konnect server.
+                  It can be either a full URL with an HTTPs scheme or just a hostname.
+                  Please refer to https://docs.konghq.com/konnect/network/ for the list of supported hostnames.
                 type: string
                 x-kubernetes-validations:
+                - message: Server URL is required
+                  rule: size(self) > 0
                 - message: Server URL is immutable
                   rule: self == oldSelf
+                - message: Server URL must use HTTPs if specifying scheme
+                  rule: 'isURL(self) ? url(self).getScheme() == ''https'' : true'
+                - message: Server URL must satisfy hostname (RFC 1123) regex if not
+                    a valid absolute URL
+                  rule: 'size(self) > 0 && !isURL(self) ? self.matches(''^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]).)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])$'')
+                    : true'
               token:
                 description: Token is the Konnect token used to authenticate with
                   the Konnect API.
@@ -92,10 +103,12 @@ spec:
             - type
             type: object
             x-kubernetes-validations:
-            - message: Token is required if auth type is set to token or secretRef
-                is required if auth type is set to secretRef
-              rule: (self.type == 'token' && has(self.token)) || (self.type == 'secretRef'
-                && has(self.secretRef))
+            - message: spec.token is required if auth type is set to token
+              rule: 'self.type == ''token'' ? size(self.token) > 0 : true'
+            - message: spec.secretRef is required if auth type is set to secretRef
+              rule: 'self.type == ''secretRef'' ? has(self.secretRef) : true'
+            - message: spec.token and spec.secretRef cannot be set at the same time
+              rule: '!(has(self.token) && has(self.secretRef))'
           status:
             description: Status is the status of the KonnectAPIAuthConfiguration resource.
             properties:
@@ -182,8 +195,6 @@ spec:
             || self.spec.token.startsWith('kpat_'))
         - message: Token is required once set
           rule: self.spec.type != 'token' || (!has(oldSelf.spec.token) || has(self.spec.token))
-        - message: Server URL is required once set
-          rule: '!has(oldSelf.spec.serverURL) || has(self.spec.serverURL)'
     served: true
     storage: true
     subresources:

--- a/docs/konnect-api-reference.md
+++ b/docs/konnect-api-reference.md
@@ -71,8 +71,8 @@ KonnectAPIAuthConfigurationSpec is the specification of the KonnectAPIAuthConfig
 | --- | --- |
 | `type` _[KonnectAPIAuthType](#konnectapiauthtype)_ |  |
 | `token` _string_ | Token is the Konnect token used to authenticate with the Konnect API. |
-| `secretRef` _[SecretReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretreference-v1-core)_ | SecretRef is a reference to a Kubernetes Secret containing the Konnect token. This secret is required to has the konghq.com/credential label set to "konnect". |
-| `serverURL` _string_ | ServerURL is the URL of the Konnect server. |
+| `secretRef` _[SecretReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretreference-v1-core)_ | SecretRef is a reference to a Kubernetes Secret containing the Konnect token. This secret is required to have the konghq.com/credential label set to "konnect". |
+| `serverURL` _string_ | ServerURL is the URL of the Konnect server. It can be either a full URL with an HTTPs scheme or just a hostname. Please refer to https://docs.konghq.com/konnect/network/ for the list of supported hostnames. |
 
 
 _Appears in:_

--- a/test/crdsvalidation/konnectapiauthconfiguration/konnectapiauthconfiguration_test.go
+++ b/test/crdsvalidation/konnectapiauthconfiguration/konnectapiauthconfiguration_test.go
@@ -1,0 +1,62 @@
+package kongpluginbindings
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	konnectv1alpha1client "github.com/kong/kubernetes-configuration/pkg/clientset/typed/konnect/v1alpha1"
+	"github.com/kong/kubernetes-configuration/test/crdsvalidation/konnectapiauthconfiguration/testcases"
+)
+
+func TestKonnectAPIAuthConfiguration(t *testing.T) {
+	ctx := context.Background()
+	cfg, err := config.GetConfig()
+	require.NoError(t, err, "error loading Kubernetes config")
+	cl, err := konnectv1alpha1client.NewForConfig(cfg)
+	require.NoError(t, err, "error creating konnectv1alpha1client client")
+
+	for _, tcsGroup := range testcases.TestCases {
+		t.Run(tcsGroup.Name, func(t *testing.T) {
+			for _, tc := range tcsGroup.TestCases {
+				t.Run(tc.Name, func(t *testing.T) {
+					cl := cl.KonnectAPIAuthConfigurations(tc.KonnectAPIAuthConfiguration.Namespace)
+					entity, err := cl.Create(ctx, &tc.KonnectAPIAuthConfiguration, metav1.CreateOptions{})
+					if err == nil {
+						t.Cleanup(func() {
+							assert.NoError(t, client.IgnoreNotFound(cl.Delete(ctx, entity.Name, metav1.DeleteOptions{})))
+						})
+						// Create doesn't set the status, so we need to update it explicitly.
+						entity.Status = tc.KonnectAPIAuthConfiguration.Status
+						entity, err = cl.UpdateStatus(ctx, entity, metav1.UpdateOptions{})
+						assert.NoError(t, err)
+					}
+
+					if tc.ExpectedErrorMessage == nil {
+						assert.NoError(t, err)
+
+						// Update the object and check if the update is allowed.
+						if tc.Update != nil {
+							tc.Update(entity)
+							_, err := cl.Update(ctx, entity, metav1.UpdateOptions{})
+							if tc.ExpectedUpdateErrorMessage != nil {
+								require.NotNil(t, err)
+								assert.Contains(t, err.Error(), *tc.ExpectedUpdateErrorMessage)
+							} else {
+								assert.NoError(t, err)
+							}
+						}
+					} else {
+						require.NotNil(t, err)
+						assert.Contains(t, err.Error(), *tc.ExpectedErrorMessage)
+					}
+				})
+			}
+		})
+	}
+}

--- a/test/crdsvalidation/konnectapiauthconfiguration/testcases/common.go
+++ b/test/crdsvalidation/konnectapiauthconfiguration/testcases/common.go
@@ -1,0 +1,37 @@
+package testcases
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
+)
+
+// testCase is a test case related to KonnectAPIAuthConfiguration validation.
+type testCase struct {
+	Name                        string
+	KonnectAPIAuthConfiguration konnectv1alpha1.KonnectAPIAuthConfiguration
+	Update                      func(*konnectv1alpha1.KonnectAPIAuthConfiguration)
+	ExpectedErrorMessage        *string
+	ExpectedUpdateErrorMessage  *string
+}
+
+// testCasesGroup is a group of test cases related to KonnectAPIAuthConfiguration validation.
+// The grouping is done by a common name.
+type testCasesGroup struct {
+	Name      string
+	TestCases []testCase
+}
+
+// TestCases is a collection of all test cases groups related to KonnectAPIAuthConfiguration validation.
+var TestCases = []testCasesGroup{}
+
+func init() {
+	TestCases = append(TestCases,
+		specTestCases,
+	)
+}
+
+var commonObjectMeta = metav1.ObjectMeta{
+	GenerateName: "test-konnectapiauthconfiguration-",
+	Namespace:    "default",
+}

--- a/test/crdsvalidation/konnectapiauthconfiguration/testcases/spec.go
+++ b/test/crdsvalidation/konnectapiauthconfiguration/testcases/spec.go
@@ -1,0 +1,159 @@
+package testcases
+
+import (
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+
+	konnectv1alpha1 "github.com/kong/kubernetes-configuration/api/konnect/v1alpha1"
+)
+
+var specTestCases = testCasesGroup{
+	Name: "spec",
+	TestCases: []testCase{
+		{
+			Name: "valid token type - spat prefix",
+			KonnectAPIAuthConfiguration: konnectv1alpha1.KonnectAPIAuthConfiguration{
+				ObjectMeta: commonObjectMeta,
+				Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+					Type:      konnectv1alpha1.KonnectAPIAuthTypeToken,
+					Token:     "spat_token",
+					ServerURL: "api.us.konghq.com",
+				},
+			},
+		},
+		{
+			Name: "valid token type - kpat prefix",
+			KonnectAPIAuthConfiguration: konnectv1alpha1.KonnectAPIAuthConfiguration{
+				ObjectMeta: commonObjectMeta,
+				Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+					Type:      konnectv1alpha1.KonnectAPIAuthTypeToken,
+					Token:     "kpat_token",
+					ServerURL: "api.us.konghq.com",
+				},
+			},
+		},
+		{
+			Name: "invalid token type - no prefix",
+			KonnectAPIAuthConfiguration: konnectv1alpha1.KonnectAPIAuthConfiguration{
+				ObjectMeta: commonObjectMeta,
+				Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+					Type:      konnectv1alpha1.KonnectAPIAuthTypeToken,
+					Token:     "token",
+					ServerURL: "api.us.konghq.com",
+				},
+			},
+			ExpectedErrorMessage: lo.ToPtr("Konnect tokens have to start with spat_ or kpat_"),
+		},
+		{
+			Name: "invalid token type - missing token",
+			KonnectAPIAuthConfiguration: konnectv1alpha1.KonnectAPIAuthConfiguration{
+				ObjectMeta: commonObjectMeta,
+				Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+					Type:      konnectv1alpha1.KonnectAPIAuthTypeToken,
+					ServerURL: "api.us.konghq.com",
+				},
+			},
+			ExpectedErrorMessage: lo.ToPtr("Konnect tokens have to start with spat_ or kpat_"),
+		},
+		{
+			Name: "token is required once set",
+			KonnectAPIAuthConfiguration: konnectv1alpha1.KonnectAPIAuthConfiguration{
+				ObjectMeta: commonObjectMeta,
+				Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+					Type:      konnectv1alpha1.KonnectAPIAuthTypeToken,
+					Token:     "kpat_token",
+					ServerURL: "api.us.konghq.com",
+				},
+			},
+			Update: func(obj *konnectv1alpha1.KonnectAPIAuthConfiguration) {
+				obj.Spec.Token = ""
+			},
+			ExpectedUpdateErrorMessage: lo.ToPtr("Token is required once set"),
+		},
+		{
+			Name: "valid secretRef type",
+			KonnectAPIAuthConfiguration: konnectv1alpha1.KonnectAPIAuthConfiguration{
+				ObjectMeta: commonObjectMeta,
+				Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+					Type: konnectv1alpha1.KonnectAPIAuthTypeSecretRef,
+					SecretRef: &corev1.SecretReference{
+						Name: "secret",
+					},
+					ServerURL: "api.us.konghq.com",
+				},
+			},
+		},
+		{
+			Name: "invalid secretRef type - missing secretRef",
+			KonnectAPIAuthConfiguration: konnectv1alpha1.KonnectAPIAuthConfiguration{
+				ObjectMeta: commonObjectMeta,
+				Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+					Type:      konnectv1alpha1.KonnectAPIAuthTypeSecretRef,
+					ServerURL: "api.us.konghq.com",
+				},
+			},
+			ExpectedErrorMessage: lo.ToPtr("spec.secretRef is required if auth type is set to secretRef"),
+		},
+		{
+			Name: "server URL is required",
+			KonnectAPIAuthConfiguration: konnectv1alpha1.KonnectAPIAuthConfiguration{
+				ObjectMeta: commonObjectMeta,
+				Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+					Type:  konnectv1alpha1.KonnectAPIAuthTypeToken,
+					Token: "spat_token",
+				},
+			},
+			ExpectedErrorMessage: lo.ToPtr("Server URL is required"),
+		},
+		{
+			Name: "server URL is immutable",
+			KonnectAPIAuthConfiguration: konnectv1alpha1.KonnectAPIAuthConfiguration{
+				ObjectMeta: commonObjectMeta,
+				Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+					Type:      konnectv1alpha1.KonnectAPIAuthTypeToken,
+					Token:     "spat_token",
+					ServerURL: "api.us.konghq.com",
+				},
+			},
+			Update: func(obj *konnectv1alpha1.KonnectAPIAuthConfiguration) {
+				obj.Spec.ServerURL = "api.eu.konghq.com"
+			},
+			ExpectedUpdateErrorMessage: lo.ToPtr("Server URL is immutable"),
+		},
+		{
+			Name: "server URL is valid when using HTTPs scheme",
+			KonnectAPIAuthConfiguration: konnectv1alpha1.KonnectAPIAuthConfiguration{
+				ObjectMeta: commonObjectMeta,
+				Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+					Type:      konnectv1alpha1.KonnectAPIAuthTypeToken,
+					Token:     "spat_token",
+					ServerURL: "https://api.us.konghq.com",
+				},
+			},
+		},
+		{
+			Name: "server URL must use HTTPs if specifying scheme",
+			KonnectAPIAuthConfiguration: konnectv1alpha1.KonnectAPIAuthConfiguration{
+				ObjectMeta: commonObjectMeta,
+				Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+					Type:      konnectv1alpha1.KonnectAPIAuthTypeToken,
+					Token:     "spat_token",
+					ServerURL: "http://api.us.konghq.com",
+				},
+			},
+			ExpectedErrorMessage: lo.ToPtr("Server URL must use HTTPs if specifying scheme"),
+		},
+		{
+			Name: "server URL must satisfy hostname (RFC 1123) regex if not a valid absolute URL",
+			KonnectAPIAuthConfiguration: konnectv1alpha1.KonnectAPIAuthConfiguration{
+				ObjectMeta: commonObjectMeta,
+				Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+					Type:      konnectv1alpha1.KonnectAPIAuthTypeToken,
+					Token:     "spat_token",
+					ServerURL: "%%%invalid%%%hostname",
+				},
+			},
+			ExpectedErrorMessage: lo.ToPtr("Server URL must satisfy hostname (RFC 1123) regex if not a valid absolute URL"),
+		},
+	},
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Covers KonnectAPIAuthConfiguration CEL rules in tests. Allow `spec.serverURL` to be set to a full absolute URL with HTTPs scheme or just a hostname. 

**Which issue this PR fixes**

Fixes https://github.com/Kong/kubernetes-configuration/issues/63. 
