### PR TITLE
feat: do not allow kic ControlPlane ref type for types unsupported by KIC

### DIFF
--- a/api/configuration/v1alpha1/kong_ca_certificate.go
+++ b/api/configuration/v1alpha1/kong_ca_certificate.go
@@ -32,10 +32,13 @@ type KongCACertificate struct {
 }
 
 // KongCACertificateSpec contains the specification for the KongCACertificate.
+// +kubebuilder:validation:XValidation:rule="!has(self.controlPlaneRef) ? true : self.controlPlaneRef.type != 'kic'", message="KIC is not supported as control plane"
 // +apireference:kgo:include
 type KongCACertificateSpec struct {
 	// ControlPlaneRef references the Konnect Control Plane that this KongCACertificate should be created in.
-	ControlPlaneRef          *ControlPlaneRef `json:"controlPlaneRef,omitempty"`
+	// +kubebuilder:validation:Required
+	ControlPlaneRef *ControlPlaneRef `json:"controlPlaneRef"`
+
 	KongCACertificateAPISpec `json:",inline"`
 }
 

--- a/api/configuration/v1alpha1/kong_certificate.go
+++ b/api/configuration/v1alpha1/kong_certificate.go
@@ -32,10 +32,13 @@ type KongCertificate struct {
 }
 
 // KongCertificateSpec contains the specification for the KongCertificate.
+// +kubebuilder:validation:XValidation:rule="!has(self.controlPlaneRef) ? true : self.controlPlaneRef.type != 'kic'", message="KIC is not supported as control plane"
 // +apireference:kgo:include
 type KongCertificateSpec struct {
 	// ControlPlaneRef references the Konnect Control Plane that this KongCertificate should be created in.
-	ControlPlaneRef        *ControlPlaneRef `json:"controlPlaneRef,omitempty"`
+	// +kubebuilder:validation:Required
+	ControlPlaneRef *ControlPlaneRef `json:"controlPlaneRef"`
+
 	KongCertificateAPISpec `json:",inline"`
 }
 

--- a/api/configuration/v1alpha1/kong_target_types.go
+++ b/api/configuration/v1alpha1/kong_target_types.go
@@ -44,8 +44,7 @@ type KongTarget struct {
 	Status KongTargetStatus `json:"status,omitempty"`
 }
 
