### PR TITLE
feat: add scheme param to crd validation testcase types

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,5 @@
 **/zz_generated*.go linguist-generated=true
+config/crd/gateway-operator/configuration.yaml linguist-generated=true
+config/crd/gateway-operator/konnect.*.yaml linguist-generated=true
+config/crd/ingress-controller/configuration.*.yaml linguist-generated=true
+config/crd/ingress-controller-incubator/incubator.*.yaml linguist-generated=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,22 @@ Adding a new version? You'll need three changes:
 * Add the section header, like "## [v1.2.3]".
 * Add the diff link, like "[v2.7.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v1.2.2...v1.2.3".
 --->
+- [v1.0.5](#v105)
 - [v1.0.4](#v104)
 - [v1.0.3](#v103)
 - [v1.0.2](#v102)
 - [v1.0.0](#v100)
+
+## [v1.0.5]
+
+[v1.0.5]: https://github.com/Kong/kubernetes-configuration/compare/v1.0.4...v1.0.5
+
+> Release date: 2025-01-10
+
+### Changes
+
+- Exported CRD validation test suite types.
+  [#220](https://github.com/Kong/kubernetes-configuration/pull/220)
 
 ## [v1.0.4]
 

--- a/test/crdsvalidation/testcase.go
+++ b/test/crdsvalidation/testcase.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -18,9 +19,9 @@ import (
 type TestCasesGroup[T client.Object] []TestCase[T]
 
 // RunWithConfig runs all test cases in the group against the provided rest.Config's cluster.
-func (g TestCasesGroup[T]) RunWithConfig(t *testing.T, cfg *rest.Config) {
+func (g TestCasesGroup[T]) RunWithConfig(t *testing.T, cfg *rest.Config, scheme *runtime.Scheme) {
 	for _, tc := range g {
-		tc.RunWithConfig(t, cfg)
+		tc.RunWithConfig(t, cfg, scheme)
 	}
 }
 
@@ -28,7 +29,7 @@ func (g TestCasesGroup[T]) RunWithConfig(t *testing.T, cfg *rest.Config) {
 func (g TestCasesGroup[T]) Run(t *testing.T) {
 	cfg, err := config.GetConfig()
 	require.NoError(t, err)
-	g.RunWithConfig(t, cfg)
+	g.RunWithConfig(t, cfg, scheme.Scheme)
 }
 
 // TestCase represents a test case for CRD validation.
@@ -51,7 +52,7 @@ type TestCase[T client.Object] struct {
 }
 
 // RunWithConfig runs the test case against the provided rest.Config's cluster.
-func (tc *TestCase[T]) RunWithConfig(t *testing.T, cfg *rest.Config) {
+func (tc *TestCase[T]) RunWithConfig(t *testing.T, cfg *rest.Config, scheme *runtime.Scheme) {
 	// Run the test case.
 	t.Run(tc.Name, func(t *testing.T) {
 		t.Parallel()
@@ -59,7 +60,7 @@ func (tc *TestCase[T]) RunWithConfig(t *testing.T, cfg *rest.Config) {
 
 		// Create a new controller-runtime client.Client.
 		cl, err := client.New(cfg, client.Options{
-			Scheme: scheme.Scheme,
+			Scheme: scheme,
 		})
 		require.NoError(t, err)
 
@@ -123,5 +124,5 @@ func (tc *TestCase[T]) Run(t *testing.T) {
 	cfg, err := config.GetConfig()
 	require.NoError(t, err)
 
-	tc.RunWithConfig(t, cfg)
+	tc.RunWithConfig(t, cfg, scheme.Scheme)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Expose `scheme` param to allow call sites to provide a scheme which is not `github.com/kong/kubernetes-configuration/pkg/clientset/scheme.Scheme`.

Also update the missing Changelog entry and update .gitattributes with generated CRD yaml  paths.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
