### PR TITLE
fix: allow updating KongVault with empty CP ref

### DIFF
--- a/api/configuration/v1alpha1/kong_vault_types.go
+++ b/api/configuration/v1alpha1/kong_vault_types.go
@@ -47,7 +47,7 @@ const (
 // +kubebuilder:printcolumn:name="Programmed",type=string,JSONPath=`.status.conditions[?(@.type=="Programmed")].status`
 // +kubebuilder:validation:XValidation:rule="self.spec.prefix == oldSelf.spec.prefix", message="The spec.prefix field is immutable"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
-// +kubebuilder:validation:XValidation:rule="(!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
+// +kubebuilder:validation:XValidation:rule="(!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True') || !has(self.spec.controlPlaneRef)) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 // +apireference:kgo:include
 // +apireference:kic:include
 type KongVault struct {

--- a/config/crd/bases/configuration.konghq.com_kongvaults.yaml
+++ b/config/crd/bases/configuration.konghq.com_kongvaults.yaml
@@ -271,8 +271,8 @@ spec:
           rule: '!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)'
         - message: spec.controlPlaneRef is immutable when an entity is already Programmed
           rule: '(!has(self.status) || !self.status.conditions.exists(c, c.type ==
-            ''Programmed'' && c.status == ''True'')) ? true : oldSelf.spec.controlPlaneRef
-            == self.spec.controlPlaneRef'
+            ''Programmed'' && c.status == ''True'') || !has(self.spec.controlPlaneRef))
+            ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef'
     served: true
     storage: true
     subresources:


### PR DESCRIPTION
**What this PR does / why we need it**:

`KongVault`'s CEL validation prevents updates of an object without a CP ref set due to reference to a non-existing field. This PR fixes the validation rule to that into account.

```console
KongVault.configuration.konghq.com "test-2lqs2" is invalid: <nil>: Invalid value: "object": no such key: controlPlaneRef evaluating rule: spec.controlPlaneRef is immutable when an entity is already Programmed
```

**Which issue this PR fixes**

Part of https://github.com/Kong/kubernetes-ingress-controller/issues/6578.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
