### PR TITLE
chore: add contents:write permission to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,6 +57,8 @@ jobs:
     needs:
       - tests
       - verify-tag
+    permissions:
+      contents: write # This is required to create GH releases.
     steps:
       - uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5 # v1.14.0
         with:

--- a/.github/workflows/release_on_version_change.yaml
+++ b/.github/workflows/release_on_version_change.yaml
@@ -28,6 +28,8 @@ jobs:
     needs:
     - version
     uses: ./.github/workflows/release.yaml
+    permissions:
+      contents: write # This is required to create GH releases.
     with:
       tag: ${{ needs.version.outputs.version }}
       latest: ${{ needs.version.outputs.latest == 'true' }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Should fix https://github.com/Kong/kubernetes-configuration/actions/runs/12674261856. 

Permissions reference: https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release--fine-grained-access-tokens
