### PR TITLE
feat: validate KonnectGatewayControlPlane labels

### DIFF
--- a/api/konnect/v1alpha1/konnect_gateway_controlplane_types.go
+++ b/api/konnect/v1alpha1/konnect_gateway_controlplane_types.go
@@ -37,6 +37,11 @@ type KonnectGatewayControlPlane struct {
 }
 
 // KonnectGatewayControlPlaneSpec defines the desired state of KonnectGatewayControlPlane.
+// +kubebuilder:validation:XValidation:message="spec.labels must not have more than 40 entries", rule="has(self.labels) ? size(self.labels) <= 40 : true"
+// +kubebuilder:validation:XValidation:message="spec.labels keys must be of length 1-63 characters", rule="has(self.labels) ? self.labels.all(key, size(key) >= 1 && size(key) <= 63) : true"
+// +kubebuilder:validation:XValidation:message="spec.labels values must be of length 1-63 characters", rule="has(self.labels) ? self.labels.all(key, size(self.labels[key]) >= 1 && size(self.labels[key]) <= 63) : true"
+// +kubebuilder:validation:XValidation:message="spec.labels keys must not start with 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'", rule="has(self.labels) ? self.labels.all(key, !key.startsWith('kong') && !key.startsWith('konnect') && !key.startsWith('mesh') && !key.startsWith('kic') && !key.startsWith('_') && !key.startsWith('insomnia')) : true"
+// +kubebuilder:validation:XValidation:message="spec.labels keys must satisfy the '^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$' pattern", rule="has(self.labels) ? self.labels.all(key, key.matches('^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$')) : true"
 // +apireference:kgo:include
 type KonnectGatewayControlPlaneSpec struct {
 	sdkkonnectcomp.CreateControlPlaneRequest `json:",inline"`

--- a/api/konnect/v1alpha1/konnect_gateway_controlplane_types.go
+++ b/api/konnect/v1alpha1/konnect_gateway_controlplane_types.go
@@ -40,7 +40,7 @@ type KonnectGatewayControlPlane struct {
 // +kubebuilder:validation:XValidation:message="spec.labels must not have more than 40 entries", rule="has(self.labels) ? size(self.labels) <= 40 : true"
 // +kubebuilder:validation:XValidation:message="spec.labels keys must be of length 1-63 characters", rule="has(self.labels) ? self.labels.all(key, size(key) >= 1 && size(key) <= 63) : true"
 // +kubebuilder:validation:XValidation:message="spec.labels values must be of length 1-63 characters", rule="has(self.labels) ? self.labels.all(key, size(self.labels[key]) >= 1 && size(self.labels[key]) <= 63) : true"
-// +kubebuilder:validation:XValidation:message="spec.labels keys must not start with 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'", rule="has(self.labels) ? self.labels.all(key, !key.startsWith('kong') && !key.startsWith('konnect') && !key.startsWith('mesh') && !key.startsWith('kic') && !key.startsWith('_') && !key.startsWith('insomnia')) : true"
+// +kubebuilder:validation:XValidation:message="spec.labels keys must not start with 'k8s', 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'", rule="has(self.labels) ? self.labels.all(key, !key.startsWith('k8s') && !key.startsWith('kong') && !key.startsWith('konnect') && !key.startsWith('mesh') && !key.startsWith('kic') && !key.startsWith('_') && !key.startsWith('insomnia')) : true"
 // +kubebuilder:validation:XValidation:message="spec.labels keys must satisfy the '^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$' pattern", rule="has(self.labels) ? self.labels.all(key, key.matches('^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$')) : true"
 // +apireference:kgo:include
 type KonnectGatewayControlPlaneSpec struct {

--- a/config/crd/bases/konnect.konghq.com_konnectgatewaycontrolplanes.yaml
+++ b/config/crd/bases/konnect.konghq.com_konnectgatewaycontrolplanes.yaml
@@ -144,6 +144,24 @@ spec:
             required:
             - name
             type: object
+            x-kubernetes-validations:
+            - message: spec.labels must not have more than 40 entries
+              rule: 'has(self.labels) ? size(self.labels) <= 40 : true'
+            - message: spec.labels keys must be of length 1-63 characters
+              rule: 'has(self.labels) ? self.labels.all(key, size(key) >= 1 && size(key)
+                <= 63) : true'
+            - message: spec.labels values must be of length 1-63 characters
+              rule: 'has(self.labels) ? self.labels.all(key, size(self.labels[key])
+                >= 1 && size(self.labels[key]) <= 63) : true'
+            - message: spec.labels keys must not start with 'kong', 'konnect', 'mesh',
+                'kic', 'insomnia' or '_'
+              rule: 'has(self.labels) ? self.labels.all(key, !key.startsWith(''kong'')
+                && !key.startsWith(''konnect'') && !key.startsWith(''mesh'') && !key.startsWith(''kic'')
+                && !key.startsWith(''_'') && !key.startsWith(''insomnia'')) : true'
+            - message: spec.labels keys must satisfy the '^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$'
+                pattern
+              rule: 'has(self.labels) ? self.labels.all(key, key.matches(''^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$''))
+                : true'
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:

