### PR TITLE
revert: DP and CP empty deploymentSpec not allowed

### DIFF
--- a/api/gateway-operator/v1beta1/controlplane_types.go
+++ b/api/gateway-operator/v1beta1/controlplane_types.go
@@ -28,6 +28,8 @@ func init() {
 	SchemeBuilder.Register(&ControlPlane{}, &ControlPlaneList{})
 }
 
+// ControlPlane is the Schema for the controlplanes API
+//
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
@@ -35,9 +37,7 @@ func init() {
 // +kubebuilder:resource:shortName=kocp,categories=kong;all
 // +kubebuilder:printcolumn:name="Ready",description="The Resource is ready",type=string,JSONPath=`.status.conditions[?(@.type=='Ready')].status`
 // +kubebuilder:printcolumn:name="Provisioned",description="The Resource is provisioned",type=string,JSONPath=`.status.conditions[?(@.type=='Provisioned')].status`
-// +kubebuilder:validation:XValidation:message="ControlPlane requires an image to be set on controller container",rule="((has(self.spec.deployment) && has(self.spec.deployment.podTemplateSpec) && has(self.spec.deployment.podTemplateSpec.spec)) ? self.spec.deployment.podTemplateSpec.spec.containers.exists(c, c.name == 'controller' && has(c.image)) : true)"
-
-// ControlPlane is the Schema for the controlplanes API
+// +kubebuilder:validation:XValidation:message="ControlPlane requires an image to be set on controller container",rule="has(self.spec.deployment.podTemplateSpec) && has(self.spec.deployment.podTemplateSpec.spec.containers) && self.spec.deployment.podTemplateSpec.spec.containers.exists(c, c.name == 'controller' && has(c.image))"
 // +apireference:kgo:include
 // +kong:channels=gateway-operator
 type ControlPlane struct {

--- a/api/gateway-operator/v1beta1/dataplane_types.go
+++ b/api/gateway-operator/v1beta1/dataplane_types.go
@@ -39,7 +39,7 @@ func init() {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=kodp,categories=kong;all
 // +kubebuilder:printcolumn:name="Ready",description="The Resource is ready",type=string,JSONPath=`.status.conditions[?(@.type=='Ready')].status`
-// +kubebuilder:validation:XValidation:message="DataPlane requires an image to be set on proxy container",rule="((has(self.spec.deployment) && has(self.spec.deployment.podTemplateSpec) && has(self.spec.deployment.podTemplateSpec.spec)) ? self.spec.deployment.podTemplateSpec.spec.containers.exists(c, c.name == 'proxy' && has(c.image)) : true)"
+// +kubebuilder:validation:XValidation:message="DataPlane requires an image to be set on proxy container",rule="has(self.spec.deployment.podTemplateSpec) && has(self.spec.deployment.podTemplateSpec.spec.containers) && self.spec.deployment.podTemplateSpec.spec.containers.exists(c, c.name == 'proxy' && has(c.image))"
 // +kubebuilder:validation:XValidation:message="DataPlane supports only db mode 'off'",rule="!has(self.spec.deployment.podTemplateSpec) ? true : ( self.spec.deployment.podTemplateSpec.spec.containers.size() == 0 || self.spec.deployment.podTemplateSpec.spec.containers[0].name == 'proxy' ? (!has(self.spec.deployment.podTemplateSpec.spec.containers[0].env) ? true : self.spec.deployment.podTemplateSpec.spec.containers[0].env.all(e, e.name != 'KONG_DATABASE' || e.value == 'off' || size(e.value)==0)) : true)"
 // +kubebuilder:validation:XValidation:message="DataPlane spec cannot be updated when promotion is in progress",rule="((self.spec == oldSelf.spec) || !has(self.status.rollout)) ? true : self.status.rollout.conditions.all(c, c.type != 'RolledOut' || c.reason != 'PromotionInProgress')"
 type DataPlane struct {

--- a/config/crd/gateway-operator/gateway-operator.konghq.com_controlplanes.yaml
+++ b/config/crd/gateway-operator/gateway-operator.konghq.com_controlplanes.yaml
@@ -8338,9 +8338,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: ControlPlane requires an image to be set on controller container
-          rule: '((has(self.spec.deployment) && has(self.spec.deployment.podTemplateSpec)
-            && has(self.spec.deployment.podTemplateSpec.spec)) ? self.spec.deployment.podTemplateSpec.spec.containers.exists(c,
-            c.name == ''controller'' && has(c.image)) : true)'
+          rule: has(self.spec.deployment.podTemplateSpec) && has(self.spec.deployment.podTemplateSpec.spec.containers)
+            && self.spec.deployment.podTemplateSpec.spec.containers.exists(c, c.name
+            == 'controller' && has(c.image))
     served: true
     storage: true
     subresources:

--- a/config/crd/gateway-operator/gateway-operator.konghq.com_dataplanes.yaml
+++ b/config/crd/gateway-operator/gateway-operator.konghq.com_dataplanes.yaml
@@ -9453,9 +9453,9 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: DataPlane requires an image to be set on proxy container
-          rule: '((has(self.spec.deployment) && has(self.spec.deployment.podTemplateSpec)
-            && has(self.spec.deployment.podTemplateSpec.spec)) ? self.spec.deployment.podTemplateSpec.spec.containers.exists(c,
-            c.name == ''proxy'' && has(c.image)) : true)'
+          rule: has(self.spec.deployment.podTemplateSpec) && has(self.spec.deployment.podTemplateSpec.spec.containers)
+            && self.spec.deployment.podTemplateSpec.spec.containers.exists(c, c.name
+            == 'proxy' && has(c.image))
         - message: DataPlane supports only db mode 'off'
           rule: '!has(self.spec.deployment.podTemplateSpec) ? true : ( self.spec.deployment.podTemplateSpec.spec.containers.size()
             == 0 || self.spec.deployment.podTemplateSpec.spec.containers[0].name ==

