### PR TITLE
tests: fix missing tests assertions in CRD validation suite

### DIFF
--- a/api/configuration/v1alpha1/kongpluginbinding_types.go
+++ b/api/configuration/v1alpha1/kongpluginbinding_types.go
@@ -97,8 +97,7 @@ type KongPluginBindingSpec struct {
 
 	// ControlPlaneRef is a reference to a ControlPlane this KongPluginBinding is associated with.
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:XValidation:message="spec.controlPlaneRef: Required value",rule="has(self.konnectID) || has(self.konnectNamespacedRef)"
-	ControlPlaneRef ControlPlaneRef `json:"controlPlaneRef"`
+	ControlPlaneRef ControlPlaneRef `json:"controlPlaneRef,omitzero"`
 
 	// Scope defines the scope of the plugin binding.
 	// +optional

--- a/api/configuration/v1alpha1/kongpluginbinding_types.go
+++ b/api/configuration/v1alpha1/kongpluginbinding_types.go
@@ -97,6 +97,7 @@ type KongPluginBindingSpec struct {
 
 	// ControlPlaneRef is a reference to a ControlPlane this KongPluginBinding is associated with.
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:XValidation:message="spec.controlPlaneRef: Required value",rule="has(self.konnectID) || has(self.konnectNamespacedRef)"
 	ControlPlaneRef ControlPlaneRef `json:"controlPlaneRef"`
 
 	// Scope defines the scope of the plugin binding.

--- a/config/crd/gateway-operator/configuration.konghq.com_kongpluginbindings.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongpluginbindings.yaml
@@ -96,8 +96,6 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-validations:
-                - message: 'spec.controlPlaneRef: Required value'
-                  rule: has(self.konnectID) || has(self.konnectNamespacedRef)
                 - message: when type is konnectNamespacedRef, konnectNamespacedRef
                     must be set
                   rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')

--- a/config/crd/gateway-operator/configuration.konghq.com_kongpluginbindings.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongpluginbindings.yaml
@@ -96,6 +96,8 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-validations:
+                - message: 'spec.controlPlaneRef: Required value'
+                  rule: has(self.konnectID) || has(self.konnectNamespacedRef)
                 - message: when type is konnectNamespacedRef, konnectNamespacedRef
                     must be set
                   rule: '(has(self.type) && self.type == ''konnectNamespacedRef'')

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/kubernetes-configuration
 
-go 1.23.2
+go 1.24.0
 
 require (
 	github.com/Kong/sdk-konnect-go v0.2.9

--- a/test/crdsvalidation/kongcacertificate_test.go
+++ b/test/crdsvalidation/kongcacertificate_test.go
@@ -46,6 +46,6 @@ func TestKongCACertificate(t *testing.T) {
 			},
 		}
 
-		NewCRDValidationTestCasesGroupCPRefChange(t, obj, NotSupportedByKIC).Run(t)
+		NewCRDValidationTestCasesGroupCPRefChange(t, obj, NotSupportedByKIC, ControlPlaneRefRequired).Run(t)
 	})
 }

--- a/test/crdsvalidation/kongcertificate_test.go
+++ b/test/crdsvalidation/kongcertificate_test.go
@@ -27,7 +27,7 @@ func TestKongCertificate(t *testing.T) {
 			},
 		}
 