--- a/config/crd/bases/konnect.konghq.com_konnectgatewaycontrolplanes.yaml
+++ b/config/crd/bases/konnect.konghq.com_konnectgatewaycontrolplanes.yaml
@@ -153,11 +153,12 @@ spec:
             - message: spec.labels values must be of length 1-63 characters
               rule: 'has(self.labels) ? self.labels.all(key, size(self.labels[key])
                 >= 1 && size(self.labels[key]) <= 63) : true'
-            - message: spec.labels keys must not start with 'kong', 'konnect', 'mesh',
-                'kic', 'insomnia' or '_'
-              rule: 'has(self.labels) ? self.labels.all(key, !key.startsWith(''kong'')
-                && !key.startsWith(''konnect'') && !key.startsWith(''mesh'') && !key.startsWith(''kic'')
-                && !key.startsWith(''_'') && !key.startsWith(''insomnia'')) : true'
+            - message: spec.labels keys must not start with 'k8s', 'kong', 'konnect',
+                'mesh', 'kic', 'insomnia' or '_'
+              rule: 'has(self.labels) ? self.labels.all(key, !key.startsWith(''k8s'')
+                && !key.startsWith(''kong'') && !key.startsWith(''konnect'') && !key.startsWith(''mesh'')
+                && !key.startsWith(''kic'') && !key.startsWith(''_'') && !key.startsWith(''insomnia''))
+                : true'
             - message: spec.labels keys must satisfy the '^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$'
                 pattern
               rule: 'has(self.labels) ? self.labels.all(key, key.matches(''^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$''))

--- a/test/crdsvalidation/konnectgatewaycontrolplane_test.go
+++ b/test/crdsvalidation/konnectgatewaycontrolplane_test.go
@@ -373,6 +373,27 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 				ExpectedErrorMessage: lo.ToPtr("spec.labels values must be of length 1-63 characters"),
 			},
 			{
+				Name: "spec.labels keys must not start with k8s",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: commonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								"k8s_key": "value",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.labels keys must not start with 'k8s', 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'"),
+			},
+			{
 				Name: "spec.labels keys must not start with kong",
 				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
 					ObjectMeta: commonObjectMeta,
@@ -391,7 +412,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 						},
 					},
 				},
-				ExpectedErrorMessage: lo.ToPtr("spec.labels keys must not start with 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'"),
+				ExpectedErrorMessage: lo.ToPtr("spec.labels keys must not start with 'k8s', 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'"),
 			},
 			{
 				Name: "spec.labels keys must not start with konnect",
@@ -412,7 +433,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 						},
 					},
 				},
-				ExpectedErrorMessage: lo.ToPtr("spec.labels keys must not start with 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'"),
+				ExpectedErrorMessage: lo.ToPtr("spec.labels keys must not start with 'k8s', 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'"),
 			},
 			{
 				Name: "spec.labels keys must not start with mesh",
@@ -433,7 +454,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 						},
 					},
 				},
-				ExpectedErrorMessage: lo.ToPtr("spec.labels keys must not start with 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'"),
+				ExpectedErrorMessage: lo.ToPtr("spec.labels keys must not start with 'k8s', 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'"),
 			},
 			{
 				Name: "spec.labels keys must not start with kic",
@@ -454,7 +475,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 						},
 					},
 				},
-				ExpectedErrorMessage: lo.ToPtr("spec.labels keys must not start with 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'"),
+				ExpectedErrorMessage: lo.ToPtr("spec.labels keys must not start with 'k8s', 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'"),
 			},
 			{
 				Name: "spec.labels keys must not start with insomnia",
@@ -475,7 +496,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 						},
 					},
 				},
