### PR TITLE
chore(ci): fix extractVersion for kustomize

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,5 +24,11 @@
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n.+\"(?<currentValue>.*?)\""
       ]
     }
+  ],
+  "packageRules": [
+    {
+      "packageNames": ["kubernetes-sigs/kustomize"],
+      "extractVersion": "^kustomize\\/v(?<version>\\d+\\.\\d+\\.\\d+)$"
+    }
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

kustomize uses prefixed tags, e.g. https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.5.0 which does not work with default kustomize config.

This PR fixes it by adding a custom `extractVersion`.

Tested via:


```
docker run --rm -it -v $PWD/renovate.json:/usr/src/app/renovate.json -v /tmp:/tmp -v $(pwd):/tmp/workdir -w /tmp/workdir -e LOG_LEVEL=debug -e GITHUB_COM_TOKEN=${GITHUB_TOKEN} renovate/renovate --platform local --base-dir /tmp/

...

               {
                 "depName": "kubernetes-sigs/kustomize",
                 "currentValue": "5.3.0",
                 "datasource": "github-releases",
                 "replaceString": "# renovate: datasource=github-releases depName=kubernetes-sigs/kustomize\nkustomize: \"5.3.0\"",
                 "updates": [
                   {
                     "bucket": "minor",
                     "newVersion": "5.5.0",
                     "newValue": "5.5.0",
                     "releaseTimestamp": "2024-10-09T13:17:14.000Z",
                     "newVersionAgeInDays": 71,
                     "newMajor": 5,
                     "newMinor": 5,
                     "newPatch": 0,
                     "updateType": "minor",
                     "branchName": "renovate/kubernetes-sigs-kustomize-5.x"
                   }
                 ],
                 "packageName": "kubernetes-sigs/kustomize",
                 "versioning": "semver-coerced",
                 "warnings": [],
                 "sourceUrl": "https://github.com/kubernetes-sigs/kustomize",
                 "registryUrl": "https://github.com",
                 "currentVersion": "5.3.0",
                 "currentVersionTimestamp": "2023-12-07T10:53:09.000Z",
                 "currentVersionAgeInDays": 378,
                 "isSingleVersion": true,
                 "fixedVersion": "5.3.0"
               },

...
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
