### PR TITLE
chore: bump sdk-konnect-go to 0.1.2

### DIFF
--- a/docs/konnect-api-reference.md
+++ b/docs/konnect-api-reference.md
@@ -153,7 +153,7 @@ KonnectGatewayControlPlaneSpec defines the desired state of KonnectGatewayContro
 | --- | --- |
 | `name` _string_ | The name of the control plane. |
 | `description` _string_ | The description of the control plane in Konnect. |
-| `cluster_type` _[ClusterType](#clustertype)_ | The ClusterType value of the cluster associated with the Control Plane. |
+| `cluster_type` _[CreateControlPlaneRequestClusterType](#createcontrolplanerequestclustertype)_ | The ClusterType value of the cluster associated with the Control Plane. |
 | `auth_type` _[AuthType](#authtype)_ | The auth type value of the cluster associated with the Runtime Group. |
 | `cloud_gateway` _boolean_ | Whether this control-plane can be used for cloud-gateways. |
 | `proxy_urls` _[ProxyURL](#proxyurl) array_ | Array of proxy URLs associated with reaching the data-planes connected to a control-plane. |

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/kong/kubernetes-configuration
 go 1.22.4
 
 require (
-	github.com/Kong/sdk-konnect-go v0.0.16
+	github.com/Kong/sdk-konnect-go v0.1.2
 	github.com/kong/go-kong v0.59.1
 	github.com/stretchr/testify v1.9.0
 	k8s.io/api v0.31.2

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Kong/sdk-konnect-go v0.0.16 h1:xQMvwhMpypFUlPZiAbNpT/epeL1az2/RGa8/qlzKpmw=
-github.com/Kong/sdk-konnect-go v0.0.16/go.mod h1:ipu67aQNnwDzu/LXKePG46cVqkkZnAHKWpsbhTEI8xE=
+github.com/Kong/sdk-konnect-go v0.1.2 h1:axA0ZxMxmcjsSm0oWPK8NHlKMdatQCm1vANp+TuCAqc=
+github.com/Kong/sdk-konnect-go v0.1.2/go.mod h1:ipu67aQNnwDzu/LXKePG46cVqkkZnAHKWpsbhTEI8xE=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=

--- a/test/crdsvalidation/konnectgatewaycontrolplane_test.go
+++ b/test/crdsvalidation/konnectgatewaycontrolplane_test.go
@@ -23,7 +23,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 							Name:        "cpg-1",
-							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlaneGroup),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup),
 						},
 						Members: []corev1.LocalObjectReference{
 							{
@@ -45,7 +45,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 							Name:        "cpg-1",
-							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
 						},
 						Members: []corev1.LocalObjectReference{
 							{
@@ -68,30 +68,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 							Name:        "cpg-1",
-							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeK8SIngressController),
-						},
-						Members: []corev1.LocalObjectReference{
-							{
-								Name: "cp-1",
-							},
-						},
-						KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
-							APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
-								Name: "name-1",
-							},
-						},
-					},
-				},
-				ExpectedErrorMessage: lo.ToPtr("spec.members is only applicable for ControlPlanes that are created as groups"),
-			},
-			{
-				Name: "members cannot be set on hybrid control-planes",
-				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
-					ObjectMeta: commonObjectMeta,
-					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
-						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
-							Name:        "cpg-1",
-							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeHybrid),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeK8SIngressController),
 						},
 						Members: []corev1.LocalObjectReference{
 							{
@@ -114,7 +91,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 							Name:        "cpg-1",
-							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeServerless),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeServerless),
 						},
 						Members: []corev1.LocalObjectReference{
 							{
@@ -142,7 +119,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 							Name:        "cp-1",
-							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
 						},
 						KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
 							APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
@@ -173,7 +150,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 							Name:        "cp-1",
-							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
 						},
 						KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
 							APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
@@ -204,7 +181,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 							Name:        "cp-1",
-							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
 						},
 						KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
 							APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
@@ -240,7 +217,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 							Name:        "cp-1",
-							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
 						},
 						KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
 							APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
@@ -250,7 +227,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 					},
 				},
 				Update: func(kcp *konnectv1alpha1.KonnectGatewayControlPlane) {
-					kcp.Spec.ClusterType = sdkkonnectcomp.ClusterTypeClusterTypeControlPlaneGroup.ToPointer()
+					kcp.Spec.ClusterType = sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup.ToPointer()
 				},
 				ExpectedUpdateErrorMessage: lo.ToPtr("spec.cluster_type is immutable"),
 			},
