### PR TITLE
chore: add apireference:kic:include for KongLicense and KongCustomEntity

### DIFF
--- a/api/configuration/v1alpha1/kong_custom_entity_types.go
+++ b/api/configuration/v1alpha1/kong_custom_entity_types.go
@@ -13,6 +13,8 @@ const (
 // KongEntityScope defines the scope of the Kong entity.
 type KongEntityScope string
 
+// KongCustomEntity defines a "custom" Kong entity that KIC cannot support the entity type directly.
+//
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
@@ -24,8 +26,7 @@ type KongEntityScope string
 // +kubebuilder:printcolumn:name="Programmed",type=string,JSONPath=`.status.conditions[?(@.type=="Programmed")].status`
 // +kubebuilder:validation:XValidation:rule="self.spec.type == oldSelf.spec.type",message="The spec.type field is immutable"
 // +kubebuilder:validation:XValidation:rule="!(self.spec.type in ['services','routes','upstreams','targets','plugins','consumers','consumer_groups'])",message="The spec.type field cannot be known Kong entity types"
-
-// KongCustomEntity defines a "custom" Kong entity that KIC cannot support the entity type directly.
+// +apireference:kic:include
 type KongCustomEntity struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/configuration/v1alpha1/kong_license_types.go
+++ b/api/configuration/v1alpha1/kong_license_types.go
@@ -15,6 +15,7 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age"
 // +kubebuilder:printcolumn:name="Enabled",type=boolean,JSONPath=`.enabled`,description="Enabled to configure on Kong gateway instances"
+// +apireference:kic:include
 // +apireference:kgo:include
 type KongLicense struct {
 	metav1.TypeMeta   `json:",inline"`


### PR DESCRIPTION
**What this PR does / why we need it**:
Add `apireference:kic:include` in `KongLicense` and `KongCustomEntity` to make them appear in KIC's CRD apidoc.
**Which issue this PR fixes**

Part of #149 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