-// KongTargetSpec defines the specification of a Kong Target.
-// KongTargetSpec defines the desired state of KongTarget.
+// KongTargetSpec defines the spec of KongTarget.
 // +apireference:kgo:include
 type KongTargetSpec struct {
 	// UpstreamRef is a reference to a KongUpstream this KongTarget is attached to.

--- a/api/configuration/v1alpha1/kongdataplaneclientcertificate_types.go
+++ b/api/configuration/v1alpha1/kongdataplaneclientcertificate_types.go
@@ -48,11 +48,12 @@ type KongDataPlaneClientCertificate struct {
 }
 
 // KongDataPlaneClientCertificateSpec defines the spec for a KongDataPlaneClientCertificate.
+// +kubebuilder:validation:XValidation:rule="!has(self.controlPlaneRef) ? true : self.controlPlaneRef.type != 'kic'", message="KIC is not supported as control plane"
 // +apireference:kgo:include
 type KongDataPlaneClientCertificateSpec struct {
 	// ControlPlaneRef is a reference to a Konnect ControlPlane this KongDataPlaneClientCertificate is associated with.
-	// +optional
-	ControlPlaneRef *ControlPlaneRef `json:"controlPlaneRef,omitempty"`
+	// +kubebuilder:validation:Required
+	ControlPlaneRef *ControlPlaneRef `json:"controlPlaneRef"`
 
 	// KongDataPlaneClientCertificateAPISpec are the attributes of the KongDataPlaneClientCertificate itself.
 	KongDataPlaneClientCertificateAPISpec `json:",inline"`

--- a/api/configuration/v1alpha1/kongkey_types.go
+++ b/api/configuration/v1alpha1/kongkey_types.go
@@ -48,6 +48,7 @@ type KongKey struct {
 }
 
 // KongKeySpec defines the spec for a KongKey.
+// +kubebuilder:validation:XValidation:rule="!has(self.controlPlaneRef) ? true : self.controlPlaneRef.type != 'kic'", message="KIC is not supported as control plane"
 // +apireference:kgo:include
 type KongKeySpec struct {
 	// ControlPlaneRef is a reference to a Konnect ControlPlane this KongKey is associated with.

--- a/api/configuration/v1alpha1/kongkeyset_types.go
+++ b/api/configuration/v1alpha1/kongkeyset_types.go
@@ -47,11 +47,12 @@ type KongKeySet struct {
 }
 
 // KongKeySetSpec defines the spec for a KongKeySet.
+// +kubebuilder:validation:XValidation:rule="!has(self.controlPlaneRef) ? true : self.controlPlaneRef.type != 'kic'", message="KIC is not supported as control plane"
 // +apireference:kgo:include
 type KongKeySetSpec struct {
 	// ControlPlaneRef is a reference to a Konnect ControlPlane with which KongKeySet is associated.
-	// +optional
-	ControlPlaneRef *ControlPlaneRef `json:"controlPlaneRef,omitempty"`
+	// +kubebuilder:validation:Required
+	ControlPlaneRef *ControlPlaneRef `json:"controlPlaneRef"`
 
 	// KongKeySetAPISpec are the attributes of the KongKeySet itself.
 	KongKeySetAPISpec `json:",inline"`

--- a/api/configuration/v1alpha1/kongroute_types.go
+++ b/api/configuration/v1alpha1/kongroute_types.go
@@ -39,7 +39,7 @@ import (
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.serviceRef) || has(self.spec.serviceRef)", message="serviceRef is required once set"
 // +kubebuilder:validation:XValidation:rule="has(self.spec.protocols) && self.spec.protocols.exists(p, p == 'http') ? (has(self.spec.hosts) || has(self.spec.methods) || has(self.spec.paths) || has(self.spec.paths) || has(self.spec.paths) || has(self.spec.headers) ) : true", message="If protocols has 'http', at least one of 'hosts', 'methods', 'paths' or 'headers' must be set"
-// +kubebuilder:validation:XValidation:rule="!has(self.spec.controlPlaneRef) && !has(self.spec.serviceRef) || has(self.spec.controlPlaneRef) && !has(self.spec.serviceRef) || !has(self.spec.controlPlaneRef) && has(self.spec.serviceRef)", message="Cannot set both controlPlaneRef or serviceRef at the same time"
+// +kubebuilder:validation:XValidation:rule="has(self.spec.controlPlaneRef) && !has(self.spec.serviceRef) || !has(self.spec.controlPlaneRef) && has(self.spec.serviceRef)", message="Has to set either controlPlaneRef or serviceRef"
 // +kubebuilder:validation:XValidation:rule="(!has(self.spec.controlPlaneRef) || !has(self.spec.controlPlaneRef.konnectNamespacedRef)) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
 // +kubebuilder:validation:XValidation:rule="!has(self.spec.serviceRef) ? true : (!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.serviceRef == self.spec.serviceRef", message="spec.serviceRef is immutable when an entity is already Programmed"
 // +kubebuilder:validation:XValidation:rule="!has(self.spec.controlPlaneRef) ? true :(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
@@ -55,7 +55,8 @@ type KongRoute struct {
 	Status KongRouteStatus `json:"status,omitempty"`
 }
 
-// KongRouteSpec defines specification of a Kong Route.
+// KongRouteSpec defines spec of a Kong Route.
+// +kubebuilder:validation:XValidation:rule="!has(self.controlPlaneRef) ? true : self.controlPlaneRef.type != 'kic'", message="KIC is not supported as control plane"
 // +apireference:kgo:include
 type KongRouteSpec struct {
 	// ControlPlaneRef is a reference to a ControlPlane this KongRoute is associated with.

--- a/api/configuration/v1alpha1/kongservice_types.go
+++ b/api/configuration/v1alpha1/kongservice_types.go
@@ -52,16 +52,17 @@ type KongService struct {
 }
 
 // KongServiceSpec defines specification of a Kong Route.
+// +kubebuilder:validation:XValidation:rule="!has(self.controlPlaneRef) ? true : self.controlPlaneRef.type != 'kic'", message="KIC is not supported as control plane"
 // +apireference:kgo:include
 type KongServiceSpec struct {
 	// ControlPlaneRef is a reference to a ControlPlane this KongService is associated with.
-	// +optional
-	ControlPlaneRef *ControlPlaneRef `json:"controlPlaneRef,omitempty"`
+	// +kubebuilder:validation:Required
+	ControlPlaneRef *ControlPlaneRef `json:"controlPlaneRef"`
 
 	KongServiceAPISpec `json:",inline"`
 }
 
-// KongServiceAPISpec defines specification of a Kong Service.
+// KongServiceAPISpec defines the specification of a Kong Service.
 // +apireference:kgo:include
 type KongServiceAPISpec struct {
 	// TODO(pmalek): client certificate implement ref

--- a/api/configuration/v1alpha1/kongsni_types.go
+++ b/api/configuration/v1alpha1/kongsni_types.go
@@ -45,7 +45,7 @@ type KongSNI struct {
 	Status KongSNIStatus `json:"status,omitempty"`
 }
 
-// KongSNIAPISpec defines specification of an SNI.
+// KongSNIAPISpec defines the spec of an SNI.
 // +apireference:kgo:include
 type KongSNIAPISpec struct {
 	// Name is the name of the SNI. Required and must be a host or wildcard host.

--- a/api/configuration/v1alpha1/kongupstream_types.go
+++ b/api/configuration/v1alpha1/kongupstream_types.go
@@ -49,12 +49,13 @@ type KongUpstream struct {
 	Status KongUpstreamStatus `json:"status,omitempty"`
 }
 
-// KongUpstreamSpec defines specification of a Kong Upstream.
+// KongUpstreamSpec defines the spec of Kong Upstream.
+// +kubebuilder:validation:XValidation:rule="!has(self.controlPlaneRef) ? true : self.controlPlaneRef.type != 'kic'", message="KIC is not supported as control plane"
 // +apireference:kgo:include
 type KongUpstreamSpec struct {
 	// ControlPlaneRef is a reference to a ControlPlane this KongUpstream is associated with.
-	// +optional
-	ControlPlaneRef *ControlPlaneRef `json:"controlPlaneRef,omitempty"`
+	// +kubebuilder:validation:Required
+	ControlPlaneRef *ControlPlaneRef `json:"controlPlaneRef"`
 
 	KongUpstreamAPISpec `json:",inline"`
 }

--- a/config/crd/gateway-operator/configuration.konghq.com_kongcacertificates.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongcacertificates.yaml
@@ -127,7 +127,12 @@ spec:
                   rule: self.all(tag, size(tag) >= 1 && size(tag) <= 128)
             required:
             - cert
+            - controlPlaneRef
             type: object
+            x-kubernetes-validations:
+            - message: KIC is not supported as control plane
+              rule: '!has(self.controlPlaneRef) ? true : self.controlPlaneRef.type
+                != ''kic'''
           status:
             default:
               conditions:

--- a/config/crd/gateway-operator/configuration.konghq.com_kongcertificates.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongcertificates.yaml
@@ -143,8 +143,13 @@ spec:
                   rule: self.all(tag, size(tag) >= 1 && size(tag) <= 128)
             required:
             - cert
+            - controlPlaneRef
             - key
             type: object
+            x-kubernetes-validations:
+            - message: KIC is not supported as control plane
+              rule: '!has(self.controlPlaneRef) ? true : self.controlPlaneRef.type
+                != ''kic'''
           status:
             default:
               conditions:

--- a/config/crd/gateway-operator/configuration.konghq.com_kongdataplaneclientcertificates.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongdataplaneclientcertificates.yaml
@@ -120,7 +120,12 @@ spec:
                   rule: '!has(self.type) ? !has(self.konnectNamespacedRef) : true'
             required:
             - cert
+            - controlPlaneRef
             type: object
+            x-kubernetes-validations:
+            - message: KIC is not supported as control plane
+              rule: '!has(self.controlPlaneRef) ? true : self.controlPlaneRef.type
+                != ''kic'''
           status:
             default:
               conditions:

--- a/config/crd/gateway-operator/configuration.konghq.com_kongkeys.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongkeys.yaml
@@ -199,6 +199,9 @@ spec:
             - kid
             type: object
             x-kubernetes-validations:
+            - message: KIC is not supported as control plane
+              rule: '!has(self.controlPlaneRef) ? true : self.controlPlaneRef.type
+                != ''kic'''
             - message: Either 'jwk' or 'pem' must be set
               rule: has(self.jwk) || has(self.pem)
           status:

--- a/config/crd/gateway-operator/configuration.konghq.com_kongkeysets.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongkeysets.yaml
@@ -127,8 +127,13 @@ spec:
                 - message: tags entries must not be longer than 128 characters
                   rule: self.all(tag, size(tag) >= 1 && size(tag) <= 128)
             required:
+            - controlPlaneRef
             - name
             type: object
+            x-kubernetes-validations:
+            - message: KIC is not supported as control plane
+              rule: '!has(self.controlPlaneRef) ? true : self.controlPlaneRef.type
+                != ''kic'''
           status:
             default:
               conditions:

--- a/config/crd/gateway-operator/configuration.konghq.com_kongroutes.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongroutes.yaml
@@ -42,7 +42,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: KongRouteSpec defines specification of a Kong Route.
+            description: KongRouteSpec defines spec of a Kong Route.
             properties:
               controlPlaneRef:
                 description: |-
@@ -266,6 +266,10 @@ spec:
                 - message: tags entries must not be longer than 128 characters
                   rule: self.all(tag, size(tag) >= 1 && size(tag) <= 128)
             type: object
+            x-kubernetes-validations:
+            - message: KIC is not supported as control plane
+              rule: '!has(self.controlPlaneRef) ? true : self.controlPlaneRef.type
+                != ''kic'''
           status:
             default:
               conditions:
@@ -377,10 +381,9 @@ spec:
             ? (has(self.spec.hosts) || has(self.spec.methods) || has(self.spec.paths)
             || has(self.spec.paths) || has(self.spec.paths) || has(self.spec.headers)
             ) : true'
-        - message: Cannot set both controlPlaneRef or serviceRef at the same time
-          rule: '!has(self.spec.controlPlaneRef) && !has(self.spec.serviceRef) ||
-            has(self.spec.controlPlaneRef) && !has(self.spec.serviceRef) || !has(self.spec.controlPlaneRef)
-            && has(self.spec.serviceRef)'
+        - message: Has to set either controlPlaneRef or serviceRef
+          rule: has(self.spec.controlPlaneRef) && !has(self.spec.serviceRef) || !has(self.spec.controlPlaneRef)
+            && has(self.spec.serviceRef)
         - message: spec.controlPlaneRef cannot specify namespace for namespaced resource
           rule: '(!has(self.spec.controlPlaneRef) || !has(self.spec.controlPlaneRef.konnectNamespacedRef))
             ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'

--- a/config/crd/gateway-operator/configuration.konghq.com_kongservices.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongservices.yaml
@@ -185,8 +185,13 @@ spec:
                 format: int64
                 type: integer
             required:
+            - controlPlaneRef
             - host
             type: object
+            x-kubernetes-validations:
+            - message: KIC is not supported as control plane
+              rule: '!has(self.controlPlaneRef) ? true : self.controlPlaneRef.type
+                != ''kic'''
           status:
             default:
               conditions:

--- a/config/crd/gateway-operator/configuration.konghq.com_kongtargets.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongtargets.yaml
@@ -43,9 +43,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: |-
-              KongTargetSpec defines the specification of a Kong Target.
-              KongTargetSpec defines the desired state of KongTarget.
+            description: KongTargetSpec defines the spec of KongTarget.
             properties:
               tags:
                 description: Tags is an optional set of strings associated with the

--- a/config/crd/gateway-operator/configuration.konghq.com_kongupstreams.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongupstreams.yaml
@@ -43,7 +43,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: KongUpstreamSpec defines specification of a Kong Upstream.
+            description: KongUpstreamSpec defines the spec of Kong Upstream.
             properties:
               algorithm:
                 description: Which load balancing algorithm to use.
@@ -288,8 +288,13 @@ spec:
                 description: If set, the balancer will use SRV hostname(if DNS Answer
                   has SRV record) as the proxy upstream `Host`.
                 type: boolean
+            required:
+            - controlPlaneRef
             type: object
             x-kubernetes-validations:
+            - message: KIC is not supported as control plane
+              rule: '!has(self.controlPlaneRef) ? true : self.controlPlaneRef.type
+                != ''kic'''
             - message: hash_fallback_header is required when `hash_fallback` is set
                 to `header`.
               rule: '!has(self.hash_fallback) || (self.hash_fallback != ''header''

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1314,7 +1314,7 @@ _Appears in:_
 #### KongRouteSpec
 
 
-KongRouteSpec defines specification of a Kong Route.
+KongRouteSpec defines spec of a Kong Route.
 
 
 
@@ -1349,7 +1349,7 @@ _Appears in:_
 #### KongSNIAPISpec
 
 
-KongSNIAPISpec defines specification of an SNI.
+KongSNIAPISpec defines the spec of an SNI.
 
 
 
@@ -1384,7 +1384,7 @@ _Appears in:_
 #### KongServiceAPISpec
 
 
-KongServiceAPISpec defines specification of a Kong Service.
+KongServiceAPISpec defines the specification of a Kong Service.
 
 
 
@@ -1460,8 +1460,7 @@ _Appears in:_
 #### KongTargetSpec
 
 
-KongTargetSpec defines the specification of a Kong Target.
-KongTargetSpec defines the desired state of KongTarget.
+KongTargetSpec defines the spec of KongTarget.
 
 
 
@@ -1513,7 +1512,7 @@ _Appears in:_
 #### KongUpstreamSpec
 
 
-KongUpstreamSpec defines specification of a Kong Upstream.
+KongUpstreamSpec defines the spec of Kong Upstream.
 
 
 

--- a/scripts/crds-generator/main.go
+++ b/scripts/crds-generator/main.go
@@ -162,7 +162,7 @@ type ChannelsMarker []string
 
 // ApplyToCRD applies the channels marker to the given CRD by adding the channels annotation.
 // It implements the Marker interface.
-func (m ChannelsMarker) ApplyToCRD(crd *apiext.CustomResourceDefinition, _ string) error { // nolint:unparam
+func (m ChannelsMarker) ApplyToCRD(crd *apiext.CustomResourceDefinition, _ string) error { //nolint:unparam
 	if crd.Annotations == nil {
 		crd.Annotations = map[string]string{}
 	}

--- a/test/crdsvalidation/kongcacertificate_test.go
+++ b/test/crdsvalidation/kongcacertificate_test.go
@@ -45,6 +45,6 @@ func TestKongCACertificate(t *testing.T) {
 			},
 		}
 
-		NewCRDValidationTestCasesGroupCPRefChange(t, obj).Run(t)
+		NewCRDValidationTestCasesGroupCPRefChange(t, obj, NotSupportedByKIC).Run(t)
 	})
 }

--- a/test/crdsvalidation/kongcertificate_test.go
+++ b/test/crdsvalidation/kongcertificate_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 
 	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestKongCertificate(t *testing.T) {
@@ -26,7 +26,7 @@ func TestKongCertificate(t *testing.T) {
 			},
 		}
 
-		NewCRDValidationTestCasesGroupCPRefChange(t, obj).Run(t)
+		NewCRDValidationTestCasesGroupCPRefChange(t, obj, NotSupportedByKIC).Run(t)
 	})
 
 	t.Run("required fields", func(t *testing.T) {

--- a/test/crdsvalidation/kongconsumer_test.go
+++ b/test/crdsvalidation/kongconsumer_test.go
@@ -22,7 +22,7 @@ func TestKongConsumer(t *testing.T) {
 			Username:   "username-1",
 		}
 
-		NewCRDValidationTestCasesGroupCPRefChange(t, obj).Run(t)
+		NewCRDValidationTestCasesGroupCPRefChange(t, obj, SupportedByKIC).Run(t)
 	})
 
 	t.Run("required fields", func(t *testing.T) {

--- a/test/crdsvalidation/kongconsumergroup_test.go
+++ b/test/crdsvalidation/kongconsumergroup_test.go
@@ -25,7 +25,7 @@ func TestKongConsumerGroup(t *testing.T) {
 			},
 		}
 
-		NewCRDValidationTestCasesGroupCPRefChange(t, obj).Run(t)
+		NewCRDValidationTestCasesGroupCPRefChange(t, obj, NotSupportedByKIC).Run(t)
 	})
 
 	t.Run("cp ref update", func(t *testing.T) {

--- a/test/crdsvalidation/kongdataplaneclientcertificate_test.go
+++ b/test/crdsvalidation/kongdataplaneclientcertificate_test.go
@@ -10,21 +10,25 @@ import (
 )
 
 func TestKongDataPlaneClientCertificate(t *testing.T) {
-	t.Run("cp ref", func(t *testing.T) {
-		obj := &configurationv1alpha1.KongDataPlaneClientCertificate{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "KongDataPlaneClientCertificate",
-				APIVersion: configurationv1alpha1.GroupVersion.String(),
+	obj := &configurationv1alpha1.KongDataPlaneClientCertificate{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KongDataPlaneClientCertificate",
+			APIVersion: configurationv1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: commonObjectMeta,
+		Spec: configurationv1alpha1.KongDataPlaneClientCertificateSpec{
+			KongDataPlaneClientCertificateAPISpec: configurationv1alpha1.KongDataPlaneClientCertificateAPISpec{
+				Cert: "cert",
 			},
-			ObjectMeta: commonObjectMeta,
-			Spec: configurationv1alpha1.KongDataPlaneClientCertificateSpec{
-				KongDataPlaneClientCertificateAPISpec: configurationv1alpha1.KongDataPlaneClientCertificateAPISpec{
-					Cert: "cert",
-				},
-			},
-		}
+		},
+	}
 
-		NewCRDValidationTestCasesGroupCPRefChange(t, obj).Run(t)
+	t.Run("cp ref", func(t *testing.T) {
+		NewCRDValidationTestCasesGroupCPRefChange(t, obj, NotSupportedByKIC).Run(t)
+	})
+
+	t.Run("cp ref, type=kic", func(t *testing.T) {
+		NewCRDValidationTestCasesGroupCPRefChangeKICUnsupportedTypes(t, obj, EmptyControlPlaneRefNotAllowed).Run(t)
 	})
 
 	t.Run("spec", func(t *testing.T) {
@@ -36,6 +40,12 @@ func TestKongDataPlaneClientCertificate(t *testing.T) {
 					Spec: configurationv1alpha1.KongDataPlaneClientCertificateSpec{
 						KongDataPlaneClientCertificateAPISpec: configurationv1alpha1.KongDataPlaneClientCertificateAPISpec{
 							Cert: "cert",
+						},
+						ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &configurationv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
 						},
 					},
 				},
@@ -54,6 +64,12 @@ func TestKongDataPlaneClientCertificate(t *testing.T) {
 					Spec: configurationv1alpha1.KongDataPlaneClientCertificateSpec{
 						KongDataPlaneClientCertificateAPISpec: configurationv1alpha1.KongDataPlaneClientCertificateAPISpec{
 							Cert: "cert",
+						},
+						ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &configurationv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
 						},
 					},
 					Status: configurationv1alpha1.KongDataPlaneClientCertificateStatus{
@@ -78,6 +94,12 @@ func TestKongDataPlaneClientCertificate(t *testing.T) {
 					Spec: configurationv1alpha1.KongDataPlaneClientCertificateSpec{
 						KongDataPlaneClientCertificateAPISpec: configurationv1alpha1.KongDataPlaneClientCertificateAPISpec{
 							Cert: "cert",
+						},
+						ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &configurationv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
 						},
 					},
 					Status: configurationv1alpha1.KongDataPlaneClientCertificateStatus{

--- a/test/crdsvalidation/kongkey_test.go
+++ b/test/crdsvalidation/kongkey_test.go
@@ -26,8 +26,9 @@ func TestKongKey(t *testing.T) {
 			},
 		}
 
-		NewCRDValidationTestCasesGroupCPRefChange(t, obj).Run(t)
+		NewCRDValidationTestCasesGroupCPRefChange(t, obj, NotSupportedByKIC).Run(t)
 	})
+
 	t.Run("pem/cp ref", func(t *testing.T) {
 		obj := &configurationv1alpha1.KongKey{
 			TypeMeta: metav1.TypeMeta{
@@ -46,7 +47,27 @@ func TestKongKey(t *testing.T) {
 			},
 		}
 
-		NewCRDValidationTestCasesGroupCPRefChange(t, obj).Run(t)
+		NewCRDValidationTestCasesGroupCPRefChange(t, obj, NotSupportedByKIC).Run(t)
+	})
+
+	t.Run("pem/cp ref, type=kic", func(t *testing.T) {
+		obj := &configurationv1alpha1.KongKey{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "KongKey",
+				APIVersion: configurationv1alpha1.GroupVersion.String(),
+			},
+			ObjectMeta: commonObjectMeta,
+			Spec: configurationv1alpha1.KongKeySpec{
+				KongKeyAPISpec: configurationv1alpha1.KongKeyAPISpec{
+					KID: "1",
+					PEM: &configurationv1alpha1.PEMKeyPair{
+						PublicKey:  "public",
+						PrivateKey: "private",
+					},
+				},
+			},
+		}
+		NewCRDValidationTestCasesGroupCPRefChangeKICUnsupportedTypes(t, obj, EmptyControlPlaneRefAllowed).Run(t)
 	})
 
 	t.Run("spec", func(t *testing.T) {
@@ -59,6 +80,12 @@ func TestKongKey(t *testing.T) {
 						KongKeyAPISpec: configurationv1alpha1.KongKeyAPISpec{
 							JWK: lo.ToPtr("{}"),
 						},
+						ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &configurationv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
 					},
 				},
 				ExpectedErrorMessage: lo.ToPtr("spec.kid in body should be at least 1 chars long"),
@@ -70,6 +97,12 @@ func TestKongKey(t *testing.T) {
 					Spec: configurationv1alpha1.KongKeySpec{
 						KongKeyAPISpec: configurationv1alpha1.KongKeyAPISpec{
 							KID: "1",
+						},
+						ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &configurationv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
 						},
 					},
 				},

--- a/test/crdsvalidation/kongkeyset_test.go
+++ b/test/crdsvalidation/kongkeyset_test.go
@@ -11,21 +11,25 @@ import (
 )
 
 func TestKongKeySet(t *testing.T) {
-	t.Run("cp ref", func(t *testing.T) {
-		obj := &configurationv1alpha1.KongKeySet{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "KongKeySet",
-				APIVersion: configurationv1alpha1.GroupVersion.String(),
+	obj := &configurationv1alpha1.KongKeySet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KongKeySet",
+			APIVersion: configurationv1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: commonObjectMeta,
+		Spec: configurationv1alpha1.KongKeySetSpec{
+			KongKeySetAPISpec: configurationv1alpha1.KongKeySetAPISpec{
+				Name: "keyset",
 			},
-			ObjectMeta: commonObjectMeta,
-			Spec: configurationv1alpha1.KongKeySetSpec{
-				KongKeySetAPISpec: configurationv1alpha1.KongKeySetAPISpec{
-					Name: "keyset",
-				},
-			},
-		}
+		},
+	}
 
-		NewCRDValidationTestCasesGroupCPRefChange(t, obj).Run(t)
+	t.Run("cp ref", func(t *testing.T) {
+		NewCRDValidationTestCasesGroupCPRefChange(t, obj, NotSupportedByKIC).Run(t)
+	})
+
+	t.Run("cp ref, type=kic", func(t *testing.T) {
+		NewCRDValidationTestCasesGroupCPRefChangeKICUnsupportedTypes(t, obj, EmptyControlPlaneRefNotAllowed).Run(t)
 	})
 
 	t.Run("spec", func(t *testing.T) {

--- a/test/crdsvalidation/kongpluginbindings_test.go
+++ b/test/crdsvalidation/kongpluginbindings_test.go
@@ -31,7 +31,7 @@ func TestKongPluginBindings(t *testing.T) {
 			},
 		}
 
-		NewCRDValidationTestCasesGroupCPRefChange(t, obj).Run(t)
+		NewCRDValidationTestCasesGroupCPRefChange(t, obj, NotSupportedByKIC).Run(t)
 	})
 
 	t.Run("plugin ref", func(t *testing.T) {

--- a/test/crdsvalidation/kongroute_test.go
+++ b/test/crdsvalidation/kongroute_test.go
@@ -13,16 +13,22 @@ import (
 )
 
 func TestKongRoute(t *testing.T) {
-	t.Run("cp ref", func(t *testing.T) {
-		obj := &configurationv1alpha1.KongRoute{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "KongRoute",
-				APIVersion: configurationv1alpha1.GroupVersion.String(),
-			},
-			ObjectMeta: commonObjectMeta,
-		}
+	obj := &configurationv1alpha1.KongRoute{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KongRoute",
+			APIVersion: configurationv1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: commonObjectMeta,
+	}
 
-		NewCRDValidationTestCasesGroupCPRefChange(t, obj).Run(t)
+	t.Run("cp ref", func(t *testing.T) {
+		NewCRDValidationTestCasesGroupCPRefChange(t, obj, NotSupportedByKIC).Run(t)
+	})
+
+	t.Run("cp ref, type=kic", func(t *testing.T) {
+		// NOTE: empty cp ref is not allowed in this context because a route can be attached to a service
+		// but this test doesn't check that.
+		NewCRDValidationTestCasesGroupCPRefChangeKICUnsupportedTypes(t, obj, EmptyControlPlaneRefNotAllowed).Run(t)
 	})
 
 	t.Run("protocols", func(t *testing.T) {

--- a/test/crdsvalidation/kongroute_test.go
+++ b/test/crdsvalidation/kongroute_test.go
@@ -83,6 +83,23 @@ func TestKongRoute(t *testing.T) {
 		}.Run(t)
 	})
 
+	t.Run("no service ref and no cp ref provided", func(t *testing.T) {
+		CRDValidationTestCasesGroup[*configurationv1alpha1.KongRoute]{
+			{
+				Name: "have to provide either controlPlaneRef or serviceRef",
+				TestObject: &configurationv1alpha1.KongRoute{
+					ObjectMeta: commonObjectMeta,
+					Spec: configurationv1alpha1.KongRouteSpec{
+						KongRouteAPISpec: configurationv1alpha1.KongRouteAPISpec{
+							Paths: []string{"/"},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("Has to set either controlPlaneRef or serviceRef"),
+			},
+		}.Run(t)
+	})
+
 	t.Run("service ref", func(t *testing.T) {
 		CRDValidationTestCasesGroup[*configurationv1alpha1.KongRoute]{
 			{

--- a/test/crdsvalidation/kongservice_test.go
+++ b/test/crdsvalidation/kongservice_test.go
@@ -11,16 +11,20 @@ import (
 )
 
 func TestKongService(t *testing.T) {
-	t.Run("cp ref", func(t *testing.T) {
-		obj := &configurationv1alpha1.KongService{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "KongService",
-				APIVersion: configurationv1alpha1.GroupVersion.String(),
-			},
-			ObjectMeta: commonObjectMeta,
-		}
+	obj := &configurationv1alpha1.KongService{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KongService",
+			APIVersion: configurationv1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: commonObjectMeta,
+	}
 
-		NewCRDValidationTestCasesGroupCPRefChange(t, obj).Run(t)
+	t.Run("cp ref", func(t *testing.T) {
+		NewCRDValidationTestCasesGroupCPRefChange(t, obj, NotSupportedByKIC).Run(t)
+	})
+
+	t.Run("cp ref, type=kic", func(t *testing.T) {
+		NewCRDValidationTestCasesGroupCPRefChangeKICUnsupportedTypes(t, obj, EmptyControlPlaneRefNotAllowed).Run(t)
 	})
 
 	t.Run("tags validation", func(t *testing.T) {

--- a/test/crdsvalidation/kongupstream_test.go
+++ b/test/crdsvalidation/kongupstream_test.go
@@ -13,16 +13,20 @@ import (
 )
 
 func TestKongUpstream(t *testing.T) {
-	t.Run("cp ref", func(t *testing.T) {
-		obj := &configurationv1alpha1.KongUpstream{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "KongUpstream",
-				APIVersion: configurationv1alpha1.GroupVersion.String(),
-			},
-			ObjectMeta: commonObjectMeta,
-		}
+	obj := &configurationv1alpha1.KongUpstream{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KongUpstream",
+			APIVersion: configurationv1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: commonObjectMeta,
+	}
 
-		NewCRDValidationTestCasesGroupCPRefChange(t, obj).Run(t)
+	t.Run("cp ref", func(t *testing.T) {
+		NewCRDValidationTestCasesGroupCPRefChange(t, obj, NotSupportedByKIC).Run(t)
+	})
+
+	t.Run("cp ref, type=kic", func(t *testing.T) {
+		NewCRDValidationTestCasesGroupCPRefChangeKICUnsupportedTypes(t, obj, EmptyControlPlaneRefNotAllowed).Run(t)
 	})
 
 	t.Run("required fields", func(t *testing.T) {

--- a/test/crdsvalidation/kongvault_test.go
+++ b/test/crdsvalidation/kongvault_test.go
@@ -24,7 +24,7 @@ func TestKongVault(t *testing.T) {
 			},
 		}
 
-		NewCRDValidationTestCasesGroupCPRefChange(t, obj).Run(t)
+		NewCRDValidationTestCasesGroupCPRefChange(t, obj, SupportedByKIC).Run(t)
 	})
 
 	t.Run("spec", func(t *testing.T) {

--- a/test/crdsvalidation/suite_crd_ref_change_kic_unsupported_test.go
+++ b/test/crdsvalidation/suite_crd_ref_change_kic_unsupported_test.go
@@ -1,0 +1,65 @@
+package crdsvalidation_test
+
+import (
+	"testing"
+
+	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configurationv1alpha1 "github.com/kong/kubernetes-configuration/api/configuration/v1alpha1"
+)
+
+type EmptyControlPlaneRefAllowedT bool
+
+const (
+	EmptyControlPlaneRefAllowed    EmptyControlPlaneRefAllowedT = true
+	EmptyControlPlaneRefNotAllowed EmptyControlPlaneRefAllowedT = false
+)
+
+func NewCRDValidationTestCasesGroupCPRefChangeKICUnsupportedTypes[
+	T interface {
+		client.Object
+		DeepCopy() T
+		SetConditions([]metav1.Condition)
+		SetControlPlaneRef(*configurationv1alpha1.ControlPlaneRef)
+		GetControlPlaneRef() *configurationv1alpha1.ControlPlaneRef
+	},
+](
+	t *testing.T,
+	obj T,
+	emptyControlPlaneRefAllowed EmptyControlPlaneRefAllowedT,
+) CRDValidationTestCasesGroup[T] {
+	ret := CRDValidationTestCasesGroup[T]{}
+
+	{
+		obj := obj.DeepCopy()
+		obj.SetControlPlaneRef(&configurationv1alpha1.ControlPlaneRef{
+			Type: configurationv1alpha1.ControlPlaneRefKIC,
+		})
+		ret = append(ret, CRDValidationTestCase[T]{
+			Name:                 "kic control plane ref is not allowed",
+			TestObject:           obj,
+			ExpectedErrorMessage: lo.ToPtr("KIC is not supported as control plane"),
+		})
+	}
+	{
+		obj := obj.DeepCopy()
+		obj.SetControlPlaneRef(nil)
+		switch emptyControlPlaneRefAllowed {
+		case EmptyControlPlaneRefNotAllowed:
+			ret = append(ret, CRDValidationTestCase[T]{
+				Name:                 "<unset> control plane ref is not allowed",
+				TestObject:           obj,
+				ExpectedErrorMessage: lo.ToPtr("controlPlaneRef"),
+			})
+		case EmptyControlPlaneRefAllowed:
+			ret = append(ret, CRDValidationTestCase[T]{
+				Name:       "<unset> control plane ref is allowed",
+				TestObject: obj,
+			})
+		}
+	}
+
+	return ret
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a follow up PR from #159.

It adds validation rules for types which are not supported by KIC so that `kic` ControlPlane ref type is not used for them.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
