### PR TITLE
chore: add release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,9 @@ jobs:
   verify-tag:
     name: Verify tag
     runs-on: ubuntu-latest
+    outputs:
+      # The prerelease part of the semver tag, if any. To be used in the release job.
+      prerelease: ${{ steps.parse-semver.outputs.prerelease }}
     steps:
       - uses: mukunku/tag-exists-action@v1.6.0
         id: check-tag
@@ -45,12 +48,6 @@ jobs:
       - tests
       - verify-tag
     steps:
-      - name: Parse semver string
-        id: parse-semver
-        uses: booxmedialtd/ws-action-parse-semver@v1.4.7
-        with:
-          input_string: ${{ github.event.inputs.tag }}
-          version_extractor_regex: 'v(.*)$'
       - uses: ncipollo/release-action@v1
         with:
           body: |
@@ -59,7 +56,7 @@ jobs:
             See [changelog] for a complete list of changes. 
             
             [changelog]: https://github.com/kong/kubernetes-configuration/blob/main/CHANGELOG.md#${{ github.event.inputs.tag }}
-             
+            
             #### Install CRDs from all channels
             ```shell
             kustomize build github.com/kong/kubernetes-configuration/config/crd/gateway-operator?ref=${{ github.event.inputs.tag }} | kubectl apply -f -
@@ -69,5 +66,5 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.event.inputs.tag }}
           commit: ${{ github.sha }}
-          prerelease: ${{ steps.parse-semver.outputs.prerelease != '' }}
+          prerelease: ${{ needs.verify-tag.outputs.prerelease != '' }}
           makeLatest: ${{ github.event.inputs.latest == 'true' }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,73 @@
+name: Create release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v1.0.0)"
+        required: true
+        type: string
+      latest:
+        description: "Whether to tag this release latest"
+        required: true
+        type: boolean
+        default: false
+
+jobs:
+  tests:
+    name: Run tests
+    uses: ./.github/workflows/tests.yaml
+
+  verify-tag:
+    name: Verify tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mukunku/tag-exists-action@v1.6.0
+        id: check-tag
+        with:
+          tag: ${{ github.event.inputs.tag }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: fail if tag already exists
+        if: ${{ steps.check-tag.outputs.exists == 'true' }}
+        run: exit 1
+      - name: Validate semver
+        id: parse-semver
+        uses: booxmedialtd/ws-action-parse-semver@v1.4.7
+        with:
+          input_string: ${{ github.event.inputs.tag }}
+          version_extractor_regex: 'v(.*)$'
+
+  release:
+    name: Create a GH release
+    runs-on: ubuntu-latest
+    needs:
+      - tests
+      - verify-tag
+    steps:
+      - name: Parse semver string
+        id: parse-semver
+        uses: booxmedialtd/ws-action-parse-semver@v1.4.7
+        with:
+          input_string: ${{ github.event.inputs.tag }}
+          version_extractor_regex: 'v(.*)$'
+      - uses: ncipollo/release-action@v1
+        with:
+          body: |
+            #### Changes
+
+            See [changelog] for a complete list of changes. 
+            
+            [changelog]: https://github.com/kong/kubernetes-configuration/blob/main/CHANGELOG.md#${{ github.event.inputs.tag }}
+             
+            #### Install CRDs from all channels
+            ```shell
+            kustomize build github.com/kong/kubernetes-configuration/config/crd/gateway-operator?ref=${{ github.event.inputs.tag }} | kubectl apply -f -
+            kustomize build github.com/kong/kubernetes-configuration/config/crd/ingress-controller?ref=${{ github.event.inputs.tag }} | kubectl apply -f -
+            kustomize build github.com/kong/kubernetes-configuration/config/crd/ingress-controller-incubator?ref=${{ github.event.inputs.tag }} | kubectl apply -f -
+            ```
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.event.inputs.tag }}
+          commit: ${{ github.sha }}
+          prerelease: ${{ steps.parse-semver.outputs.prerelease != '' }}
+          makeLatest: ${{ github.event.inputs.latest == 'true' }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,4 @@
-name: tests
+name: Run tests
 run-name: tests, branch:${{ github.ref_name }}, triggered by @${{ github.actor }}
 
 concurrency:
@@ -18,6 +18,7 @@ on:
     tags:
       - '*'
   workflow_dispatch: {}
+  workflow_call: {}
 
 jobs:
   test-unit:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Table of Contents
+
+<!---
+Adding a new version? You'll need three changes:
+* Add the ToC link, like "[v1.2.3](#v123)".
+* Add the section header, like "## [v1.2.3]".
+* Add the diff link, like "[v2.7.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v1.2.2...v1.2.3".
+  This is all the way at the bottom. It's the thing we always forget.
+--->
+- [v1.0.0-rc.0](#v100-rc0)
+
+## Unreleased
+
+> Release date: TBA
+
+## [v1.0.0-rc.0]
+
+> Release date: 2024-11-26
+
+This is an initial stable release of the Kong Kubernetes configuration module.
+It includes CRDs for the Kong Ingress Controller and the Kong Gateway Operator
+in the `ingress-controller`, `ingress-controller-incubator` and `gateway-operator`
+channels.
+
+Go bindings for the CRDs are available in the [`api/`][api] directory and the
+[`pkg/clientset/`][clientset] directory contains the clientset for interacting
+with the CRDs.
+
+[v1.0.0-rc.0]: https://github.com/kong/kubernetes-configuration/compare/ecf9b7bd62bfb92327a6ddd9aeaec9f73fc13a72...v1.0.0-rc.0

--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 This repository holds the API definitions for Kong's Kubernetes configuration.
 
-> 👷 🚧 This is currently a work in progress which is heavily based on [Kong's Ingress Controller][kic] CRDs
-> Before KIC starts using these CRDs this repo should contain only additive,
-> non-breaking changes on top of KIC's types.
-
-[kic]: https://github.com/Kong/kubernetes-ingress-controller
-
 ## Repository structure
 
 - [`api/`][api] directory contains Go types that are the source for generating
@@ -86,8 +80,10 @@ When you add a new CRD make sure to
 
 ## How to release?
 
-Currently, in order to make a new release/tag available for users to use is to
-create a new tag and push it to the repository.
+- Make sure a changelog is updated with the new version, the release date, and all the changes.
+- Trigger a [release workflow]. This will create a tag a release in GitHub.
+
+[release workflow]: ./.github/workflows/release.yaml
 
 ## Available custom markers
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a `release.yaml` workflow. It's meant to be triggered manually to create proper GH releases.

Tested on fork: 
 - workflow run: https://github.com/czeslavo/kubernetes-configuration/actions/runs/12034412037
 - GH release: https://github.com/czeslavo/kubernetes-configuration/releases/tag/v1.0.0-rc.1

**Which issue this PR fixes**

Closes https://github.com/Kong/kubernetes-configuration/issues/150.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
