### PR TITLE
fix: disallow konnectID references

### DIFF
--- a/api/configuration/v1alpha1/key_set_ref.go
+++ b/api/configuration/v1alpha1/key_set_ref.go
@@ -19,13 +19,13 @@ const (
 // KeySetRef is the schema for the KeySetRef type.
 // It is used to reference a KeySet entity.
 // +kubebuilder:validation:XValidation:rule="self.type == 'namespacedRef' ? has(self.namespacedRef) : true", message="when type is namespacedRef, namespacedRef must be set"
-// +kubebuilder:validation:XValidation:rule="self.type == 'konnectID' ? has(self.konnectID) : true", message="when type is konnectID, konnectID must be set"
 // +apireference:kgo:include
 // +kong:channels=gateway-operator
 type KeySetRef struct {
 	// Type defines type of the KeySet object reference. It can be one of:
-	// - konnectID
 	// - namespacedRef
+	//
+	// +kubebuilder:validation:Enum=namespacedRef
 	Type KeySetRefType `json:"type"`
 
 	// KonnectID is the schema for the KonnectID type.

--- a/api/configuration/v1alpha1/konnect_controlplaneref_types.go
+++ b/api/configuration/v1alpha1/konnect_controlplaneref_types.go
@@ -26,13 +26,12 @@ const (
 // +apireference:kgo:include
 type ControlPlaneRef struct {
 	// Type indicates the type of the control plane being referenced. Allowed values:
-	// - konnectID
 	// - konnectNamespacedRef
 	// - kic
 	//
 	// The default is kic, which implies that the Control Plane is KIC.
 	//
-	// +kubebuilder:validation:Enum=konnectID;konnectNamespacedRef;kic
+	// +kubebuilder:validation:Enum=konnectNamespacedRef;kic
 	// +kubebuilder:default:=kic
 	Type string `json:"type,omitempty"`
 

--- a/config/crd/gateway-operator/configuration.konghq.com_kongcacertificates.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongcacertificates.yaml
@@ -79,13 +79,11 @@ spec:
                     default: kic
                     description: |-
                       Type indicates the type of the control plane being referenced. Allowed values:
-                      - konnectID
                       - konnectNamespacedRef
                       - kic
 
                       The default is kic, which implies that the Control Plane is KIC.
                     enum:
-                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string

--- a/config/crd/gateway-operator/configuration.konghq.com_kongcertificates.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongcertificates.yaml
@@ -85,13 +85,11 @@ spec:
                     default: kic
                     description: |-
                       Type indicates the type of the control plane being referenced. Allowed values:
-                      - konnectID
                       - konnectNamespacedRef
                       - kic
 
                       The default is kic, which implies that the Control Plane is KIC.
                     enum:
-                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string

--- a/config/crd/gateway-operator/configuration.konghq.com_kongconsumergroups.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongconsumergroups.yaml
@@ -81,13 +81,11 @@ spec:
                     default: kic
                     description: |-
                       Type indicates the type of the control plane being referenced. Allowed values:
-                      - konnectID
                       - konnectNamespacedRef
                       - kic
 
                       The default is kic, which implies that the Control Plane is KIC.
                     enum:
-                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string

--- a/config/crd/gateway-operator/configuration.konghq.com_kongconsumers.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongconsumers.yaml
@@ -106,13 +106,11 @@ spec:
                     default: kic
                     description: |-
                       Type indicates the type of the control plane being referenced. Allowed values:
-                      - konnectID
                       - konnectNamespacedRef
                       - kic
 
                       The default is kic, which implies that the Control Plane is KIC.
                     enum:
-                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string

--- a/config/crd/gateway-operator/configuration.konghq.com_kongdataplaneclientcertificates.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongdataplaneclientcertificates.yaml
@@ -81,13 +81,11 @@ spec:
                     default: kic
                     description: |-
                       Type indicates the type of the control plane being referenced. Allowed values:
-                      - konnectID
                       - konnectNamespacedRef
                       - kic
 
                       The default is kic, which implies that the Control Plane is KIC.
                     enum:
-                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string

--- a/config/crd/gateway-operator/configuration.konghq.com_kongkeys.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongkeys.yaml
@@ -75,13 +75,11 @@ spec:
                     default: kic
                     description: |-
                       Type indicates the type of the control plane being referenced. Allowed values:
-                      - konnectID
                       - konnectNamespacedRef
                       - kic
 
                       The default is kic, which implies that the Control Plane is KIC.
                     enum:
-                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string
@@ -141,13 +139,15 @@ spec:
                     - name
                     type: object
                   type:
-                    description: |-
-                      Type defines type of the KeySet object reference. It can be one of:
+                    allOf:
+                    - enum:
                       - konnectID
                       - namespacedRef
-                    enum:
-                    - konnectID
-                    - namespacedRef
+                    - enum:
+                      - namespacedRef
+                    description: |-
+                      Type defines type of the KeySet object reference. It can be one of:
+                      - namespacedRef
                     type: string
                 required:
                 - type
@@ -156,8 +156,6 @@ spec:
                 - message: when type is namespacedRef, namespacedRef must be set
                   rule: 'self.type == ''namespacedRef'' ? has(self.namespacedRef)
                     : true'
-                - message: when type is konnectID, konnectID must be set
-                  rule: 'self.type == ''konnectID'' ? has(self.konnectID) : true'
               kid:
                 description: |-
                   KID is a unique identifier for a key.

--- a/config/crd/gateway-operator/configuration.konghq.com_kongkeysets.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongkeysets.yaml
@@ -75,13 +75,11 @@ spec:
                     default: kic
                     description: |-
                       Type indicates the type of the control plane being referenced. Allowed values:
-                      - konnectID
                       - konnectNamespacedRef
                       - kic
 
                       The default is kic, which implies that the Control Plane is KIC.
                     enum:
-                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string

--- a/config/crd/gateway-operator/configuration.konghq.com_kongpluginbindings.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongpluginbindings.yaml
@@ -83,13 +83,11 @@ spec:
                     default: kic
                     description: |-
                       Type indicates the type of the control plane being referenced. Allowed values:
-                      - konnectID
                       - konnectNamespacedRef
                       - kic
 
                       The default is kic, which implies that the Control Plane is KIC.
                     enum:
-                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string

--- a/config/crd/gateway-operator/configuration.konghq.com_kongroutes.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongroutes.yaml
@@ -76,13 +76,11 @@ spec:
                     default: kic
                     description: |-
                       Type indicates the type of the control plane being referenced. Allowed values:
-                      - konnectID
                       - konnectNamespacedRef
                       - kic
 
                       The default is kic, which implies that the Control Plane is KIC.
                     enum:
-                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string

--- a/config/crd/gateway-operator/configuration.konghq.com_kongservices.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongservices.yaml
@@ -88,13 +88,11 @@ spec:
                     default: kic
                     description: |-
                       Type indicates the type of the control plane being referenced. Allowed values:
-                      - konnectID
                       - konnectNamespacedRef
                       - kic
 
                       The default is kic, which implies that the Control Plane is KIC.
                     enum:
-                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string

--- a/config/crd/gateway-operator/configuration.konghq.com_kongupstreams.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongupstreams.yaml
@@ -85,13 +85,11 @@ spec:
                     default: kic
                     description: |-
                       Type indicates the type of the control plane being referenced. Allowed values:
-                      - konnectID
                       - konnectNamespacedRef
                       - kic
 
                       The default is kic, which implies that the Control Plane is KIC.
                     enum:
-                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string

--- a/config/crd/gateway-operator/configuration.konghq.com_kongvaults.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongvaults.yaml
@@ -108,13 +108,11 @@ spec:
                     default: kic
                     description: |-
                       Type indicates the type of the control plane being referenced. Allowed values:
-                      - konnectID
                       - konnectNamespacedRef
                       - kic
 
                       The default is kic, which implies that the Control Plane is KIC.
                     enum:
-                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string

--- a/config/crd/ingress-controller/configuration.konghq.com_kongconsumergroups.yaml
+++ b/config/crd/ingress-controller/configuration.konghq.com_kongconsumergroups.yaml
@@ -81,13 +81,11 @@ spec:
                     default: kic
                     description: |-
                       Type indicates the type of the control plane being referenced. Allowed values:
-                      - konnectID
                       - konnectNamespacedRef
                       - kic
 
                       The default is kic, which implies that the Control Plane is KIC.
                     enum:
-                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string

--- a/config/crd/ingress-controller/configuration.konghq.com_kongconsumers.yaml
+++ b/config/crd/ingress-controller/configuration.konghq.com_kongconsumers.yaml
@@ -106,13 +106,11 @@ spec:
                     default: kic
                     description: |-
                       Type indicates the type of the control plane being referenced. Allowed values:
-                      - konnectID
                       - konnectNamespacedRef
                       - kic
 
                       The default is kic, which implies that the Control Plane is KIC.
                     enum:
-                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string

--- a/config/crd/ingress-controller/configuration.konghq.com_kongvaults.yaml
+++ b/config/crd/ingress-controller/configuration.konghq.com_kongvaults.yaml
@@ -108,13 +108,11 @@ spec:
                     default: kic
                     description: |-
                       Type indicates the type of the control plane being referenced. Allowed values:
-                      - konnectID
                       - konnectNamespacedRef
                       - kic
 
                       The default is kic, which implies that the Control Plane is KIC.
                     enum:
-                    - konnectID
                     - konnectNamespacedRef
                     - kic
                     type: string

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -685,7 +685,7 @@ It is used to reference a Control Plane entity.
 
 | Field | Description |
 | --- | --- |
-| `type` _string_ | Type indicates the type of the control plane being referenced. Allowed values: - konnectID - konnectNamespacedRef - kic<br /><br /> The default is kic, which implies that the Control Plane is KIC. |
+| `type` _string_ | Type indicates the type of the control plane being referenced. Allowed values: - konnectNamespacedRef - kic<br /><br /> The default is kic, which implies that the Control Plane is KIC. |
 | `konnectID` _string_ | KonnectID is the schema for the KonnectID type. This field is required when the Type is konnectID. |
 | `konnectNamespacedRef` _[KonnectNamespacedRef](#konnectnamespacedref)_ | KonnectNamespacedRef is a reference to a Konnect Control Plane entity inside the cluster. It contains the name of the Konnect Control Plane. This field is required when the Type is konnectNamespacedRef. |
 
@@ -776,7 +776,7 @@ It is used to reference a KeySet entity.
 
 | Field | Description |
 | --- | --- |
-| `type` _[KeySetRefType](#keysetreftype)_ | Type defines type of the KeySet object reference. It can be one of: - konnectID - namespacedRef |
+| `type` _[KeySetRefType](#keysetreftype)_ | Type defines type of the KeySet object reference. It can be one of: - namespacedRef |
 | `konnectID` _string_ | KonnectID is the schema for the KonnectID type. This field is required when the Type is konnectID. |
 | `namespacedRef` _[KeySetNamespacedRef](#keysetnamespacedref)_ | NamespacedRef is a reference to a KeySet entity inside the cluster. This field is required when the Type is namespacedRef. |
 

--- a/test/crdsvalidation/kongkey_test.go
+++ b/test/crdsvalidation/kongkey_test.go
@@ -162,6 +162,8 @@ func TestKongKey(t *testing.T) {
 						},
 					},
 				},
+				// TODO change when konnectID ref is allowed
+				ExpectedErrorMessage: lo.ToPtr("Unsupported value: \"konnectID\": supported values: \"namespacedRef\""),
 			},
 			{
 				Name: "when type is 'konnectID', konnectID is required",
@@ -177,7 +179,8 @@ func TestKongKey(t *testing.T) {
 						},
 					},
 				},
-				ExpectedErrorMessage: lo.ToPtr("when type is konnectID, konnectID must be set"),
+				// TODO change when konnectID ref is allowed
+				ExpectedErrorMessage: lo.ToPtr("Unsupported value: \"konnectID\": supported values: \"namespacedRef\""),
 			},
 			{
 				Name: "unknown type is not accepted",

--- a/test/crdsvalidation/suite_crd_ref_change_test.go
+++ b/test/crdsvalidation/suite_crd_ref_change_test.go
@@ -124,9 +124,11 @@ func NewCRDValidationTestCasesGroupCPRefChange[
 			},
 		})
 		ret = append(ret, CRDValidationTestCase[T]{
-			Name:                 "providing konnectNamespacedRef when type is konnectID yields an error",
-			TestObject:           obj,
-			ExpectedErrorMessage: lo.ToPtr("when type is konnectID, konnectID must be set"),
+			Name:       "providing konnectNamespacedRef when type is konnectID yields an error",
+			TestObject: obj,
+			// TODO: change when konnectID is allowed
+			// ExpectedErrorMessage: lo.ToPtr("when type is konnectID, konnectID must be set"),
+			ExpectedErrorMessage: lo.ToPtr("Unsupported value: \"konnectID\": supported values: \"konnectNamespacedRef\", \"kic\""),
 		})
 	}
 	{
@@ -139,9 +141,10 @@ func NewCRDValidationTestCasesGroupCPRefChange[
 			},
 		})
 		ret = append(ret, CRDValidationTestCase[T]{
-			Name:                 "providing konnectNamespacedRef and konnectID when type is konnectID yields an error",
-			TestObject:           obj,
-			ExpectedErrorMessage: lo.ToPtr("when type is konnectID, konnectNamespacedRef must not be set"),
+			Name:       "providing konnectNamespacedRef and konnectID when type is konnectID yields an error",
+			TestObject: obj,
+			// TODO: change when konnectID is allowed
+			ExpectedErrorMessage: lo.ToPtr("Unsupported value: \"konnectID\": supported values: \"konnectNamespacedRef\", \"kic\""),
 		})
 	}
 	{


### PR DESCRIPTION
**What this PR does / why we need it**:

`konnectID` references were not implemented as part of KGO 1.4. This PR enforces this at the API level.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
