### PR TITLE
chore: migrate KGO conditions to this repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ Adding a new version? You'll need three changes:
 - [v1.0.2](#v102)
 - [v1.0.0](#v100)
 
+## Unreleased
+
+### Added
+
+- Migrate KGO conditions to this repo.
+  [#323](https://github.com/Kong/kubernetes-configuration/pull/323)
+
 ## [v1.2.0-rc.1]
 
 [v1.2.0-rc.1]: https://github.com/Kong/kubernetes-configuration/compare/v1.1.0...v1.2.0-rc.1

--- a/api/common/consts/consts.go
+++ b/api/common/consts/consts.go
@@ -1,0 +1,7 @@
+package consts
+
+// ConditionType literal that defines the different types of condition
+type ConditionType string
+
+// ConditionReason represents a literal to enumerate a specific condition reason
+type ConditionReason string

--- a/api/gateway-operator/controlplane/conditions.go
+++ b/api/gateway-operator/controlplane/conditions.go
@@ -1,0 +1,35 @@
+package controlplane
+
+import "github.com/kong/kubernetes-configuration/api/common/consts"
+
+// -----------------------------------------------------------------------------
+// ControlPlane - Status Condition Types
+// -----------------------------------------------------------------------------
+
+const (
+	// ConditionTypeProvisioned is a condition type indicating whether or
+	// not all Deployments (or Daemonsets) for the ControlPlane have been provisioned
+	// successfully.
+	ConditionTypeProvisioned consts.ConditionType = "Provisioned"
+)
+
+// -----------------------------------------------------------------------------
+// ControlPlane - Status Condition Reasons
+// -----------------------------------------------------------------------------
+
+// ConditionReason are the condition reasons for ControlPlane status conditions.
+type ConditionReason string
+
+const (
+	// ConditionReasonPodsNotReady is a reason which indicates why a ControlPlane
+	// has not yet reached a fully Provisioned status.
+	ConditionReasonPodsNotReady consts.ConditionReason = "PodsNotReady"
+
+	// ConditionReasonPodsReady is a reason which indicates how a ControlPlane
+	// reached fully Provisioned status.
+	ConditionReasonPodsReady consts.ConditionReason = "PodsReady"
+
+	// ConditionReasonNoDataPlane is a reason which indicates that no DataPlane
+	// has been provisioned.
+	ConditionReasonNoDataPlane consts.ConditionReason = "NoDataPlane"
+)

--- a/api/gateway-operator/dataplane/conditions.go
+++ b/api/gateway-operator/dataplane/conditions.go
@@ -1,0 +1,47 @@
+package dataplane
+
+import "github.com/kong/kubernetes-configuration/api/common/consts"
+
+// -----------------------------------------------------------------------------
+// DataPlane - Status Condition Reasons
+// -----------------------------------------------------------------------------
+
+const (
+	// DataPlaneConditionValidationFailed is a reason which indicates validation of
+	// a dataplane is failed.
+	DataPlaneConditionValidationFailed consts.ConditionReason = "ValidationFailed"
+
+	// DataPlaneConditionReferencedResourcesNotAvailable is a reason which indicates
+	// that the referenced resources in DataPlane configuration (e.g. KongPluginInstallation)
+	// are not available.
+	DataPlaneConditionReferencedResourcesNotAvailable consts.ConditionReason = "ReferencedResourcesNotAvailable"
+)
+
+// -----------------------------------------------------------------------------
+// DataPlane - Ready Condition Constants
+// -----------------------------------------------------------------------------
+
+const (
+	// ReadyType indicates if the resource has all the dependent conditions Ready
+	ReadyType consts.ConditionType = "Ready"
+
+	// DependenciesNotReadyReason is a generic reason describing that the other Conditions are not true
+	DependenciesNotReadyReason consts.ConditionReason = "DependenciesNotReady"
+	// ResourceReadyReason indicates the resource is ready
+	ResourceReadyReason consts.ConditionReason = consts.ConditionReason("Ready")
+	// WaitingToBecomeReadyReason generic message for dependent resources waiting to be ready
+	WaitingToBecomeReadyReason consts.ConditionReason = "WaitingToBecomeReady"
+	// ResourceCreatedOrUpdatedReason generic message for missing or outdated resources
+	ResourceCreatedOrUpdatedReason consts.ConditionReason = "ResourceCreatedOrUpdated"
+	// UnableToProvisionReason generic message for unexpected errors
+	UnableToProvisionReason consts.ConditionReason = "UnableToProvision"
+
+	// DependenciesNotReadyMessage indicates the other conditions are not yet ready
+	DependenciesNotReadyMessage = "There are other conditions that are not yet ready"
+	// WaitingToBecomeReadyMessage indicates the target resource is not ready
+	WaitingToBecomeReadyMessage = "Waiting for the resource to become ready"
+	// ResourceCreatedMessage indicates a missing resource was provisioned
+	ResourceCreatedMessage = "Resource has been created"
+	// ResourceUpdatedMessage indicates a resource was updated
+	ResourceUpdatedMessage = "Resource has been updated"
+)

--- a/api/gateway-operator/gateway/conditions.go
+++ b/api/gateway-operator/gateway/conditions.go
@@ -1,0 +1,33 @@
+package gateway
+
+import "github.com/kong/kubernetes-configuration/api/common/consts"
+
+// -----------------------------------------------------------------------------
+// Gateway - Status Condition Types
+// -----------------------------------------------------------------------------
+
+const (
+	// GatewayServiceType the Gateway service condition type
+	GatewayServiceType consts.ConditionType = "GatewayService"
+
+	// ControlPlaneReadyType the ControlPlane is deployed and Ready
+	ControlPlaneReadyType consts.ConditionType = "ControlPlaneReady"
+
+	// DataPlaneReadyType the DataPlane is deployed and Ready
+	DataPlaneReadyType consts.ConditionType = "DataPlaneReady"
+)
+
+// -----------------------------------------------------------------------------
+// Gateway - Status Condition Reasons
+// -----------------------------------------------------------------------------
+
+const (
+	// GatewayReasonServiceError must be used with the GatewayService condition
+	// to express that the Gateway Service is not properly configured.
+	GatewayReasonServiceError consts.ConditionReason = "GatewayServiceError"
+
+	// ListenerReasonTooManyTLSSecrets must be used with the ResolvedRefs condition
+	// to express that more than one TLS secret has been set in the listener
+	// TLS configuration.
+	ListenerReasonTooManyTLSSecrets consts.ConditionReason = "TooManyTLSSecrets"
+)

--- a/api/konnect/conditions.go
+++ b/api/konnect/conditions.go
@@ -1,0 +1,49 @@
+package konnect
+
+import "github.com/kong/kubernetes-configuration/api/common/consts"
+
+// -----------------------------------------------------------------------------
+// DataPlane - Extensions conditions Constants
+// -----------------------------------------------------------------------------
+
+const (
+	// KonnectExtensionAppliedType indicates that the KonnectExtension has been applied
+	KonnectExtensionAppliedType consts.ConditionType = "KonnectExtensionApplied"
+
+	// KonnectExtensionAppliedReason is a reason describing that the Konnect extension has been applied. It must be used when the KonnectExtensionApplied condition is set to True.
+	KonnectExtensionAppliedReason consts.ConditionReason = "KonnectExtensionApplied"
+	// RefNotPermittedReason is a reason describing that the cross-namespace reference is not permitted. It must be used when the KonnectExtensionApplied condition is set to False.
+	RefNotPermittedReason consts.ConditionReason = "RefNotPermitted"
+	// InvalidExtensionRefReason is a reason describing that the extension reference is invalid. It must be used when the KonnectExtensionApplied condition is set to False.
+	InvalidExtensionRefReason consts.ConditionReason = "InvalidExtension"
+	// InvalidSecretRefReason is a reason describing that the secret reference in the KonnectExtension is invalid. It must be used when the KonnectExtensionApplied condition is set to False.
+	InvalidSecretRefReason consts.ConditionReason = "InvalidSecret"
+	// KonnectExtensionNotReadyReason is a reason describing that the Konnect extension is not ready. It must be used when the KonnectExtensionApplied condition is set to False.
+	KonnectExtensionNotReadyReason consts.ConditionReason = "KonnectExtensionNotReady"
+)
+
+const (
+	// AcceptedExtensionsType inditicates if the resource has all the dependent extensions accepted
+	AcceptedExtensionsType consts.ConditionType = "AcceptedExtensions"
+
+	// AcceptedExtensionsReason is a reason describing that the extensions are accepted. It must be used when the AcceptedExtensions condition is set to True.
+	AcceptedExtensionsReason consts.ConditionReason = "AcceptedExtensions"
+	// NotSupportedExtensionsReason is a reason describing that the extensions are not supported. It must be used when the AcceptedExtensions condition is set to False.
+	NotSupportedExtensionsReason consts.ConditionReason = "NotSupportedExtensions"
+)
+
+// -----------------------------------------------------------------------------
+// Konnect entities - Programmed Condition Constants
+// -----------------------------------------------------------------------------
+
+const (
+	// KonnectEntitiesFailedToCreateReason is the reason assigned to Konnect entities that failed to get created.
+	// It must be used when Programmed condition is set to False.
+	KonnectEntitiesFailedToCreateReason consts.ConditionReason = "FailedToCreate"
+	// KonnectEntitiesFailedToUpdateReason is the reason assigned to Konnect entities that failed to get updated.
+	// It must be used when Programmed condition is set to False.
+	KonnectEntitiesFailedToUpdateReason consts.ConditionReason = "FailedToUpdate"
+	// FailedToAttachConsumerToConsumerGroupReason is the reason assigned to KonnConsumers when failed to attach it to any consumer group.
+	// It must be used when Programmed condition is set to False.
+	FailedToAttachConsumerToConsumerGroupReason consts.ConditionReason = "FailedToAttachConsumerToConsumerGroup"
+)


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request introduces new condition types and reasons across multiple components in the `api` package. The changes include defining new literals for condition types and reasons, and applying these in various sub-packages to standardize status reporting.

Key changes include:

### Common Constants Definition:

* [`api/common/consts/consts.go`](diffhunk://#diff-f65991d0446b9b25a0ec8b204591d4f2e02f534ad116fea8c5eeddc6c3aeadffR1-R7): Added `ConditionType` and `ConditionReason` types to define condition literals.

### ControlPlane Conditions:

* [`api/gateway-operator/controlplane/conditions.go`](diffhunk://#diff-4ede1ca2bf1be900d3660968d735c6e02e39d0e872cc9a09633d8aa6279e0296R1-R35): Introduced `ConditionTypeProvisioned` and various `ConditionReason` literals to describe the status of the ControlPlane.

### DataPlane Conditions:

* [`api/gateway-operator/dataplane/conditions.go`](diffhunk://#diff-e7f49a8e67e675b6df7b1c65edea07e23e4cfce12834741a14babbaa6758cc2aR1-R47): Added multiple `ConditionReason` literals for validation and readiness status, along with `ReadyType` and related messages.

### Gateway Conditions:

* [`api/gateway-operator/gateway/conditions.go`](diffhunk://#diff-673f802d518bf1dec68f77a3a49616dfaadaa2f067f84b1e509ee7e84f0dc983R1-R33): Defined condition types and reasons for Gateway service and readiness status of ControlPlane and DataPlane.

### Konnect Conditions:

* [`api/konnect/conditions.go`](diffhunk://#diff-4427ba91d13b04c4fa8244d467ccba38bd5716c027591d396bb52c21913ab074R1-R49): Introduced condition types and reasons for Konnect extensions and entities, including reasons for failure scenarios.

**Which issue this PR fixes**

part of https://github.com/Kong/kubernetes-configuration/issues/303

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
