### PR TITLE
Add apireference:kic:include marker for KongServiceFacade

### DIFF
--- a/api/incubator/v1alpha1/kongservicefacade_types.go
+++ b/api/incubator/v1alpha1/kongservicefacade_types.go
@@ -29,6 +29,7 @@ func init() {
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // +kong:channels=ingress-controller-incubator
+// +apireference:kic:include
 type KongServiceFacade struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -38,6 +39,7 @@ type KongServiceFacade struct {
 
 // KongServiceFacadeList contains a list of KongServiceFacade.
 // +kubebuilder:object:root=true
+// +apireference:kic:include
 type KongServiceFacadeList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
@@ -45,6 +47,7 @@ type KongServiceFacadeList struct {
 }
 
 // KongServiceFacadeSpec defines the desired state of KongServiceFacade.
+// +apireference:kic:include
 type KongServiceFacadeSpec struct {
 	// Backend is a reference to a Kubernetes Service that is used as a backend
 	// for this Kong Service Facade.
@@ -54,6 +57,7 @@ type KongServiceFacadeSpec struct {
 
 // KongServiceFacadeBackend is a reference to a Kubernetes Service
 // that is used as a backend for a Kong Service Facade.
+// +apireference:kic:include
 type KongServiceFacadeBackend struct {
 	// Name is the name of the referenced Kubernetes Service.
 	// +kubebuilder:validation:Required
@@ -65,6 +69,7 @@ type KongServiceFacadeBackend struct {
 }
 
 // KongServiceFacadeStatus defines the observed state of KongServiceFacade.
+// +apireference:kic:include
 type KongServiceFacadeStatus struct {
 	// Conditions describe the current conditions of the KongServiceFacade.
 	//


### PR DESCRIPTION
**What this PR does / why we need it**:
Add  `apireference:kic:include` marker for `KongServiceFacade` to make the `crd-ref-gen` to recognize it and generate docs for it. 
**Which issue this PR fixes**

Required for https://github.com/Kong/kubernetes-ingress-controller/pull/6627.

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