@@ -266,7 +243,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 							Name:        "cp-1",
-							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
 							Labels: func() map[string]string {
 								labels := make(map[string]string)
 								for i := range 40 {
@@ -290,7 +267,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 							Name:        "cp-1",
-							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
 							Labels: func() map[string]string {
 								labels := make(map[string]string)
 								for i := range 41 {
@@ -315,7 +292,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 							Name:        "cp-1",
-							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
 							Labels: map[string]string{
 								lo.RandomString(64, lo.AllCharset): "value",
 							},
@@ -336,7 +313,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 							Name:        "cp-1",
-							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
 							Labels: map[string]string{
 								"": "value",
 							},
@@ -358,7 +335,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 							Name:        "cp-1",
-							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
 							Labels: map[string]string{
 								"key": lo.RandomString(64, lo.AllCharset),
 							},
@@ -379,7 +356,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 							Name:        "cp-1",
-							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
 							Labels: map[string]string{
 								"key": "",
 							},
@@ -400,7 +377,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 							Name:        "cp-1",
-							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
 							Labels: map[string]string{
 								"k8s_key": "value",
 							},
@@ -421,7 +398,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 							Name:        "cp-1",
-							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
 							Labels: map[string]string{
 								"kong_key": "value",
 							},
@@ -442,7 +419,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 							Name:        "cp-1",
-							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
 							Labels: map[string]string{
 								"konnect_key": "value",
 							},
@@ -463,7 +440,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 							Name:        "cp-1",
-							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
 							Labels: map[string]string{
 								"mesh_key": "value",
 							},
@@ -484,7 +461,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 							Name:        "cp-1",
-							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
 							Labels: map[string]string{
 								"kic_key": "value",
 							},
@@ -505,7 +482,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 							Name:        "cp-1",
-							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
 							Labels: map[string]string{
 								"insomnia_key": "value",
 							},
@@ -526,7 +503,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 							Name:        "cp-1",
-							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
 							Labels: map[string]string{
 								"_key": "value",
 							},
@@ -547,7 +524,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 							Name:        "cp-1",
-							ClusterType: lo.ToPtr(sdkkonnectcomp.ClusterTypeClusterTypeControlPlane),
+							ClusterType: lo.ToPtr(sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane),
 							Labels: map[string]string{
 								"key-": "value",
 							},
@@ -584,7 +561,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 							Name:        "cp-1",
-							ClusterType: sdkkonnectcomp.ClusterTypeClusterTypeControlPlaneGroup.ToPointer(),
+							ClusterType: sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup.ToPointer(),
 						},
 						KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
 							APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
@@ -601,7 +578,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 							Name:        "cp-1",
-							ClusterType: sdkkonnectcomp.ClusterTypeClusterTypeControlPlane.ToPointer(),
+							ClusterType: sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane.ToPointer(),
 						},
 						KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
 							APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
@@ -618,7 +595,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 							Name:        "cp-1",
-							ClusterType: sdkkonnectcomp.ClusterTypeClusterTypeK8SIngressController.ToPointer(),
+							ClusterType: sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeK8SIngressController.ToPointer(),
 						},
 						KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
 							APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
@@ -627,24 +604,6 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 						},
 					},
 				},
-			},
-			{
-				Name: "CLUSTER_TYPE_HYBRID not is supported",
-				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
-					ObjectMeta: commonObjectMeta,
-					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
-						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
-							Name:        "cp-1",
-							ClusterType: sdkkonnectcomp.ClusterTypeClusterTypeHybrid.ToPointer(),
-						},
-						KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
-							APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
-								Name: "name-1",
-							},
-						},
-					},
-				},
-				ExpectedErrorMessage: lo.ToPtr("spec.cluster_type must be one of 'CLUSTER_TYPE_CONTROL_PLANE_GROUP', 'CLUSTER_TYPE_CONTROL_PLANE' or 'CLUSTER_TYPE_K8S_INGRESS_CONTROLLER'"),
 			},
 			{
 				Name: "CLUSTER_TYPE_SERVERLESS is not supported",
@@ -653,7 +612,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 							Name:        "cp-1",
-							ClusterType: sdkkonnectcomp.ClusterTypeClusterTypeServerless.ToPointer(),
+							ClusterType: sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeServerless.ToPointer(),
 						},
 						KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
 							APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
@@ -671,7 +630,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 							Name:        "cp-1",
-							ClusterType: sdkkonnectcomp.ClusterType("CLUSTER_TYPE_CUSTOM").ToPointer(),
+							ClusterType: sdkkonnectcomp.CreateControlPlaneRequestClusterType("CLUSTER_TYPE_CUSTOM").ToPointer(),
 						},
 						KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
 							APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
@@ -698,7 +657,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 					},
 				},
 				Update: func(cp *konnectv1alpha1.KonnectGatewayControlPlane) {
-					cp.Spec.ClusterType = sdkkonnectcomp.ClusterTypeClusterTypeControlPlaneGroup.ToPointer()
+					cp.Spec.ClusterType = sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup.ToPointer()
 				},
 				ExpectedUpdateErrorMessage: lo.ToPtr("spec.cluster_type is immutable"),
 			},
@@ -709,7 +668,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
 						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
 							Name:        "cp-1",
-							ClusterType: sdkkonnectcomp.ClusterTypeClusterTypeControlPlane.ToPointer(),
+							ClusterType: sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeControlPlane.ToPointer(),
 						},
 						KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
 							APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump to https://github.com/Kong/sdk-konnect-go/releases/tag/v0.1.2

This release removes HYBRID CP type: https://github.com/Kong/platform-api/pull/767