### PR TITLE
chore: add missing protocol to kustomize release description

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,9 +59,9 @@ jobs:
             
             #### Install CRDs from all channels
             ```shell
-            kustomize build github.com/kong/kubernetes-configuration/config/crd/gateway-operator?ref=${{ github.event.inputs.tag }} | kubectl apply -f -
-            kustomize build github.com/kong/kubernetes-configuration/config/crd/ingress-controller?ref=${{ github.event.inputs.tag }} | kubectl apply -f -
-            kustomize build github.com/kong/kubernetes-configuration/config/crd/ingress-controller-incubator?ref=${{ github.event.inputs.tag }} | kubectl apply -f -
+            kustomize build https://github.com/kong/kubernetes-configuration/config/crd/gateway-operator?ref=${{ github.event.inputs.tag }} | kubectl apply -f -
+            kustomize build https://github.com/kong/kubernetes-configuration/config/crd/ingress-controller?ref=${{ github.event.inputs.tag }} | kubectl apply -f -
+            kustomize build https://github.com/kong/kubernetes-configuration/config/crd/ingress-controller-incubator?ref=${{ github.event.inputs.tag }} | kubectl apply -f -
             ```
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.event.inputs.tag }}


### PR DESCRIPTION
Add missing `https://` to kustomize build commands.