### PR TITLE
fix: add KongConsumerGroup back to KGO reference

### DIFF
--- a/api/configuration/v1beta1/kongconsumergroup_types.go
+++ b/api/configuration/v1beta1/kongconsumergroup_types.go
@@ -37,6 +37,7 @@ import (
 // +kubebuilder:validation:XValidation:rule="(!has(self.spec) || !has(self.spec.controlPlaneRef) || !has(self.spec.controlPlaneRef.konnectNamespacedRef)) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
 // +kubebuilder:validation:XValidation:rule="(!has(oldSelf.spec) || !has(oldSelf.spec.controlPlaneRef)) ? true : (!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 // +apireference:kic:include
+// +apireference:kgo:include
 type KongConsumerGroup struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
**What this PR does / why we need it**:

Annotates `KongConsumerGroup` back with the KGO API reference `include` marker that was mistakenly removed in https://github.com/Kong/kubernetes-configuration/commit/b53eed6636122b0e5c818b776606444cf3815625.
