### PR TITLE
chore: downgrade sdk-konnect-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/kong/kubernetes-configuration
 go 1.24.0
 
 require (
-	github.com/Kong/sdk-konnect-go v0.2.12
+	github.com/Kong/sdk-konnect-go v0.2.10
 	github.com/kong/go-kong v0.63.0
 	github.com/stretchr/testify v1.10.0
 	k8s.io/api v0.32.2

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Kong/sdk-konnect-go v0.2.12 h1:TjP+cqMLzY0fucHZlY9bxDQWWKJWsaL13EBO0luMzUE=
-github.com/Kong/sdk-konnect-go v0.2.12/go.mod h1:xsmTIkBbmVyUh1nRFjQMOhxYIPDl+sMfmRmPuZHtwLE=
+github.com/Kong/sdk-konnect-go v0.2.10 h1:0uMDjZUyo4qjGPzpS9yisPUokIt6HHCz/tnjCIN43to=
+github.com/Kong/sdk-konnect-go v0.2.10/go.mod h1:xsmTIkBbmVyUh1nRFjQMOhxYIPDl+sMfmRmPuZHtwLE=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=


### PR DESCRIPTION
**What this PR does / why we need it**:

sdk-konnect-go 0.2.12 introduced a breaking change that prevents us to bump kubernetes-configuration in KGO. Temporarily downgrading to 0.2.10 to allow the bump. Note: 0.2.11 does not exist at all.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
