### PR TITLE
fix: generate CRDs' embedded object meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ Adding a new version? You'll need three changes:
 - Added `GatewayConfiguration` extension point.
   [#300](https://github.com/Kong/kubernetes-configuration/pull/300)
 
+### Changes
+
+- Set `GenerateEmbeddedObjectMeta` to `true` when generating CRDs to align with
+  existing KGO CRDs.
+  [#298](https://github.com/Kong/kubernetes-configuration/pull/298)
+
 ## [v1.1.0]
 
 [v1.1.0]: https://github.com/Kong/kubernetes-configuration/compare/v1.0.6...v1.1.0

--- a/config/crd/gateway-operator/gateway-operator.konghq.com_controlplanes.yaml
+++ b/config/crd/gateway-operator/gateway-operator.konghq.com_controlplanes.yaml
@@ -76,6 +76,23 @@ spec:
                         description: |-
                           Standard object's metadata.
                           More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          finalizers:
+                            items:
+                              type: string
+                            type: array
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          name:
+                            type: string
+                          namespace:
+                            type: string
                         type: object
                       spec:
                         description: |-
@@ -6826,6 +6843,23 @@ spec:
                                             May contain labels and annotations that will be copied into the PVC
                                             when creating it. No other fields are allowed and will be rejected during
                                             validation.
+                                          properties:
+                                            annotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            finalizers:
+                                              items:
+                                                type: string
+                                              type: array
+                                            labels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
                                           type: object
                                         spec:
                                           description: |-

--- a/config/crd/gateway-operator/gateway-operator.konghq.com_dataplanes.yaml
+++ b/config/crd/gateway-operator/gateway-operator.konghq.com_dataplanes.yaml
@@ -65,6 +65,23 @@ spec:
                         description: |-
                           Standard object's metadata.
                           More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          finalizers:
+                            items:
+                              type: string
+                            type: array
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          name:
+                            type: string
+                          namespace:
+                            type: string
                         type: object
                       spec:
                         description: |-
@@ -6815,6 +6832,23 @@ spec:
                                             May contain labels and annotations that will be copied into the PVC
                                             when creating it. No other fields are allowed and will be rejected during
                                             validation.
+                                          properties:
+                                            annotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            finalizers:
+                                              items:
+                                                type: string
+                                              type: array
+                                            labels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
                                           type: object
                                         spec:
                                           description: |-

--- a/config/crd/gateway-operator/gateway-operator.konghq.com_gatewayconfigurations.yaml
+++ b/config/crd/gateway-operator/gateway-operator.konghq.com_gatewayconfigurations.yaml
@@ -73,6 +73,23 @@ spec:
                             description: |-
                               Standard object's metadata.
                               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              finalizers:
+                                items:
+                                  type: string
+                                type: array
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              name:
+                                type: string
+                              namespace:
+                                type: string
                             type: object
                           spec:
                             description: |-
@@ -6902,6 +6919,23 @@ spec:
                                                 May contain labels and annotations that will be copied into the PVC
                                                 when creating it. No other fields are allowed and will be rejected during
                                                 validation.
+                                              properties:
+                                                annotations:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                                finalizers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                labels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
                                               type: object
                                             spec:
                                               description: |-
@@ -8312,6 +8346,23 @@ spec:
                             description: |-
                               Standard object's metadata.
                               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              finalizers:
+                                items:
+                                  type: string
+                                type: array
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              name:
+                                type: string
+                              namespace:
+                                type: string
                             type: object
                           spec:
                             description: |-
@@ -15141,6 +15192,23 @@ spec:
                                                 May contain labels and annotations that will be copied into the PVC
                                                 when creating it. No other fields are allowed and will be rejected during
                                                 validation.
+                                              properties:
+                                                annotations:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                                finalizers:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                labels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
                                               type: object
                                             spec:
                                               description: |-

--- a/scripts/crds-generator/main.go
+++ b/scripts/crds-generator/main.go
@@ -95,7 +95,8 @@ func main() {
 		Checker: &loader.TypeChecker{
 			NodeFilters: []loader.NodeFilter{generator.CheckFilter()},
 		},
-		AllowDangerousTypes: true, // Allows float32 and float64.
+		AllowDangerousTypes:        true, // Allows float32 and float64.
+		GenerateEmbeddedObjectMeta: true,
 	}
 
 	err = generator.RegisterMarkers(parser.Collector.Registry)


### PR DESCRIPTION
**What this PR does / why we need it**:

Add missing `GenerateEmbeddedObjectMeta` flag when generating CRDs. This is necessary to align with existing KGO CRDs (this option up until now has been set in https://github.com/Kong/gateway-operator/blob/26c8db7b0f86bfd6edbdd36033efbda1de5ae90e/Makefile#L293).

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
