### PR TITLE
fix(konnect): fix cluster_type validation rule on `KonnectGatewayControlPlanes`

### DIFF
--- a/api/konnect/v1alpha1/konnect_gateway_controlplane_types.go
+++ b/api/konnect/v1alpha1/konnect_gateway_controlplane_types.go
@@ -23,7 +23,6 @@ func init() {
 // +kubebuilder:printcolumn:name="OrgID",description="Konnect Organization ID this resource belongs to.",type=string,JSONPath=`.status.organizationID`
 // +kubebuilder:validation:XValidation:message="spec.konnect.authRef is immutable when an entity is already Programmed", rule="!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef"
 // +kubebuilder:validation:XValidation:message="spec.konnect.authRef is immutable when an entity refers to a Valid API Auth Configuration", rule="!self.status.conditions.exists(c, c.type == 'APIAuthValid' && c.status == 'True') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef"
-// +kubebuilder:validation:XValidation:message="spec.cluster_type is immutable", rule="self.spec.cluster_type == oldSelf.spec.cluster_type"
 // +apireference:kgo:include
 type KonnectGatewayControlPlane struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -44,6 +43,7 @@ type KonnectGatewayControlPlane struct {
 // +kubebuilder:validation:XValidation:message="spec.labels keys must satisfy the '^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$' pattern", rule="has(self.labels) ? self.labels.all(key, key.matches('^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$')) : true"
 // +kubebuilder:validation:XValidation:message="when specified, spec.cluster_type must be one of 'CLUSTER_TYPE_CONTROL_PLANE_GROUP', 'CLUSTER_TYPE_CONTROL_PLANE' or 'CLUSTER_TYPE_K8S_INGRESS_CONTROLLER'", rule="!has(self.cluster_type) ? true : ['CLUSTER_TYPE_CONTROL_PLANE_GROUP', 'CLUSTER_TYPE_CONTROL_PLANE', 'CLUSTER_TYPE_K8S_INGRESS_CONTROLLER'].exists(ct, ct == self.cluster_type)"
 // +kubebuilder:validation:XValidation:message="spec.members is only applicable for ControlPlanes that are created as groups", rule="(has(self.cluster_type) && self.cluster_type != 'CLUSTER_TYPE_CONTROL_PLANE_GROUP') ? !has(self.members) : true"
+// +kubebuilder:validation:XValidation:message="spec.cluster_type is immutable", rule="!has(self.cluster_type) ? !has(oldSelf.cluster_type) : self.cluster_type == oldSelf.cluster_type"
 // +apireference:kgo:include
 type KonnectGatewayControlPlaneSpec struct {
 	sdkkonnectcomp.CreateControlPlaneRequest `json:",inline"`

--- a/config/crd/bases/konnect.konghq.com_konnectgatewaycontrolplanes.yaml
+++ b/config/crd/bases/konnect.konghq.com_konnectgatewaycontrolplanes.yaml
@@ -172,6 +172,9 @@ spec:
                 created as groups
               rule: '(has(self.cluster_type) && self.cluster_type != ''CLUSTER_TYPE_CONTROL_PLANE_GROUP'')
                 ? !has(self.members) : true'
+            - message: spec.cluster_type is immutable
+              rule: '!has(self.cluster_type) ? !has(oldSelf.cluster_type) : self.cluster_type
+                == oldSelf.cluster_type'
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:
@@ -270,8 +273,6 @@ spec:
             API Auth Configuration
           rule: '!self.status.conditions.exists(c, c.type == ''APIAuthValid'' && c.status
             == ''True'') ? true : self.spec.konnect.authRef == oldSelf.spec.konnect.authRef'
-        - message: spec.cluster_type is immutable
-          rule: self.spec.cluster_type == oldSelf.spec.cluster_type
     served: true
     storage: true
     subresources:

--- a/test/crdsvalidation/konnectgatewaycontrolplane_test.go
+++ b/test/crdsvalidation/konnectgatewaycontrolplane_test.go
@@ -682,6 +682,47 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 				},
 				ExpectedErrorMessage: lo.ToPtr("spec.cluster_type must be one of 'CLUSTER_TYPE_CONTROL_PLANE_GROUP', 'CLUSTER_TYPE_CONTROL_PLANE' or 'CLUSTER_TYPE_K8S_INGRESS_CONTROLLER'"),
 			},
+			{
+				Name: "cluster type is immutable",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: commonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
+							Name: "cp-1",
+						},
+						KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				Update: func(cp *konnectv1alpha1.KonnectGatewayControlPlane) {
+					cp.Spec.ClusterType = sdkkonnectcomp.ClusterTypeClusterTypeControlPlaneGroup.ToPointer()
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("spec.cluster_type is immutable"),
+			},
+			{
+				Name: "cluster type is immutable when having it set and then trying to unset it",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: commonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: sdkkonnectcomp.ClusterTypeClusterTypeControlPlane.ToPointer(),
+						},
+						KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				Update: func(cp *konnectv1alpha1.KonnectGatewayControlPlane) {
+					cp.Spec.ClusterType = nil
+				},
+				ExpectedUpdateErrorMessage: lo.ToPtr("spec.cluster_type is immutable"),
+			},
 		}.Run(t)
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:


Previous change #135, made `KonnectGatewayControlPlanes`s broken, and KGO returning the following error when applying `KonnectGatewayControlPlane` objects without `cluster_type` specified:

```
{"level":"error","ts":"2024-10-24T17:29:11.935+0200","msg":"Reconciler error","controller":"KonnectGatewayControlPlane","controllerGroup":"konnect.konghq.com","controllerKind":"KonnectGatewayControlPlane","KonnectGatewayControlPlane":{"name":"test1","namespace":"default"},"namespace":"default","name":"test1","reconcileID":"c7513c87-a811-48e1-8070-701b5c40094f","error":"failed to patch status with APIAuthResolvedRef condition: KonnectGatewayControlPlane.konnect.konghq.com \"test1\" is invalid: <nil>: Invalid value: \"object\": no such key: cluster_type evaluating rule: spec.cluster_type is immutable","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/Users/patryk.malek@konghq.com/.gvm/pkgsets/go1.23.2/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:316\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/Users/patryk.malek@konghq.com/.gvm/pkgsets/go1.23.2/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/Users/patryk.malek@konghq.com/.gvm/pkgsets/go1.23.2/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:224"}
```

```
# * <nil>: Invalid value: "object": no such key: cluster_type evaluating rule: spec.cluster_type is immutable
```

This PR fixes that by checking if the `cluster_type` field is set.