### PR TITLE
feat: add more plugin annotation funcs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/kubernetes-configuration
 
-go 1.22.4
+go 1.23.2
 
 require (
 	github.com/Kong/sdk-konnect-go v0.1.5

--- a/pkg/metadata/plugins.go
+++ b/pkg/metadata/plugins.go
@@ -1,7 +1,6 @@
 package metadata
 
 import (
-	"iter"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -25,32 +24,6 @@ func ExtractPluginsWithNamespaces(obj ObjectWithAnnotationsAndNamespace) []strin
 // annotation set to "p1,p2" this will return []string{"p1", "p2"}
 func ExtractPlugins(obj ObjectWithAnnotationsAndNamespace) []string {
 	return extractPlugins(obj, nsOptWithoutNamespace)
-}
-
-// ExtractPluginsWithNamespacesIter extracts plugin namespaced names from the given object's
-// konghq.com/plugins annotation.
-// This function trims the whitespace from the plugin names.
-// The return value is a an iterator.
-//
-// For example, for KongConsumer in namespace default, having the "konghq.com/plugins"
-// annotation set to "p1,p2" this will return an iterator over
-// - "default/p1"
-// - "default/p2"
-func ExtractPluginsWithNamespacesIter(obj ObjectWithAnnotationsAndNamespace) iter.Seq[string] {
-	return extractPluginsIter(obj, nsOptWithNamespace)
-}
-
-// ExtractPluginsIter extracts plugin names from the given object's
-// konghq.com/plugins annotation.
-// This function trims the whitespace from the plugin names.
-// The return value is a an iterator.
-//
-// For example, for KongConsumer having the "konghq.com/plugins"
-// annotation set to "p1,p2" this will return an iterator over
-// - "p1"
-// - "p2"
-func ExtractPluginsIter(obj ObjectWithAnnotationsAndNamespace) iter.Seq[string] {
-	return extractPluginsIter(obj, nsOptWithoutNamespace)
 }
 
 // ExtractPluginsNamespacedNames extracts plugin namespaced names from the given object's
@@ -97,52 +70,6 @@ func ExtractPluginsNamespacedNames(obj ObjectWithAnnotationsAndNamespace) []type
 	return plugins
 }
 
-// ExtractPluginsNamespacedNamesIter extracts plugin namespaced names from the given object's
-// konghq.com/plugins annotation.  Plugins can optionally specify the namespace using the
-// "<namespace>:<plugin-name>" format.
-// This function trims the whitespace from the plugin names.
-// The return value is a an iterator.
-//
-// For example, for an object having the "konghq.com/plugins" annotation set to "default:p1,p2"
-// this will return an iterator over
-// - types.NamespacedName{Namespace: "default", Name: "p1"}
-// - types.NamespacedName{Namespace: "", Name: "p2"}
-func ExtractPluginsNamespacedNamesIter(obj ObjectWithAnnotationsAndNamespace) iter.Seq[types.NamespacedName] {
-	return func(yield func(nn types.NamespacedName) bool) {
-		// NOTE: We're not returning a nil iterator above this func definition,
-		// as that would make the range loop over it panic.
-		// This comes at a small cost in performance but makes the iterator
-		// more robust and easier to work with.
-		if obj == nil {
-			return
-		}
-		iter := extractPluginsIter(obj, nsOptWithoutNamespace)
-		if iter == nil {
-			return
-		}
-
-		for p := range iter {
-			nn := types.NamespacedName{
-				Name: p,
-			}
-
-			idx := strings.Index(p, ":")
-			if idx == len(p)-1 || idx == 0 {
-				// invalid plugin name or namespace
-				continue
-			}
-
-			if idx != -1 {
-				nn.Namespace = strings.TrimSpace(p[:idx])
-				nn.Name = strings.TrimSpace(p[idx+1:])
-			}
-			if !yield(nn) {
-				return
-			}
-		}
-	}
-}
-
 type extractPluginsNamespaceOpt byte
 
 const (
@@ -177,54 +104,4 @@ func extractPlugins(obj ObjectWithAnnotationsAndNamespace, nsOpt extractPluginsN
 		ret = append(ret, v)
 	}
 	return ret
-}
-
-func extractPluginsIter(obj ObjectWithAnnotationsAndNamespace, nsOpt extractPluginsNamespaceOpt) iter.Seq[string] {
-	return func(yield func(string) bool) {
-		// NOTE: We're not returning a nil iterator above this func definition,
-		// as that would make the range loop over it panic.
-		// This comes at a small cost in performance but makes the iterator
-		// more robust and easier to work with.
-		if obj == nil {
-			return
-		}
-
-		ann, ok := obj.GetAnnotations()[AnnotationKeyPlugins]
-		if !ok || len(ann) == 0 {
-			return
-		}
-
-		namespace := obj.GetNamespace()
-
-		for {
-			if len(ann) == 0 {
-				return
-			}
-
-			i := strings.IndexByte(ann, ',')
-
-			v := ann
-			if i != -1 {
-				v = ann[0:i]
-				ann = ann[i+1:]
-			} else {
-				ann = ""
-			}
-
-			trimmed := strings.TrimSpace(v)
-			// Filter out white space only strings.
-			if trimmed == "" {
-				continue
-			}
-
-			ret := trimmed
-			if nsOpt == nsOptWithNamespace {
-				ret = namespace + "/" + trimmed
-			}
-
-			if !yield(ret) {
-				return
-			}
-		}
-	}
 }

--- a/pkg/metadata/plugins.go
+++ b/pkg/metadata/plugins.go
@@ -1,7 +1,10 @@
 package metadata
 
 import (
+	"iter"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // ExtractPluginsWithNamespaces extracts plugin namespaced names from the given object's
@@ -11,22 +14,7 @@ import (
 // For example, for KongConsumer in namespace default, having the "konghq.com/plugins"
 // annotation set to "p1,p2" this will return []string{"default/p1", "default/p2"}
 func ExtractPluginsWithNamespaces(obj ObjectWithAnnotationsAndNamespace) []string {
-	ann, ok := obj.GetAnnotations()[AnnotationKeyPlugins]
-	if !ok || len(ann) == 0 {
-		return nil
-	}
-
-	namespace := obj.GetNamespace()
-	split := strings.Split(ann, ",")
-	ret := make([]string, 0, len(split))
-	for _, p := range split {
-		trimmed := strings.TrimSpace(p)
-		if trimmed == "" {
-			continue
-		}
-		ret = append(ret, namespace+"/"+trimmed)
-	}
-	return ret
+	return extractPlugins(obj, nsOptWithNamespace)
 }
 
 // ExtractPlugins extracts plugin names from the given object's
@@ -35,11 +23,144 @@ func ExtractPluginsWithNamespaces(obj ObjectWithAnnotationsAndNamespace) []strin
 //
 // For example, for KongConsumer in namespace default, having the "konghq.com/plugins"
 // annotation set to "p1,p2" this will return []string{"p1", "p2"}
-func ExtractPlugins(obj ObjectWithAnnotations) []string {
+func ExtractPlugins(obj ObjectWithAnnotationsAndNamespace) []string {
+	return extractPlugins(obj, nsOptWithoutNamespace)
+}
+
+// ExtractPluginsWithNamespacesIter extracts plugin namespaced names from the given object's
+// konghq.com/plugins annotation.
+// This function trims the whitespace from the plugin names.
+// The return value is a an iterator.
+//
+// For example, for KongConsumer in namespace default, having the "konghq.com/plugins"
+// annotation set to "p1,p2" this will return an iterator over
+// - "default/p1"
+// - "default/p2"
+func ExtractPluginsWithNamespacesIter(obj ObjectWithAnnotationsAndNamespace) iter.Seq[string] {
+	return extractPluginsIter(obj, nsOptWithNamespace)
+}
+
+// ExtractPluginsIter extracts plugin names from the given object's
+// konghq.com/plugins annotation.
+// This function trims the whitespace from the plugin names.
+// The return value is a an iterator.
+//
+// For example, for KongConsumer having the "konghq.com/plugins"
+// annotation set to "p1,p2" this will return an iterator over
+// - "p1"
+// - "p2"
+func ExtractPluginsIter(obj ObjectWithAnnotationsAndNamespace) iter.Seq[string] {
+	return extractPluginsIter(obj, nsOptWithoutNamespace)
+}
+
+// ExtractPluginsNamespacedNames extracts plugin namespaced names from the given object's
+// konghq.com/plugins annotation. Plugins can optionally specify the namespace using the
+// "<namespace>:<plugin-name>" format.
+// This function trims the whitespace from the plugin names.
+//
+// For example, for an object having the "konghq.com/plugins" annotation set to "default:p1,p2"
+// this will return:
+//
+//	 []types.NamespacedName{
+//			types.NamespacedName{Namespace: "default", Name: "p1"},
+//			types.NamespacedName{Namespace: "", Name: "p2"},
+//		}
+func ExtractPluginsNamespacedNames(obj ObjectWithAnnotationsAndNamespace) []types.NamespacedName {
 	ann, ok := obj.GetAnnotations()[AnnotationKeyPlugins]
 	if !ok || len(ann) == 0 {
 		return nil
 	}
+
+	split := strings.Split(ann, ",")
+	plugins := make([]types.NamespacedName, 0, len(split))
+	for _, s := range split {
+		if strings.TrimSpace(s) == "" {
+			continue
+		}
+
+		plugin := types.NamespacedName{}
+
+		idxColon := strings.Index(s, ":")
+		if idxColon == len(s)-1 || idxColon == 0 {
+			// invalid plugin name or namespace
+			continue
+		}
+
+		if idxColon != -1 {
+			plugin.Namespace = strings.TrimSpace(s[0:idxColon])
+			plugin.Name = strings.TrimSpace(s[idxColon+1:])
+		} else {
+			plugin.Name = strings.TrimSpace(s)
+		}
+		plugins = append(plugins, plugin)
+	}
+	return plugins
+}
+
+// ExtractPluginsNamespacedNamesIter extracts plugin namespaced names from the given object's
+// konghq.com/plugins annotation.  Plugins can optionally specify the namespace using the
+// "<namespace>:<plugin-name>" format.
+// This function trims the whitespace from the plugin names.
+// The return value is a an iterator.
+//
+// For example, for an object having the "konghq.com/plugins" annotation set to "default:p1,p2"
+// this will return an iterator over
+// - types.NamespacedName{Namespace: "default", Name: "p1"}
+// - types.NamespacedName{Namespace: "", Name: "p2"}
+func ExtractPluginsNamespacedNamesIter(obj ObjectWithAnnotationsAndNamespace) iter.Seq[types.NamespacedName] {
+	return func(yield func(nn types.NamespacedName) bool) {
+		// NOTE: We're not returning a nil iterator above this func definition,
+		// as that would make the range loop over it panic.
+		// This comes at a small cost in performance but makes the iterator
+		// more robust and easier to work with.
+		if obj == nil {
+			return
+		}
+		iter := extractPluginsIter(obj, nsOptWithoutNamespace)
+		if iter == nil {
+			return
+		}
+
+		for p := range iter {
+			nn := types.NamespacedName{
+				Name: p,
+			}
+
+			idx := strings.Index(p, ":")
+			if idx == len(p)-1 || idx == 0 {
+				// invalid plugin name or namespace
+				continue
+			}
+
+			if idx != -1 {
+				nn.Namespace = strings.TrimSpace(p[:idx])
+				nn.Name = strings.TrimSpace(p[idx+1:])
+			}
+			if !yield(nn) {
+				return
+			}
+		}
+	}
+}
+
+type extractPluginsNamespaceOpt byte
+
+const (
+	nsOptWithNamespace extractPluginsNamespaceOpt = iota
+	nsOptWithoutNamespace
+)
+
+func extractPlugins(obj ObjectWithAnnotationsAndNamespace, nsOpt extractPluginsNamespaceOpt) []string {
+	if obj == nil {
+		return nil
+	}
+
+	ann, ok := obj.GetAnnotations()[AnnotationKeyPlugins]
+	if !ok || len(ann) == 0 {
+		return nil
+	}
+
+	namespace := obj.GetNamespace()
 
 	split := strings.Split(ann, ",")
 	ret := make([]string, 0, len(split))
@@ -48,7 +169,62 @@ func ExtractPlugins(obj ObjectWithAnnotations) []string {
 		if trimmed == "" {
 			continue
 		}
-		ret = append(ret, trimmed)
+
+		v := trimmed
+		if nsOpt == nsOptWithNamespace {
+			v = namespace + "/" + trimmed
+		}
+		ret = append(ret, v)
 	}
 	return ret
+}
+
+func extractPluginsIter(obj ObjectWithAnnotationsAndNamespace, nsOpt extractPluginsNamespaceOpt) iter.Seq[string] {
+	return func(yield func(string) bool) {
+		// NOTE: We're not returning a nil iterator above this func definition,
+		// as that would make the range loop over it panic.
+		// This comes at a small cost in performance but makes the iterator
+		// more robust and easier to work with.
+		if obj == nil {
+			return
+		}
+
+		ann, ok := obj.GetAnnotations()[AnnotationKeyPlugins]
+		if !ok || len(ann) == 0 {
+			return
+		}
+
+		namespace := obj.GetNamespace()
+
+		for {
+			if len(ann) == 0 {
+				return
+			}
+
+			i := strings.IndexByte(ann, ',')
+
+			v := ann
+			if i != -1 {
+				v = ann[0:i]
+				ann = ann[i+1:]
+			} else {
+				ann = ""
+			}
+
+			trimmed := strings.TrimSpace(v)
+			// Filter out white space only strings.
+			if trimmed == "" {
+				continue
+			}
+
+			ret := trimmed
+			if nsOpt == nsOptWithNamespace {
+				ret = namespace + "/" + trimmed
+			}
+
+			if !yield(ret) {
+				return
+			}
+		}
+	}
 }

--- a/pkg/metadata/plugins_test.go
+++ b/pkg/metadata/plugins_test.go
@@ -1,9 +1,16 @@
 package metadata
 
 import (
+	"fmt"
+	"iter"
+	"slices"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 type mockObject struct {
@@ -25,6 +32,14 @@ func TestExtractPluginsWithNamespace(t *testing.T) {
 		obj      *mockObject
 		expected []string
 	}{
+		{
+			name: "nil annotations",
+			obj: &mockObject{
+				annotations: nil,
+				namespace:   "default",
+			},
+			expected: nil,
+		},
 		{
 			name: "no annotations",
 			obj: &mockObject{
@@ -113,12 +128,495 @@ func TestExtractPluginsWithNamespace(t *testing.T) {
 	}
 }
 
+func TestExtractPluginsWithNamespaceIter(t *testing.T) {
+	tests := []struct {
+		name     string
+		obj      *mockObject
+		expected []string
+	}{
+		{
+			name: "nil annotations",
+			obj: &mockObject{
+				annotations: nil,
+				namespace:   "default",
+			},
+			expected: nil,
+		},
+		{
+			name: "no annotations",
+			obj: &mockObject{
+				annotations: map[string]string{},
+				namespace:   "default",
+			},
+			expected: nil,
+		},
+		{
+			name: "single plugin",
+			obj: &mockObject{
+				annotations: map[string]string{
+					AnnotationKeyPlugins: "plugin1",
+				},
+				namespace: "default",
+			},
+			expected: []string{"default/plugin1"},
+		},
+		{
+			name: "multiple plugins",
+			obj: &mockObject{
+				annotations: map[string]string{
+					AnnotationKeyPlugins: "plugin1,plugin2,plugin3",
+				},
+				namespace: "default",
+			},
+			expected: []string{"default/plugin1", "default/plugin2", "default/plugin3"},
+		},
+		{
+			name: "empty plugin name gets filtered out",
+			obj: &mockObject{
+				annotations: map[string]string{
+					AnnotationKeyPlugins: "plugin1,,plugin3",
+				},
+				namespace: "default",
+			},
+			expected: []string{"default/plugin1", "default/plugin3"},
+		},
+		{
+			name: "plugins with spaces",
+			obj: &mockObject{
+				annotations: map[string]string{
+					AnnotationKeyPlugins: " plugin1 , plugin2 , plugin3 ",
+				},
+				namespace: "default",
+			},
+			expected: []string{"default/plugin1", "default/plugin2", "default/plugin3"},
+		},
+		{
+			name: "different namespace",
+			obj: &mockObject{
+				annotations: map[string]string{
+					AnnotationKeyPlugins: "plugin1,plugin2",
+				},
+				namespace: "custom",
+			},
+			expected: []string{"custom/plugin1", "custom/plugin2"},
+		},
+		{
+			name: "empty names are ignored",
+			obj: &mockObject{
+				annotations: map[string]string{
+					AnnotationKeyPlugins: "plugin1,",
+				},
+				namespace: "custom",
+			},
+			expected: []string{"custom/plugin1"},
+		},
+		{
+			name: "whitespaces are ignored",
+			obj: &mockObject{
+				annotations: map[string]string{
+					AnnotationKeyPlugins: "plugin1, ",
+				},
+				namespace: "custom",
+			},
+			expected: []string{"custom/plugin1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ExtractPluginsWithNamespacesIter(tt.obj)
+
+			require.NotNil(t, result)
+			assert.Equal(t, tt.expected, slices.Collect(result))
+		})
+	}
+}
+
+func TestExtractPluginsNamespacedNames(t *testing.T) {
+	tests := []struct {
+		name     string
+		obj      *mockObject
+		expected []types.NamespacedName
+	}{
+		{
+			name:     "no annotations",
+			obj:      &mockObject{},
+			expected: nil,
+		},
+		{
+			name: "single plugin",
+			obj: &mockObject{
+				annotations: map[string]string{
+					AnnotationKeyPlugins: "plugin1",
+				},
+			},
+			expected: []types.NamespacedName{
+				{
+					Name: "plugin1",
+				},
+			},
+		},
+		{
+			name: "multiple plugins",
+			obj: &mockObject{
+				annotations: map[string]string{
+					AnnotationKeyPlugins: "plugin1,plugin2,plugin3",
+				},
+			},
+			expected: []types.NamespacedName{
+				{
+					Name: "plugin1",
+				},
+				{
+					Name: "plugin2",
+				},
+				{
+					Name: "plugin3",
+				},
+			},
+		},
+		{
+			name: "empty plugin name gets filtered out",
+			obj: &mockObject{
+				annotations: map[string]string{
+					AnnotationKeyPlugins: "plugin1,,plugin3",
+				},
+			},
+			expected: []types.NamespacedName{
+				{
+					Name: "plugin1",
+				},
+				{
+					Name: "plugin3",
+				},
+			},
+		},
+		{
+			name: "plugins with spaces",
+			obj: &mockObject{
+				annotations: map[string]string{
+					AnnotationKeyPlugins: " plugin1 , plugin2 , plugin3 ",
+				},
+			},
+			expected: []types.NamespacedName{
+				{
+					Name: "plugin1",
+				},
+				{
+					Name: "plugin2",
+				},
+				{
+					Name: "plugin3",
+				},
+			},
+		},
+		{
+			name: "different namespace",
+			obj: &mockObject{
+				annotations: map[string]string{
+					AnnotationKeyPlugins: "custom:plugin1,plugin2",
+				},
+			},
+			expected: []types.NamespacedName{
+				{
+					Namespace: "custom",
+					Name:      "plugin1",
+				},
+				{
+					Name: "plugin2",
+				},
+			},
+		},
+		{
+			name: "empty names are ignored",
+			obj: &mockObject{
+				annotations: map[string]string{
+					AnnotationKeyPlugins: "plugin1,",
+				},
+			},
+			expected: []types.NamespacedName{
+				{
+					Name: "plugin1",
+				},
+			},
+		},
+		{
+			name: "empty names are ignored",
+			obj: &mockObject{
+				annotations: map[string]string{
+					AnnotationKeyPlugins: "kong:plugin1,",
+				},
+			},
+			expected: []types.NamespacedName{
+				{
+					Namespace: "kong",
+					Name:      "plugin1",
+				},
+			},
+		},
+		{
+			name: "whitespaces are ignored",
+			obj: &mockObject{
+				annotations: map[string]string{
+					AnnotationKeyPlugins: "plugin1, ",
+				},
+			},
+			expected: []types.NamespacedName{
+				{
+					Name: "plugin1",
+				},
+			},
+		},
+		{
+			name: "mixed",
+			obj: &mockObject{
+				annotations: map[string]string{
+					AnnotationKeyPlugins: "kong:plugin1,plugin2",
+				},
+				namespace: "custom",
+			},
+			expected: []types.NamespacedName{
+				{
+					Namespace: "kong",
+					Name:      "plugin1",
+				},
+				{
+					Name: "plugin2",
+				},
+			},
+		},
+		{
+			name: "invalid namespaced plugin",
+			obj: &mockObject{
+				annotations: map[string]string{
+					AnnotationKeyPlugins: "kong:",
+				},
+			},
+			expected: []types.NamespacedName{},
+		},
+		{
+			name: "invalid namespaced plugin",
+			obj: &mockObject{
+				annotations: map[string]string{
+					AnnotationKeyPlugins: ":plugin1",
+				},
+			},
+			expected: []types.NamespacedName{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ExtractPluginsNamespacedNames(tt.obj)
+
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExtractPluginsNamespacedNamesIter(t *testing.T) {
+	tests := []struct {
+		name     string
+		obj      *mockObject
+		expected []types.NamespacedName
+	}{
+		{
+			name: "nil annotations",
+			obj: &mockObject{
+				annotations: map[string]string{},
+			},
+			expected: nil,
+		},
+		{
+			name:     "no annotations",
+			obj:      &mockObject{},
+			expected: nil,
+		},
+		{
+			name: "single plugin",
+			obj: &mockObject{
+				annotations: map[string]string{
+					AnnotationKeyPlugins: "plugin1",
+				},
+			},
+			expected: []types.NamespacedName{
+				{
+					Name: "plugin1",
+				},
+			},
+		},
+		{
+			name: "multiple plugins",
+			obj: &mockObject{
+				annotations: map[string]string{
+					AnnotationKeyPlugins: "plugin1,plugin2,plugin3",
+				},
+			},
+			expected: []types.NamespacedName{
+				{
+					Name: "plugin1",
+				},
+				{
+					Name: "plugin2",
+				},
+				{
+					Name: "plugin3",
+				},
+			},
+		},
+		{
+			name: "empty plugin name gets filtered out",
+			obj: &mockObject{
+				annotations: map[string]string{
+					AnnotationKeyPlugins: "plugin1,,plugin3",
+				},
+			},
+			expected: []types.NamespacedName{
+				{
+					Name: "plugin1",
+				},
+				{
+					Name: "plugin3",
+				},
+			},
+		},
+		{
+			name: "plugins with spaces",
+			obj: &mockObject{
+				annotations: map[string]string{
+					AnnotationKeyPlugins: " plugin1 , plugin2 , plugin3 ",
+				},
+			},
+			expected: []types.NamespacedName{
+				{
+					Name: "plugin1",
+				},
+				{
+					Name: "plugin2",
+				},
+				{
+					Name: "plugin3",
+				},
+			},
+		},
+		{
+			name: "different namespace",
+			obj: &mockObject{
+				annotations: map[string]string{
+					AnnotationKeyPlugins: "custom:plugin1,plugin2",
+				},
+			},
+			expected: []types.NamespacedName{
+				{
+					Namespace: "custom",
+					Name:      "plugin1",
+				},
+				{
+					Name: "plugin2",
+				},
+			},
+		},
+		{
+			name: "empty names are ignored",
+			obj: &mockObject{
+				annotations: map[string]string{
+					AnnotationKeyPlugins: "plugin1,",
+				},
+			},
+			expected: []types.NamespacedName{
+				{
+					Name: "plugin1",
+				},
+			},
+		},
+		{
+			name: "empty names are ignored",
+			obj: &mockObject{
+				annotations: map[string]string{
+					AnnotationKeyPlugins: "kong:plugin1,",
+				},
+			},
+			expected: []types.NamespacedName{
+				{
+					Namespace: "kong",
+					Name:      "plugin1",
+				},
+			},
+		},
+		{
+			name: "whitespaces are ignored",
+			obj: &mockObject{
+				annotations: map[string]string{
+					AnnotationKeyPlugins: "plugin1, ",
+				},
+			},
+			expected: []types.NamespacedName{
+				{
+					Name: "plugin1",
+				},
+			},
+		},
+		{
+			name: "mixed",
+			obj: &mockObject{
+				annotations: map[string]string{
+					AnnotationKeyPlugins: "kong:plugin1,plugin2",
+				},
+				namespace: "custom",
+			},
+			expected: []types.NamespacedName{
+				{
+					Namespace: "kong",
+					Name:      "plugin1",
+				},
+				{
+					Name: "plugin2",
+				},
+			},
+		},
+		{
+			name: "invalid namespaced plugin",
+			obj: &mockObject{
+				annotations: map[string]string{
+					AnnotationKeyPlugins: "kong:",
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "invalid namespaced plugin",
+			obj: &mockObject{
+				annotations: map[string]string{
+					AnnotationKeyPlugins: ":plugin1",
+				},
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ExtractPluginsNamespacedNamesIter(tt.obj)
+
+			require.NotNil(t, result)
+			assert.Equal(t, tt.expected, slices.Collect(result))
+		})
+	}
+}
+
 func TestExtractPlugins(t *testing.T) {
 	tests := []struct {
 		name     string
 		obj      *mockObject
 		expected []string
 	}{
+		{
+			name: "nil annotations",
+			obj: &mockObject{
+				annotations: nil,
+			},
+			expected: nil,
+		},
 		{
 			name: "no annotations",
 			obj: &mockObject{
@@ -204,6 +702,100 @@ func TestExtractPlugins(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := ExtractPlugins(tt.obj)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func objectWithNPluginsForBenchmark(n int) ObjectWithAnnotationsAndNamespace {
+	obj := &mockObject{
+		annotations: map[string]string{},
+		namespace:   "custom",
+	}
+
+	plugins := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		plugins = append(plugins, "plugin"+strconv.Itoa(i))
+	}
+	obj.annotations[AnnotationKeyPlugins] = strings.Join(plugins, ",")
+	return obj
+}
+
+func consumeIter[
+	T iter.Seq[R],
+	R any,
+](
+	t T,
+) {
+	for v := range t {
+		_ = v
+	}
+}
+
+func consumeSlice[
+	T ~[]R,
+	R any,
+](
+	t T,
+) {
+	for _, v := range t {
+		_ = v
+	}
+}
+
+func BenchmarkTestExtractPlugins(b *testing.B) {
+	benchmarkSlice(b, ExtractPlugins)
+}
+
+func BenchmarkTestExtractPluginsIter(b *testing.B) {
+	benchmarkIter(b, ExtractPluginsIter)
+}
+
+func BenchmarkTestExtractPluginsWithNamespaces(b *testing.B) {
+	benchmarkSlice(b, ExtractPluginsWithNamespaces)
+}
+
+func BenchmarkTestExtractPluginsWithNamespacesIter(b *testing.B) {
+	benchmarkIter(b, ExtractPluginsWithNamespacesIter)
+}
+
+func BenchmarkTestExtractPluginsNamespacedNames(b *testing.B) {
+	benchmarkSlice(b, ExtractPluginsNamespacedNames)
+}
+
+func BenchmarkTestExtractPluginsNamespacedNamesIter(b *testing.B) {
+	benchmarkIter(b, ExtractPluginsNamespacedNamesIter)
+}
+
+func benchmarkPluginCountTestcases() []int {
+	return []int{0, 1, 2, 3, 4, 5, 10, 32}
+}
+
+func benchmarkSlice[
+	T any,
+](b *testing.B, f func(ObjectWithAnnotationsAndNamespace) []T) {
+	for _, tc := range benchmarkPluginCountTestcases() {
+		obj := objectWithNPluginsForBenchmark(tc)
+
+		b.Run(fmt.Sprintf("%04d", tc), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				ret := f(obj)
+				consumeSlice(ret)
+			}
+		})
+	}
+}
+
+func benchmarkIter[
+	T any,
+](b *testing.B, f func(ObjectWithAnnotationsAndNamespace) iter.Seq[T]) {
+	for _, tc := range benchmarkPluginCountTestcases() {
+		obj := objectWithNPluginsForBenchmark(tc)
+
+		b.Run(fmt.Sprintf("%04d", tc), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				ret := f(obj)
+				consumeIter(ret)
+			}
 		})
 	}
 }

--- a/pkg/metadata/plugins_test.go
+++ b/pkg/metadata/plugins_test.go
@@ -2,14 +2,11 @@ package metadata
 
 import (
 	"fmt"
-	"iter"
-	"slices"
 	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -124,110 +121,6 @@ func TestExtractPluginsWithNamespace(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := ExtractPluginsWithNamespaces(tt.obj)
 			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func TestExtractPluginsWithNamespaceIter(t *testing.T) {
-	tests := []struct {
-		name     string
-		obj      *mockObject
-		expected []string
-	}{
-		{
-			name: "nil annotations",
-			obj: &mockObject{
-				annotations: nil,
-				namespace:   "default",
-			},
-			expected: nil,
-		},
-		{
-			name: "no annotations",
-			obj: &mockObject{
-				annotations: map[string]string{},
-				namespace:   "default",
-			},
-			expected: nil,
-		},
-		{
-			name: "single plugin",
-			obj: &mockObject{
-				annotations: map[string]string{
-					AnnotationKeyPlugins: "plugin1",
-				},
-				namespace: "default",
-			},
-			expected: []string{"default/plugin1"},
-		},
-		{
-			name: "multiple plugins",
-			obj: &mockObject{
-				annotations: map[string]string{
-					AnnotationKeyPlugins: "plugin1,plugin2,plugin3",
-				},
-				namespace: "default",
-			},
-			expected: []string{"default/plugin1", "default/plugin2", "default/plugin3"},
-		},
-		{
-			name: "empty plugin name gets filtered out",
-			obj: &mockObject{
-				annotations: map[string]string{
-					AnnotationKeyPlugins: "plugin1,,plugin3",
-				},
-				namespace: "default",
-			},
-			expected: []string{"default/plugin1", "default/plugin3"},
-		},
-		{
-			name: "plugins with spaces",
-			obj: &mockObject{
-				annotations: map[string]string{
-					AnnotationKeyPlugins: " plugin1 , plugin2 , plugin3 ",
-				},
-				namespace: "default",
-			},
-			expected: []string{"default/plugin1", "default/plugin2", "default/plugin3"},
-		},
-		{
-			name: "different namespace",
-			obj: &mockObject{
-				annotations: map[string]string{
-					AnnotationKeyPlugins: "plugin1,plugin2",
-				},
-				namespace: "custom",
-			},
-			expected: []string{"custom/plugin1", "custom/plugin2"},
-		},
-		{
-			name: "empty names are ignored",
-			obj: &mockObject{
-				annotations: map[string]string{
-					AnnotationKeyPlugins: "plugin1,",
-				},
-				namespace: "custom",
-			},
-			expected: []string{"custom/plugin1"},
-		},
-		{
-			name: "whitespaces are ignored",
-			obj: &mockObject{
-				annotations: map[string]string{
-					AnnotationKeyPlugins: "plugin1, ",
-				},
-				namespace: "custom",
-			},
-			expected: []string{"custom/plugin1"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := ExtractPluginsWithNamespacesIter(tt.obj)
-
-			require.NotNil(t, result)
-			assert.Equal(t, tt.expected, slices.Collect(result))
 		})
 	}
 }
@@ -414,196 +307,6 @@ func TestExtractPluginsNamespacedNames(t *testing.T) {
 	}
 }
 
-func TestExtractPluginsNamespacedNamesIter(t *testing.T) {
-	tests := []struct {
-		name     string
-		obj      *mockObject
-		expected []types.NamespacedName
-	}{
-		{
-			name: "nil annotations",
-			obj: &mockObject{
-				annotations: map[string]string{},
-			},
-			expected: nil,
-		},
-		{
-			name:     "no annotations",
-			obj:      &mockObject{},
-			expected: nil,
-		},
-		{
-			name: "single plugin",
-			obj: &mockObject{
-				annotations: map[string]string{
-					AnnotationKeyPlugins: "plugin1",
-				},
-			},
-			expected: []types.NamespacedName{
-				{
-					Name: "plugin1",
-				},
-			},
-		},
-		{
-			name: "multiple plugins",
-			obj: &mockObject{
-				annotations: map[string]string{
-					AnnotationKeyPlugins: "plugin1,plugin2,plugin3",
-				},
-			},
-			expected: []types.NamespacedName{
-				{
-					Name: "plugin1",
-				},
-				{
-					Name: "plugin2",
-				},
-				{
-					Name: "plugin3",
-				},
-			},
-		},
-		{
-			name: "empty plugin name gets filtered out",
-			obj: &mockObject{
-				annotations: map[string]string{
-					AnnotationKeyPlugins: "plugin1,,plugin3",
-				},
-			},
-			expected: []types.NamespacedName{
-				{
-					Name: "plugin1",
-				},
-				{
-					Name: "plugin3",
-				},
-			},
-		},
-		{
-			name: "plugins with spaces",
-			obj: &mockObject{
-				annotations: map[string]string{
-					AnnotationKeyPlugins: " plugin1 , plugin2 , plugin3 ",
-				},
-			},
-			expected: []types.NamespacedName{
-				{
-					Name: "plugin1",
-				},
-				{
-					Name: "plugin2",
-				},
-				{
-					Name: "plugin3",
-				},
-			},
-		},
-		{
-			name: "different namespace",
-			obj: &mockObject{
-				annotations: map[string]string{
-					AnnotationKeyPlugins: "custom:plugin1,plugin2",
-				},
-			},
-			expected: []types.NamespacedName{
-				{
-					Namespace: "custom",
-					Name:      "plugin1",
-				},
-				{
-					Name: "plugin2",
-				},
-			},
-		},
-		{
-			name: "empty names are ignored",
-			obj: &mockObject{
-				annotations: map[string]string{
-					AnnotationKeyPlugins: "plugin1,",
-				},
-			},
-			expected: []types.NamespacedName{
-				{
-					Name: "plugin1",
-				},
-			},
-		},
-		{
-			name: "empty names are ignored",
-			obj: &mockObject{
-				annotations: map[string]string{
-					AnnotationKeyPlugins: "kong:plugin1,",
-				},
-			},
-			expected: []types.NamespacedName{
-				{
-					Namespace: "kong",
-					Name:      "plugin1",
-				},
-			},
-		},
-		{
-			name: "whitespaces are ignored",
-			obj: &mockObject{
-				annotations: map[string]string{
-					AnnotationKeyPlugins: "plugin1, ",
-				},
-			},
-			expected: []types.NamespacedName{
-				{
-					Name: "plugin1",
-				},
-			},
-		},
-		{
-			name: "mixed",
-			obj: &mockObject{
-				annotations: map[string]string{
-					AnnotationKeyPlugins: "kong:plugin1,plugin2",
-				},
-				namespace: "custom",
-			},
-			expected: []types.NamespacedName{
-				{
-					Namespace: "kong",
-					Name:      "plugin1",
-				},
-				{
-					Name: "plugin2",
-				},
-			},
-		},
-		{
-			name: "invalid namespaced plugin",
-			obj: &mockObject{
-				annotations: map[string]string{
-					AnnotationKeyPlugins: "kong:",
-				},
-			},
-			expected: nil,
-		},
-		{
-			name: "invalid namespaced plugin",
-			obj: &mockObject{
-				annotations: map[string]string{
-					AnnotationKeyPlugins: ":plugin1",
-				},
-			},
-			expected: nil,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := ExtractPluginsNamespacedNamesIter(tt.obj)
-
-			require.NotNil(t, result)
-			assert.Equal(t, tt.expected, slices.Collect(result))
-		})
-	}
-}
-
 func TestExtractPlugins(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -720,17 +423,6 @@ func objectWithNPluginsForBenchmark(n int) ObjectWithAnnotationsAndNamespace {
 	return obj
 }
 
-func consumeIter[
-	T iter.Seq[R],
-	R any,
-](
-	t T,
-) {
-	for v := range t {
-		_ = v
-	}
-}
-
 func consumeSlice[
 	T ~[]R,
 	R any,
@@ -742,28 +434,16 @@ func consumeSlice[
 	}
 }
 
-func BenchmarkTestExtractPlugins(b *testing.B) {
+func BenchmarkExtractPlugins(b *testing.B) {
 	benchmarkSlice(b, ExtractPlugins)
 }
 
-func BenchmarkTestExtractPluginsIter(b *testing.B) {
-	benchmarkIter(b, ExtractPluginsIter)
-}
-
-func BenchmarkTestExtractPluginsWithNamespaces(b *testing.B) {
+func BenchmarkExtractPluginsWithNamespaces(b *testing.B) {
 	benchmarkSlice(b, ExtractPluginsWithNamespaces)
 }
 
-func BenchmarkTestExtractPluginsWithNamespacesIter(b *testing.B) {
-	benchmarkIter(b, ExtractPluginsWithNamespacesIter)
-}
-
-func BenchmarkTestExtractPluginsNamespacedNames(b *testing.B) {
+func BenchmarkExtractPluginsNamespacedNames(b *testing.B) {
 	benchmarkSlice(b, ExtractPluginsNamespacedNames)
-}
-
-func BenchmarkTestExtractPluginsNamespacedNamesIter(b *testing.B) {
-	benchmarkIter(b, ExtractPluginsNamespacedNamesIter)
 }
 
 func benchmarkPluginCountTestcases() []int {
@@ -780,21 +460,6 @@ func benchmarkSlice[
 			for i := 0; i < b.N; i++ {
 				ret := f(obj)
 				consumeSlice(ret)
-			}
-		})
-	}
-}
-
-func benchmarkIter[
-	T any,
-](b *testing.B, f func(ObjectWithAnnotationsAndNamespace) iter.Seq[T]) {
-	for _, tc := range benchmarkPluginCountTestcases() {
-		obj := objectWithNPluginsForBenchmark(tc)
-
-		b.Run(fmt.Sprintf("%04d", tc), func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				ret := f(obj)
-				consumeIter(ret)
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a couple of handful funcs for interacting with objects' plugins through annotations:

```
func ExtractPlugins(obj ObjectWithAnnotationsAndNamespace) []string
func ExtractPluginsNamespacedNames(obj ObjectWithAnnotationsAndNamespace) []types.NamespacedName
func ExtractPluginsWithNamespaces(obj ObjectWithAnnotationsAndNamespace) []string
```

Results from added benchmarks:

```
$go test -benchmem -bench . -run ^$ -count 1  ./pkg/metadata
goos: darwin
goarch: arm64
pkg: github.com/kong/kubernetes-configuration/pkg/metadata
cpu: Apple M1 Max
BenchmarkTestExtractPlugins/0000-10                     236752966                4.776 ns/op           0 B/op          0 allocs/op
BenchmarkTestExtractPlugins/0001-10                     21764281                56.85 ns/op           32 B/op          2 allocs/op
BenchmarkTestExtractPlugins/0002-10                     16161171                73.78 ns/op           64 B/op          2 allocs/op
BenchmarkTestExtractPlugins/0003-10                     12783318                91.04 ns/op           96 B/op          2 allocs/op
BenchmarkTestExtractPlugins/0004-10                     10236519               112.7 ns/op           128 B/op          2 allocs/op
BenchmarkTestExtractPlugins/0005-10                      8836104               134.7 ns/op           160 B/op          2 allocs/op
BenchmarkTestExtractPlugins/0010-10                      4625467               259.5 ns/op           320 B/op          2 allocs/op
BenchmarkTestExtractPlugins/0032-10                      1633317               735.7 ns/op          1024 B/op          2 allocs/op
BenchmarkTestExtractPluginsWithNamespaces/0000-10               252518941                4.789 ns/op           0 B/op          0 allocs/op
BenchmarkTestExtractPluginsWithNamespaces/0001-10               14501283                81.82 ns/op           48 B/op          3 allocs/op
BenchmarkTestExtractPluginsWithNamespaces/0002-10                9608586               122.8 ns/op            96 B/op          4 allocs/op
BenchmarkTestExtractPluginsWithNamespaces/0003-10                6794275               174.3 ns/op           144 B/op          5 allocs/op
BenchmarkTestExtractPluginsWithNamespaces/0004-10                5497418               220.5 ns/op           192 B/op          6 allocs/op
BenchmarkTestExtractPluginsWithNamespaces/0005-10                4473290               267.3 ns/op           240 B/op          7 allocs/op
BenchmarkTestExtractPluginsWithNamespaces/0010-10                2349792               509.3 ns/op           480 B/op         12 allocs/op
BenchmarkTestExtractPluginsWithNamespaces/0032-10                 730315              1569 ns/op            1536 B/op         34 allocs/op
BenchmarkTestExtractPluginsNamespacedNames/0000-10              290015607                4.133 ns/op           0 B/op          0 allocs/op
BenchmarkTestExtractPluginsNamespacedNames/0001-10              18579889                63.00 ns/op           48 B/op          2 allocs/op
BenchmarkTestExtractPluginsNamespacedNames/0002-10              13824366                85.67 ns/op           96 B/op          2 allocs/op
BenchmarkTestExtractPluginsNamespacedNames/0003-10              10668835               116.8 ns/op           144 B/op          2 allocs/op
BenchmarkTestExtractPluginsNamespacedNames/0004-10               7131752               149.0 ns/op           192 B/op          2 allocs/op
BenchmarkTestExtractPluginsNamespacedNames/0005-10               6887876               171.7 ns/op           240 B/op          2 allocs/op
BenchmarkTestExtractPluginsNamespacedNames/0010-10               3150312               387.0 ns/op           480 B/op          2 allocs/op
BenchmarkTestExtractPluginsNamespacedNames/0032-10               1000000              1082 ns/op            1664 B/op          2 allocs/op
PASS
ok      github.com/kong/kubernetes-configuration/pkg/metadata   35.093s
```