### PR TITLE
feat: add KongPluginBinding scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ Adding a new version? You'll need three changes:
 - [v1.0.2](#v102)
 - [v1.0.0](#v100)
 
+## Unreleased
+
+### Changes
+
+- Add a `scope` field to `KongPluginBindingSpec` to allow setting the scope of
+  the plugin binding. The default value (`OnlyTargets`) is aligned with the previous
+  default behavior - the plugin will only be applied to the targets specified in the
+  `targets` field. A new alternative is `GlobalInControlPlane` that will make the
+  plugin apply globally in a control plane.
+  [#236](https://github.com/Kong/kubernetes-configuration/pull/236)
+
 ## [v1.0.6]
 
 [v1.0.6]: https://github.com/Kong/kubernetes-configuration/compare/v1.0.5...v1.0.6 

--- a/api/configuration/v1alpha1/zz_generated.deepcopy.go
+++ b/api/configuration/v1alpha1/zz_generated.deepcopy.go
@@ -1783,7 +1783,11 @@ func (in *KongPluginBindingList) DeepCopyObject() runtime.Object {
 func (in *KongPluginBindingSpec) DeepCopyInto(out *KongPluginBindingSpec) {
 	*out = *in
 	in.PluginReference.DeepCopyInto(&out.PluginReference)
-	in.Targets.DeepCopyInto(&out.Targets)
+	if in.Targets != nil {
+		in, out := &in.Targets, &out.Targets
+		*out = new(KongPluginBindingTargets)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.ControlPlaneRef != nil {
 		in, out := &in.ControlPlaneRef, &out.ControlPlaneRef
 		*out = new(ControlPlaneRef)

--- a/config/crd/gateway-operator/configuration.konghq.com_kongpluginbindings.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongpluginbindings.yaml
@@ -143,6 +143,13 @@ spec:
                 x-kubernetes-validations:
                 - message: pluginRef name must be set
                   rule: self.name != ''
+              scope:
+                default: OnlyTargets
+                description: Scope defines the scope of the plugin binding.
+                enum:
+                - OnlyTargets
+                - GlobalInControlPlane
+                type: string
               targets:
                 description: |-
                   Targets contains the targets references. It is possible to set multiple combinations
@@ -263,9 +270,6 @@ spec:
                 x-kubernetes-validations:
                 - message: Cannot set Consumer and ConsumerGroup at the same time
                   rule: '(has(self.consumerRef) ? !has(self.consumerGroupRef) : true)'
-                - message: At least one entity reference must be set
-                  rule: has(self.routeRef) || has(self.serviceRef) || has(self.consumerRef)
-                    || has(self.consumerGroupRef)
                 - message: KongRoute can be used only when serviceRef is unset or
                     set to KongService
                   rule: '(has(self.routeRef) && self.routeRef.kind == ''KongRoute'')
@@ -278,8 +282,15 @@ spec:
                     : true'
             required:
             - pluginRef
-            - targets
             type: object
+            x-kubernetes-validations:
+            - message: At least one target reference must be set when scope is 'OnlyTargets'
+              rule: 'self.scope == ''OnlyTargets'' ? has(self.targets) && (has(self.targets.routeRef)
+                || has(self.targets.serviceRef) || has(self.targets.consumerRef) ||
+                has(self.targets.consumerGroupRef)) : true'
+            - message: No targets must be set when scope is 'GlobalInControlPlane'
+              rule: 'self.scope == ''GlobalInControlPlane'' ? !has(self.targets) :
+                true'
           status:
             default:
               conditions:

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1241,6 +1241,21 @@ _Appears in:_
 - [KongSNISpec](#kongsnispec)
 - [ServiceRef](#serviceref)
 
+#### KongPluginBindingScope
+_Underlying type:_ `string`
+
+KongPluginBindingScope defines the scope of the plugin binding.
+Allowed values are:
+- OnlyTargets
+- GlobalInControlPlane
+
+
+
+
+
+_Appears in:_
+- [KongPluginBindingSpec](#kongpluginbindingspec)
+
 #### KongPluginBindingSpec
 
 
@@ -1253,6 +1268,7 @@ KongPluginBindingSpec defines specification of a KongPluginBinding.
 | `pluginRef` _[PluginRef](#pluginref)_ | PluginReference is a reference to the KongPlugin or KongClusterPlugin resource. |
 | `targets` _[KongPluginBindingTargets](#kongpluginbindingtargets)_ | Targets contains the targets references. It is possible to set multiple combinations of references, as described in https://docs.konghq.com/gateway/latest/key-concepts/plugins/#precedence The complete set of allowed combinations and their order of precedence for plugins configured to multiple entities is:<br /><br /> 1. Consumer + route + service 2. Consumer group + service + route 3. Consumer + route 4. Consumer + service 5. Consumer group + route 6. Consumer group + service 7. Route + service 8. Consumer 9. Consumer group 10. Route 11. Service |
 | `controlPlaneRef` _[ControlPlaneRef](#controlplaneref)_ | ControlPlaneRef is a reference to a ControlPlane this KongPluginBinding is associated with. |
+| `scope` _[KongPluginBindingScope](#kongpluginbindingscope)_ | Scope defines the scope of the plugin binding. |
 
 
 _Appears in:_

--- a/test/crdsvalidation/kongpluginbindings_test.go
+++ b/test/crdsvalidation/kongpluginbindings_test.go
@@ -22,7 +22,7 @@ func TestKongPluginBindings(t *testing.T) {
 				PluginReference: configurationv1alpha1.PluginRef{
 					Name: "rate-limiting",
 				},
-				Targets: configurationv1alpha1.KongPluginBindingTargets{
+				Targets: &configurationv1alpha1.KongPluginBindingTargets{
 					ServiceReference: &configurationv1alpha1.TargetRefWithGroupKind{
 						Name:  "test-service",
 						Kind:  "KongService",
@@ -42,7 +42,7 @@ func TestKongPluginBindings(t *testing.T) {
 				TestObject: &configurationv1alpha1.KongPluginBinding{
 					ObjectMeta: commonObjectMeta,
 					Spec: configurationv1alpha1.KongPluginBindingSpec{
-						Targets: configurationv1alpha1.KongPluginBindingTargets{
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
 							ServiceReference: &configurationv1alpha1.TargetRefWithGroupKind{
 								Name:  "test-service",
 								Kind:  "Service",
@@ -59,7 +59,7 @@ func TestKongPluginBindings(t *testing.T) {
 					ObjectMeta: commonObjectMeta,
 					Spec: configurationv1alpha1.KongPluginBindingSpec{
 						PluginReference: configurationv1alpha1.PluginRef{},
-						Targets: configurationv1alpha1.KongPluginBindingTargets{
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
 							ServiceReference: &configurationv1alpha1.TargetRefWithGroupKind{
 								Name:  "test-service",
 								Kind:  "Service",
@@ -79,7 +79,7 @@ func TestKongPluginBindings(t *testing.T) {
 							Kind: lo.ToPtr("KongPlugin"),
 							Name: "test-plugin",
 						},
-						Targets: configurationv1alpha1.KongPluginBindingTargets{
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
 							ServiceReference: &configurationv1alpha1.TargetRefWithGroupKind{
 								Name:  "test-service",
 								Kind:  "Service",
@@ -98,7 +98,7 @@ func TestKongPluginBindings(t *testing.T) {
 							Kind: lo.ToPtr("KongPlugin"),
 							Name: "test-plugin",
 						},
-						Targets: configurationv1alpha1.KongPluginBindingTargets{
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
 							ServiceReference: &configurationv1alpha1.TargetRefWithGroupKind{
 								Name:  "test-service",
 								Kind:  "Service",
@@ -117,7 +117,7 @@ func TestKongPluginBindings(t *testing.T) {
 							Kind: lo.ToPtr("WrongPluginKind"),
 							Name: "test-plugin",
 						},
-						Targets: configurationv1alpha1.KongPluginBindingTargets{
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
 							ServiceReference: &configurationv1alpha1.TargetRefWithGroupKind{
 								Name:  "test-service",
 								Kind:  "Service",
@@ -142,7 +142,7 @@ func TestKongPluginBindings(t *testing.T) {
 							Kind: lo.ToPtr("KongPlugin"),
 							Name: "my-plugin",
 						},
-						Targets: configurationv1alpha1.KongPluginBindingTargets{
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
 							ConsumerReference: &configurationv1alpha1.TargetRef{
 								Name: "test-consumer",
 							},
@@ -169,7 +169,7 @@ func TestKongPluginBindings(t *testing.T) {
 							Kind: lo.ToPtr("KongPlugin"),
 							Name: "my-plugin",
 						},
-						Targets: configurationv1alpha1.KongPluginBindingTargets{
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
 							ConsumerGroupReference: &configurationv1alpha1.TargetRef{
 								Name: "test-consumer-group",
 							},
@@ -196,7 +196,7 @@ func TestKongPluginBindings(t *testing.T) {
 							Kind: lo.ToPtr("KongPlugin"),
 							Name: "my-plugin",
 						},
-						Targets: configurationv1alpha1.KongPluginBindingTargets{
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
 							ConsumerReference: &configurationv1alpha1.TargetRef{
 								Name: "test-consumer",
 							},
@@ -218,7 +218,7 @@ func TestKongPluginBindings(t *testing.T) {
 							Kind: lo.ToPtr("KongPlugin"),
 							Name: "my-plugin",
 						},
-						Targets: configurationv1alpha1.KongPluginBindingTargets{
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
 							ConsumerReference: &configurationv1alpha1.TargetRef{
 								Name: "test-consumer",
 							},
@@ -240,7 +240,7 @@ func TestKongPluginBindings(t *testing.T) {
 							Kind: lo.ToPtr("KongPlugin"),
 							Name: "my-plugin",
 						},
-						Targets: configurationv1alpha1.KongPluginBindingTargets{
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
 							ConsumerGroupReference: &configurationv1alpha1.TargetRef{
 								Name: "test-consumer-group",
 							},
@@ -262,7 +262,7 @@ func TestKongPluginBindings(t *testing.T) {
 							Kind: lo.ToPtr("KongPlugin"),
 							Name: "my-plugin",
 						},
-						Targets: configurationv1alpha1.KongPluginBindingTargets{
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
 							ConsumerGroupReference: &configurationv1alpha1.TargetRef{
 								Name: "test-consumer-group",
 							},
@@ -284,7 +284,7 @@ func TestKongPluginBindings(t *testing.T) {
 							Kind: lo.ToPtr("KongPlugin"),
 							Name: "my-plugin",
 						},
-						Targets: configurationv1alpha1.KongPluginBindingTargets{
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
 							ConsumerGroupReference: &configurationv1alpha1.TargetRef{
 								Name: "test-consumer-group",
 							},
@@ -311,7 +311,7 @@ func TestKongPluginBindings(t *testing.T) {
 							Kind: lo.ToPtr("KongPlugin"),
 							Name: "my-plugin",
 						},
-						Targets: configurationv1alpha1.KongPluginBindingTargets{
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
 							ConsumerReference: &configurationv1alpha1.TargetRef{
 								Name: "test-consumer",
 							},
@@ -328,7 +328,7 @@ func TestKongPluginBindings(t *testing.T) {
 							Kind: lo.ToPtr("KongPlugin"),
 							Name: "my-plugin",
 						},
-						Targets: configurationv1alpha1.KongPluginBindingTargets{
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
 							ConsumerGroupReference: &configurationv1alpha1.TargetRef{
 								Name: "test-consumer",
 							},
@@ -345,7 +345,7 @@ func TestKongPluginBindings(t *testing.T) {
 							Kind: lo.ToPtr("KongPlugin"),
 							Name: "my-plugin",
 						},
-						Targets: configurationv1alpha1.KongPluginBindingTargets{
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
 							RouteReference: &configurationv1alpha1.TargetRefWithGroupKind{
 								Name:  "test-route",
 								Kind:  "KongRoute",
@@ -364,7 +364,7 @@ func TestKongPluginBindings(t *testing.T) {
 							Kind: lo.ToPtr("KongPlugin"),
 							Name: "my-plugin",
 						},
-						Targets: configurationv1alpha1.KongPluginBindingTargets{
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
 							ServiceReference: &configurationv1alpha1.TargetRefWithGroupKind{
 								Name:  "test-service",
 								Kind:  "Service",
@@ -383,7 +383,7 @@ func TestKongPluginBindings(t *testing.T) {
 							Kind: lo.ToPtr("KongPlugin"),
 							Name: "my-plugin",
 						},
-						Targets: configurationv1alpha1.KongPluginBindingTargets{
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
 							ConsumerReference: &configurationv1alpha1.TargetRef{
 								Name: "test-consumer",
 							},
@@ -414,7 +414,7 @@ func TestKongPluginBindings(t *testing.T) {
 							Kind: lo.ToPtr("KongPlugin"),
 							Name: "my-plugin",
 						},
-						Targets: configurationv1alpha1.KongPluginBindingTargets{
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
 							ConsumerReference: &configurationv1alpha1.TargetRef{
 								Name: "test-consumer",
 							},
@@ -440,7 +440,7 @@ func TestKongPluginBindings(t *testing.T) {
 							Kind: lo.ToPtr("KongPlugin"),
 							Name: "my-plugin",
 						},
-						Targets: configurationv1alpha1.KongPluginBindingTargets{
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
 							ConsumerReference: &configurationv1alpha1.TargetRef{
 								Name: "test-consumer",
 							},
@@ -466,7 +466,7 @@ func TestKongPluginBindings(t *testing.T) {
 							Kind: lo.ToPtr("KongPlugin"),
 							Name: "my-plugin",
 						},
-						Targets: configurationv1alpha1.KongPluginBindingTargets{
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
 							ConsumerReference: &configurationv1alpha1.TargetRef{
 								Name: "test-consumer",
 							},
@@ -489,7 +489,7 @@ func TestKongPluginBindings(t *testing.T) {
 						},
 					},
 				},
-				ExpectedErrorMessage: lo.ToPtr("At least one entity reference must be set"),
+				ExpectedErrorMessage: lo.ToPtr("At least one target reference must be set when scope is 'OnlyTargets'"),
 			},
 			{
 				Name: "empty targets",
@@ -500,10 +500,10 @@ func TestKongPluginBindings(t *testing.T) {
 							Kind: lo.ToPtr("KongPlugin"),
 							Name: "my-plugin",
 						},
-						Targets: configurationv1alpha1.KongPluginBindingTargets{},
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{},
 					},
 				},
-				ExpectedErrorMessage: lo.ToPtr("At least one entity reference must be set"),
+				ExpectedErrorMessage: lo.ToPtr("At least one target reference must be set when scope is 'OnlyTargets'"),
 			},
 		}.Run(t)
 	})
@@ -519,7 +519,7 @@ func TestKongPluginBindings(t *testing.T) {
 							Kind: lo.ToPtr("KongPlugin"),
 							Name: "my-plugin",
 						},
-						Targets: configurationv1alpha1.KongPluginBindingTargets{
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
 							ServiceReference: &configurationv1alpha1.TargetRefWithGroupKind{
 								Name:  "test-service",
 								Kind:  "Ingress",
@@ -539,7 +539,7 @@ func TestKongPluginBindings(t *testing.T) {
 							Kind: lo.ToPtr("KongPlugin"),
 							Name: "my-plugin",
 						},
-						Targets: configurationv1alpha1.KongPluginBindingTargets{
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
 							RouteReference: &configurationv1alpha1.TargetRefWithGroupKind{
 								Name:  "test-route",
 								Kind:  "Service",
@@ -564,7 +564,7 @@ func TestKongPluginBindings(t *testing.T) {
 							Kind: lo.ToPtr("KongPlugin"),
 							Name: "my-plugin",
 						},
-						Targets: configurationv1alpha1.KongPluginBindingTargets{
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
 							ServiceReference: &configurationv1alpha1.TargetRefWithGroupKind{
 								Name:  "test-service",
 								Kind:  "Service",
@@ -589,7 +589,7 @@ func TestKongPluginBindings(t *testing.T) {
 							Kind: lo.ToPtr("KongPlugin"),
 							Name: "my-plugin",
 						},
-						Targets: configurationv1alpha1.KongPluginBindingTargets{
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{
 							ServiceReference: &configurationv1alpha1.TargetRefWithGroupKind{
 								Name:  "test-service",
 								Kind:  "KongService",
@@ -604,6 +604,51 @@ func TestKongPluginBindings(t *testing.T) {
 					},
 				},
 				ExpectedErrorMessage: lo.ToPtr("KongService can be used only when routeRef is unset or set to KongRoute"),
+			},
+		}.Run(t)
+	})
+
+	t.Run("scope=GlobalInControlPlane validation", func(t *testing.T) {
+		crdsvalidation.TestCasesGroup[*configurationv1alpha1.KongPluginBinding]{
+			{
+				Name: "GlobalInControlPlane allow nil targets",
+				TestObject: &configurationv1alpha1.KongPluginBinding{
+					ObjectMeta: commonObjectMeta,
+					Spec: configurationv1alpha1.KongPluginBindingSpec{
+						Scope: configurationv1alpha1.KongPluginBindingScopeGlobalInControlPlane,
+						PluginReference: configurationv1alpha1.PluginRef{
+							Kind: lo.ToPtr("KongPlugin"),
+							Name: "my-plugin",
+						},
+						ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &configurationv1alpha1.KonnectNamespacedRef{
+								Name: "test-control-plane",
+							},
+						},
+					},
+				},
+			},
+			{
+				Name: "GlobalInControlPlane rejects non-nil targets",
+				TestObject: &configurationv1alpha1.KongPluginBinding{
+					ObjectMeta: commonObjectMeta,
+					Spec: configurationv1alpha1.KongPluginBindingSpec{
+						Scope: configurationv1alpha1.KongPluginBindingScopeGlobalInControlPlane,
+						PluginReference: configurationv1alpha1.PluginRef{
+							Kind: lo.ToPtr("KongPlugin"),
+							Name: "my-plugin",
+						},
+						ControlPlaneRef: &configurationv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &configurationv1alpha1.KonnectNamespacedRef{
+								Name: "test-control-plane",
+							},
+						},
+						Targets: &configurationv1alpha1.KongPluginBindingTargets{},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("No targets must be set when scope is 'GlobalInControlPlane'"),
 			},
 		}.Run(t)
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a `scope` field to the `KongPluginBindingSpec` with a default value of `OnlyTargets` that preserves the previous default behavior (applying a plugin to targets). Also adds `GlobalInControlPlane` enum value that allows configuring a plugin to be applied globally to a control plane.

**Which issue this PR fixes**

Closes #7. Part of https://github.com/Kong/gateway-operator/issues/440.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