-				ExpectedErrorMessage: lo.ToPtr("spec.labels keys must not start with 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'"),
+				ExpectedErrorMessage: lo.ToPtr("spec.labels keys must not start with 'k8s', 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'"),
 			},
 			{
 				Name: "spec.labels keys must not start with underscore",
@@ -496,7 +517,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 						},
 					},
 				},
-				ExpectedErrorMessage: lo.ToPtr("spec.labels keys must not start with 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'"),
+				ExpectedErrorMessage: lo.ToPtr("spec.labels keys must not start with 'k8s', 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'"),
 			},
 			{
 				Name: "spec.labels keys must satisfy the '^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$' pattern",

--- a/test/crdsvalidation/konnectgatewaycontrolplane_test.go
+++ b/test/crdsvalidation/konnectgatewaycontrolplane_test.go
@@ -1,6 +1,7 @@
 package crdsvalidation_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/samber/lo"
@@ -231,6 +232,287 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 				Update: func(kcp *konnectv1alpha1.KonnectGatewayControlPlane) {
 					kcp.Spec.KonnectConfiguration.APIAuthConfigurationRef.Name = "name-2"
 				},
+			},
+		}.Run(t)
+	})
+
+	t.Run("labels constraints", func(t *testing.T) {
+		CRDValidationTestCasesGroup[*konnectv1alpha1.KonnectGatewayControlPlane]{
+			{
+				Name: "spec.labels of length 40 is allowed",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: commonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
+							Labels: func() map[string]string {
+								labels := make(map[string]string)
+								for i := range 40 {
+									labels[fmt.Sprintf("key-%d", i)] = fmt.Sprintf("value-%d", i)
+								}
+								return labels
+							}(),
+						},
+						KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "spec.labels length must not be greater than 40",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: commonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
+							Labels: func() map[string]string {
+								labels := make(map[string]string)
+								for i := range 41 {
+									labels[fmt.Sprintf("key-%d", i)] = fmt.Sprintf("value-%d", i)
+								}
+								return labels
+							}(),
+						},
+						KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.labels must not have more than 40 entries"),
+			},
+			{
+				Name: "spec.labels keys' length must not be greater than 63",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: commonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								lo.RandomString(64, lo.AllCharset): "value",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.labels keys must be of length 1-63 characters"),
+			},
+			{
+				Name: "spec.labels keys' length must at least 1 character long",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: commonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								"": "value",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.labels keys must be of length 1-63 characters"),
+			},
+			//
+			{
+				Name: "spec.labels values' length must not be greater than 63",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: commonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								"key": lo.RandomString(64, lo.AllCharset),
+							},
+						},
+						KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.labels values must be of length 1-63 characters"),
+			},
+			{
+				Name: "spec.labels values' length must at least 1 character long",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: commonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								"key": "",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.labels values must be of length 1-63 characters"),
+			},
+			{
+				Name: "spec.labels keys must not start with kong",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: commonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								"kong_key": "value",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.labels keys must not start with 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'"),
+			},
+			{
+				Name: "spec.labels keys must not start with konnect",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: commonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								"konnect_key": "value",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.labels keys must not start with 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'"),
+			},
+			{
+				Name: "spec.labels keys must not start with mesh",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: commonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								"mesh_key": "value",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.labels keys must not start with 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'"),
+			},
+			{
+				Name: "spec.labels keys must not start with kic",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: commonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								"kic_key": "value",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.labels keys must not start with 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'"),
+			},
+			{
+				Name: "spec.labels keys must not start with insomnia",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: commonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								"insomnia_key": "value",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.labels keys must not start with 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'"),
+			},
+			{
+				Name: "spec.labels keys must not start with underscore",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: commonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								"_key": "value",
+							},
+						},
+						KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.labels keys must not start with 'kong', 'konnect', 'mesh', 'kic', 'insomnia' or '_'"),
+			},
+			{
+				Name: "spec.labels keys must satisfy the '^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$' pattern",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: commonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
+							Labels: map[string]string{
+								"key-": "value",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.labels keys must satisfy the '^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$' pattern"),
 			},
 		}.Run(t)
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds CEL rules for `KonnectGatewayControlPlane` `spec.labels` and covers those with tests.

**Which issue this PR fixes**

Part of https://github.com/Kong/gateway-operator/issues/771.
