### PR TITLE
chore: fix changelog links and make install commands work in all shells

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,15 +53,15 @@ jobs:
           body: |
             #### Changes
 
-            See [changelog] for a complete list of changes. 
+            See [changelog] for a complete list of changes.
             
-            [changelog]: https://github.com/kong/kubernetes-configuration/blob/main/CHANGELOG.md#${{ github.event.inputs.tag }}
+            [changelog]: https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md#${{ github.event.inputs.tag }}
             
             #### Install CRDs from all channels
             ```shell
-            kustomize build github.com/kong/kubernetes-configuration/config/crd/gateway-operator?ref=${{ github.event.inputs.tag }} | kubectl apply -f -
-            kustomize build github.com/kong/kubernetes-configuration/config/crd/ingress-controller?ref=${{ github.event.inputs.tag }} | kubectl apply -f -
-            kustomize build github.com/kong/kubernetes-configuration/config/crd/ingress-controller-incubator?ref=${{ github.event.inputs.tag }} | kubectl apply -f -
+            kustomize build github.com/${{ github.repository }}/config/crd/gateway-operator\?ref=${{ github.event.inputs.tag }} | kubectl apply -f -
+            kustomize build github.com/${{ github.repository }}/config/crd/ingress-controller\?ref=${{ github.event.inputs.tag }} | kubectl apply -f -
+            kustomize build github.com/${{ github.repository }}/config/crd/ingress-controller-incubator\?ref=${{ github.event.inputs.tag }} | kubectl apply -f -
             ```
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.event.inputs.tag }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ Adding a new version? You'll need three changes:
 * Add the ToC link, like "[v1.2.3](#v123)".
 * Add the section header, like "## [v1.2.3]".
 * Add the diff link, like "[v2.7.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v1.2.2...v1.2.3".
-  This is all the way at the bottom. It's the thing we always forget.
 --->
 - [v1.0.0-rc.0](#v100-rc0)
 
@@ -14,6 +13,8 @@ Adding a new version? You'll need three changes:
 > Release date: TBA
 
 ## [v1.0.0-rc.0]
+
+[v1.0.0-rc.0]: https://github.com/kong/kubernetes-configuration/compare/ecf9b7bd62bfb92327a6ddd9aeaec9f73fc13a72...v1.0.0-rc.0
 
 > Release date: 2024-11-26
 
@@ -26,4 +27,5 @@ Go bindings for the CRDs are available in the [`api/`][api] directory and the
 [`pkg/clientset/`][clientset] directory contains the clientset for interacting
 with the CRDs.
 
-[v1.0.0-rc.0]: https://github.com/kong/kubernetes-configuration/compare/ecf9b7bd62bfb92327a6ddd9aeaec9f73fc13a72...v1.0.0-rc.0
+[api]: ./api/
+[clientset]: ./pkg/clientset/


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes 3 things:

- changes the installation commands in release template to work in all shells ( lacking `?` makes this not work with `zsh`)
- fixes links in changelog
- moves the diff link next to the release heading: this way it's harder to forget about

While at it, use `${{ github.repository }}` where possible in release template.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
