### PR TITLE
chore: add a sample manifest for DataPlane with Konnect extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ lint.actions: download.actionlint download.shellcheck
 
 .PHONY: test.samples
 test.samples: kustomize
-	find ./config/samples -not -name "kustomization.*" -type f | sort | xargs -I{} bash -c "kubectl apply -f {}; kubectl delete -f {}"
+	@cd config/samples/ && find . -not -name "kustomization.*" -type f | sort | xargs -I{} bash -c "echo;echo {}; kubectl apply -f {} && kubectl delete -f {}" \;
 
 GOTESTSUM_FORMAT ?= standard-verbose
 

--- a/api/konnect/v1alpha1/konnect_extension_types.go
+++ b/api/konnect/v1alpha1/konnect_extension_types.go
@@ -72,6 +72,7 @@ type KonnectExtensionSpec struct {
 	//
 	// +kubebuilder:validation:Required
 	KonnectControlPlane KonnectExtensionControlPlane `json:"konnectControlPlane"`
+
 	// DataPlaneClientAuth is the configuration for the client certificate authentication for the DataPlane.
 	// In case the ControlPlaneRef is of type KonnectID, it is required to set up the connection with the
 	// Konnect Platform.

--- a/config/samples/konnect_dataplane_with_konnectextension.yaml
+++ b/config/samples/konnect_dataplane_with_konnectextension.yaml
@@ -1,0 +1,54 @@
+kind: KonnectAPIAuthConfiguration
+apiVersion: konnect.konghq.com/v1alpha1
+metadata:
+  name: konnect-api-auth
+spec:
+  type: token
+  token: kpat_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+  serverURL: us.api.konghq.com
+---
+apiVersion: konnect.konghq.com/v1alpha1
+kind: KonnectExtension
+metadata:
+  name: my-konnect-extension
+spec:
+  konnectControlPlane:
+    controlPlaneRef:
+      type: konnectID
+      konnectID: 12345678-1234-1234-1234-123456789abc
+  dataPlaneClientAuth:
+    certificateSecret:
+      provisioning: Automatic
+  konnect:
+    authRef:
+      name: konnect-api-auth
+  dataPlaneLabels:
+    environment: "production"
+    team: "platform"
+    application: "payments"
+---
+apiVersion: gateway-operator.konghq.com/v1beta1
+kind: DataPlane
+metadata:
+  name: dataplane-konnect-extension-example
+spec:
+  extensions:
+  - kind: KonnectExtension
+    name: my-konnect-config
+    group: gateway-operator.konghq.com
+  deployment:
+    replicas: 3
+    podTemplateSpec:
+      metadata:
+        labels:
+          dataplane-pod-label: example
+        annotations:
+          dataplane-pod-annotation: example
+      spec:
+        containers:
+        - name: proxy
+          # renovate: datasource=docker versioning=docker
+          image: kong/kong-gateway:3.9
+          readinessProbe:
+            initialDelaySeconds: 1
+            periodSeconds: 1


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a sample for DataPlane with Konnect extension (as a follow up to #315).

This will help catch errors in API vs the expected manifests to be used early.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