-		NewCRDValidationTestCasesGroupCPRefChange(t, obj, NotSupportedByKIC).Run(t)
+		NewCRDValidationTestCasesGroupCPRefChange(t, obj, NotSupportedByKIC, ControlPlaneRefRequired).Run(t)
 	})
 
 	t.Run("required fields", func(t *testing.T) {

--- a/test/crdsvalidation/kongconsumer_test.go
+++ b/test/crdsvalidation/kongconsumer_test.go
@@ -23,7 +23,7 @@ func TestKongConsumer(t *testing.T) {
 			Username:   "username-1",
 		}
 
-		NewCRDValidationTestCasesGroupCPRefChange(t, obj, SupportedByKIC).Run(t)
+		NewCRDValidationTestCasesGroupCPRefChange(t, obj, SupportedByKIC, ControlPlaneRefNotRequired).Run(t)
 	})
 
 	t.Run("required fields", func(t *testing.T) {

--- a/test/crdsvalidation/kongconsumergroup_test.go
+++ b/test/crdsvalidation/kongconsumergroup_test.go
@@ -17,7 +17,7 @@ func TestKongConsumerGroup(t *testing.T) {
 	t.Run("cp ref", func(t *testing.T) {
 		obj := &configurationv1beta1.KongConsumerGroup{
 			TypeMeta: metav1.TypeMeta{
-				Kind:       "KongConsumer",
+				Kind:       "KongConsumerGroup",
 				APIVersion: configurationv1beta1.GroupVersion.String(),
 			},
 			ObjectMeta: commonObjectMeta,
@@ -26,7 +26,7 @@ func TestKongConsumerGroup(t *testing.T) {
 			},
 		}
 
-		NewCRDValidationTestCasesGroupCPRefChange(t, obj, NotSupportedByKIC).Run(t)
+		NewCRDValidationTestCasesGroupCPRefChange(t, obj, SupportedByKIC, ControlPlaneRefNotRequired).Run(t)
 	})
 
 	t.Run("cp ref update", func(t *testing.T) {

--- a/test/crdsvalidation/kongdataplaneclientcertificate_test.go
+++ b/test/crdsvalidation/kongdataplaneclientcertificate_test.go
@@ -25,7 +25,7 @@ func TestKongDataPlaneClientCertificate(t *testing.T) {
 	}
 
 	t.Run("cp ref", func(t *testing.T) {
-		NewCRDValidationTestCasesGroupCPRefChange(t, obj, NotSupportedByKIC).Run(t)
+		NewCRDValidationTestCasesGroupCPRefChange(t, obj, NotSupportedByKIC, ControlPlaneRefRequired).Run(t)
 	})
 
 	t.Run("cp ref, type=kic", func(t *testing.T) {

--- a/test/crdsvalidation/kongkey_test.go
+++ b/test/crdsvalidation/kongkey_test.go
@@ -27,7 +27,7 @@ func TestKongKey(t *testing.T) {
 			},
 		}
 
-		NewCRDValidationTestCasesGroupCPRefChange(t, obj, NotSupportedByKIC).Run(t)
+		NewCRDValidationTestCasesGroupCPRefChange(t, obj, NotSupportedByKIC, ControlPlaneRefNotRequired).Run(t)
 	})
 
 	t.Run("pem/cp ref", func(t *testing.T) {
@@ -48,27 +48,7 @@ func TestKongKey(t *testing.T) {
 			},
 		}
 
-		NewCRDValidationTestCasesGroupCPRefChange(t, obj, NotSupportedByKIC).Run(t)
-	})
-
-	t.Run("pem/cp ref, type=kic", func(t *testing.T) {
-		obj := &configurationv1alpha1.KongKey{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "KongKey",
-				APIVersion: configurationv1alpha1.GroupVersion.String(),
-			},
-			ObjectMeta: commonObjectMeta,
-			Spec: configurationv1alpha1.KongKeySpec{
-				KongKeyAPISpec: configurationv1alpha1.KongKeyAPISpec{
-					KID: "1",
-					PEM: &configurationv1alpha1.PEMKeyPair{
-						PublicKey:  "public",
-						PrivateKey: "private",
-					},
-				},
-			},
-		}
-		NewCRDValidationTestCasesGroupCPRefChangeKICUnsupportedTypes(t, obj, EmptyControlPlaneRefAllowed).Run(t)
+		NewCRDValidationTestCasesGroupCPRefChange(t, obj, NotSupportedByKIC, ControlPlaneRefNotRequired).Run(t)
 	})
 
 	t.Run("spec", func(t *testing.T) {

--- a/test/crdsvalidation/kongkeyset_test.go
+++ b/test/crdsvalidation/kongkeyset_test.go
@@ -26,7 +26,7 @@ func TestKongKeySet(t *testing.T) {
 	}
 
 	t.Run("cp ref", func(t *testing.T) {
-		NewCRDValidationTestCasesGroupCPRefChange(t, obj, NotSupportedByKIC).Run(t)
+		NewCRDValidationTestCasesGroupCPRefChange(t, obj, NotSupportedByKIC, ControlPlaneRefRequired).Run(t)
 	})
 
 	t.Run("cp ref, type=kic", func(t *testing.T) {

--- a/test/crdsvalidation/kongpluginbindings_test.go
+++ b/test/crdsvalidation/kongpluginbindings_test.go
@@ -38,11 +38,10 @@ func TestKongPluginBindings(t *testing.T) {
 						Group: "configuration.konghq.com",
 					},
 				},
-				ControlPlaneRef: validTestCPRef(),
 			},
 		}
 
-		NewCRDValidationTestCasesGroupCPRefChange(t, obj, NotSupportedByKIC).Run(t)
+		NewCRDValidationTestCasesGroupCPRefChange(t, obj, NotSupportedByKIC, ControlPlaneRefRequired).Run(t)
 	})
 
 	t.Run("plugin ref", func(t *testing.T) {

--- a/test/crdsvalidation/kongroute_test.go
+++ b/test/crdsvalidation/kongroute_test.go
@@ -23,7 +23,7 @@ func TestKongRoute(t *testing.T) {
 	}
 
 	t.Run("cp ref", func(t *testing.T) {
-		NewCRDValidationTestCasesGroupCPRefChange(t, obj, NotSupportedByKIC).Run(t)
+		NewCRDValidationTestCasesGroupCPRefChange(t, obj, NotSupportedByKIC, ControlPlaneRefNotRequired).Run(t)
 	})
 
 	t.Run("cp ref, type=kic", func(t *testing.T) {

--- a/test/crdsvalidation/kongservice_test.go
+++ b/test/crdsvalidation/kongservice_test.go
@@ -21,7 +21,7 @@ func TestKongService(t *testing.T) {
 	}
 
 	t.Run("cp ref", func(t *testing.T) {
-		NewCRDValidationTestCasesGroupCPRefChange(t, obj, NotSupportedByKIC).Run(t)
+		NewCRDValidationTestCasesGroupCPRefChange(t, obj, NotSupportedByKIC, ControlPlaneRefRequired).Run(t)
 	})
 
 	t.Run("cp ref, type=kic", func(t *testing.T) {

--- a/test/crdsvalidation/kongupstream_test.go
+++ b/test/crdsvalidation/kongupstream_test.go
@@ -23,7 +23,7 @@ func TestKongUpstream(t *testing.T) {
 	}
 
 	t.Run("cp ref", func(t *testing.T) {
-		NewCRDValidationTestCasesGroupCPRefChange(t, obj, NotSupportedByKIC).Run(t)
+		NewCRDValidationTestCasesGroupCPRefChange(t, obj, NotSupportedByKIC, ControlPlaneRefRequired).Run(t)
 	})
 
 	t.Run("cp ref, type=kic", func(t *testing.T) {

--- a/test/crdsvalidation/kongvault_test.go
+++ b/test/crdsvalidation/kongvault_test.go
@@ -25,7 +25,7 @@ func TestKongVault(t *testing.T) {
 			},
 		}
 
-		NewCRDValidationTestCasesGroupCPRefChange(t, obj, SupportedByKIC).Run(t)
+		NewCRDValidationTestCasesGroupCPRefChange(t, obj, SupportedByKIC, ControlPlaneRefNotRequired).Run(t)
 	})
 
 	t.Run("spec", func(t *testing.T) {

--- a/test/crdsvalidation/suite_crd_ref_change_test.go
+++ b/test/crdsvalidation/suite_crd_ref_change_test.go
@@ -44,6 +44,13 @@ const (
 	NotSupportedByKIC SupportedByKicT = false
 )
 
+type ControlPlaneRefRequiredT bool
+
+const (
+	ControlPlaneRefRequired    ControlPlaneRefRequiredT = true
+	ControlPlaneRefNotRequired ControlPlaneRefRequiredT = false
+)
+
 func NewCRDValidationTestCasesGroupCPRefChange[
 	T interface {
 		client.Object
@@ -56,6 +63,7 @@ func NewCRDValidationTestCasesGroupCPRefChange[
 	t *testing.T,
 	obj T,
 	supportedByKIC SupportedByKicT,
+	controlPlaneRefRequired ControlPlaneRefRequiredT,
 ) crdsvalidation.TestCasesGroup[T] {
 	var (
 		ret = crdsvalidation.TestCasesGroup[T]{}
@@ -333,13 +341,13 @@ func NewCRDValidationTestCasesGroupCPRefChange[
 		}
 	}
 	{
-		if supportedByKIC == NotSupportedByKIC {
+		if controlPlaneRefRequired == ControlPlaneRefRequired {
 			obj := obj.DeepCopy()
 			obj.SetControlPlaneRef(nil)
 			ret = append(ret, crdsvalidation.TestCase[T]{
-				Name:                       "cpRef is required",
-				TestObject:                 obj,
-				ExpectedUpdateErrorMessage: lo.ToPtr("spec.controlPlaneRef is required"),
+				Name:                 "cpRef is required",
+				TestObject:           obj,
+				ExpectedErrorMessage: lo.ToPtr("spec.controlPlaneRef: Required value"),
 			})
 		}
 	}

--- a/test/crdsvalidation/testcase.go
+++ b/test/crdsvalidation/testcase.go
@@ -35,7 +35,7 @@ func (g TestCasesGroup[T]) Run(t *testing.T) {
 
 const (
 	// DefaultEventuallyTimeout is the default timeout for EventuallyConfig.
-	DefaultEventuallyTimeout = 15 * time.Second
+	DefaultEventuallyTimeout = 1 * time.Second
 	// DefaultEventuallyPeriod is the default period for EventuallyConfig.
 	DefaultEventuallyPeriod = 10 * time.Millisecond
 )
@@ -104,7 +104,7 @@ func (tc *TestCase[T]) RunWithConfig(t *testing.T, cfg *rest.Config, scheme *run
 			})
 		}
 
-		assert.EventuallyWithT(t,
+		if !assert.EventuallyWithT(t,
 			func(c *assert.CollectT) {
 				toCreate := tc.TestObject.DeepCopyObject().(T)
 
@@ -122,11 +122,16 @@ func (tc *TestCase[T]) RunWithConfig(t *testing.T, cfg *rest.Config, scheme *run
 					if !assert.Contains(c, err.Error(), *tc.ExpectedErrorMessage) {
 						return
 					}
+				} else {
+					assert.NoError(c, err)
 				}
+
 				tc.TestObject = toCreate
 			},
 			timeout, period,
-		)
+		) {
+			return
+		}
 
 		// Check with reflect if the status field is set and Update the status if so before updating the object.
 		// That's required to populate Status that is not set on Create.


### PR DESCRIPTION
**What this PR does / why we need it**:

CRD validation suite was missing an `assert.NoError(t, err)` when `tc.ExpectedErrorMessage == nil`. This PR adds that.

On top of that some tests needed to be adjusted and KongPluginBinding ContorlPlaneRef validation rule: this field is a non pointer, marked as required, yet for some reason it doesn't fail validation when unset. The newly added validation rule on that field enforces that it is set.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
