### PR TITLE
chore(ci): add tests running on CI for release branches, limit permissions of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,9 @@ on:
         required: true
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: Run tests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,6 +11,7 @@ on:
   pull_request:
     branches:
       - 'main'
+      - 'release/*'
   push:
     branches:
       - 'main'
@@ -19,6 +20,9 @@ on:
       - '*'
   workflow_dispatch: {}
   workflow_call: {}
+
+permissions:
+  contents: read
 
 jobs:
   version:


### PR DESCRIPTION
**What this PR does / why we need it**:

When this branch gets merged, we'll add branch protection rules for `release/*` branches.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