--- a/test/crdsvalidation/gateway-operator.konghq.com/controlplane_test.go
+++ b/test/crdsvalidation/gateway-operator.konghq.com/controlplane_test.go
@@ -96,6 +96,7 @@ func TestControlPlane(t *testing.T) {
 					ObjectMeta: common.CommonObjectMeta,
 					Spec:       operatorv1beta1.ControlPlaneSpec{},
 				},
+				ExpectedErrorMessage: lo.ToPtr("ControlPlane requires an image to be set on controller container"),
 			},
 			{
 				Name: "with deploymentSpec",
@@ -107,6 +108,7 @@ func TestControlPlane(t *testing.T) {
 						},
 					},
 				},
+				ExpectedErrorMessage: lo.ToPtr("ControlPlane requires an image to be set on controller container"),
 			},
 			{
 				Name: "missing container",

--- a/test/crdsvalidation/gateway-operator.konghq.com/dataplane_test.go
+++ b/test/crdsvalidation/gateway-operator.konghq.com/dataplane_test.go
@@ -70,6 +70,7 @@ func TestDataplane(t *testing.T) {
 					ObjectMeta: common.CommonObjectMeta,
 					Spec:       operatorv1beta1.DataPlaneSpec{},
 				},
+				ExpectedErrorMessage: lo.ToPtr("DataPlane requires an image to be set on proxy container"),
 			},
 			{
 				Name: "with deploymentSpec",
@@ -83,6 +84,7 @@ func TestDataplane(t *testing.T) {
 						},
 					},
 				},
+				ExpectedErrorMessage: lo.ToPtr("DataPlane requires an image to be set on proxy container"),
 			},
 			{
 				Name: "missing container",


### PR DESCRIPTION
**What this PR does / why we need it**:

With https://github.com/Kong/kubernetes-configuration/pull/331 we loosened DP and CP validation by allowing empty `DeploymentSpec`. This is wrong as DP and CP are not allowed to have empty `DeploymentSpec`. This PR fixes that regression.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
