### PR TITLE
chore: migrate KGO bluegreen conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Adding a new version? You'll need three changes:
 
 ### Added
 
-- Migrate KGO conditions o this repo.
+- Migrate KGO conditions to this repo.
   [#323](https://github.com/Kong/kubernetes-configuration/pull/323)
   [#337](https://github.com/Kong/kubernetes-configuration/pull/337)
 - Disallowed `konnectID` as `ControlPlaneRef`'s `type` field value for Konnect entities that do not support it yet:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ Adding a new version? You'll need three changes:
 
 ### Added
 
-- Migrate KGO conditions to this repo.
+- Migrate KGO conditions o this repo.
   [#323](https://github.com/Kong/kubernetes-configuration/pull/323)
+  [#337](https://github.com/Kong/kubernetes-configuration/pull/337)
 - Disallowed `konnectID` as `ControlPlaneRef`'s `type` field value for Konnect entities that do not support it yet:
   - `KongCACertificate`
   - `KongCertificate`

--- a/api/gateway-operator/dataplane/conditions.go
+++ b/api/gateway-operator/dataplane/conditions.go
@@ -45,3 +45,59 @@ const (
 	// ResourceUpdatedMessage indicates a resource was updated
 	ResourceUpdatedMessage = "Resource has been updated"
 )
+
+// -----------------------------------------------------------------------------
+// DataPlane - BlueGreen Condition Constants
+// -----------------------------------------------------------------------------
+
+const (
+	// DataPlaneConditionTypeRolledOut is a condition type indicating whether or
+	// not, DataPlane's rollout has been successful or not.
+	DataPlaneConditionTypeRolledOut consts.ConditionType = "RolledOut"
+)
+
+const (
+	// DataPlaneConditionReasonRolloutAwaitingPromotion is a reason which indicates a DataPlane
+	// preview has been deployed successfully and is awaiting promotion.
+	// If this Reason is present and no automated rollout is disabled, user can
+	// use the preview services and deployment to inspect the state of those
+	// make a judgement call if the promotion should happen.
+	DataPlaneConditionReasonRolloutAwaitingPromotion consts.ConditionReason = "AwaitingPromotion"
+
+	// DataPlaneConditionReasonRolloutFailed is a reason which indicates a DataPlane
+	// has failed to roll out. This may be caused for example by a Deployment or
+	// a Service failing to get created during a rollout.
+	DataPlaneConditionReasonRolloutFailed consts.ConditionReason = "Failed"
+
+	// DataPlaneConditionReasonRolloutProgressing is a reason which indicates a DataPlane's
+	// new version is being rolled out.
+	DataPlaneConditionReasonRolloutProgressing consts.ConditionReason = "Progressing"
+
+	// DataPlaneConditionReasonRolloutWaitingForChange is a reason which indicates a DataPlane
+	// is waiting for a change to trigger new version to be made available before promotion.
+	DataPlaneConditionReasonRolloutWaitingForChange consts.ConditionReason = "WaitingForChange"
+
+	// DataPlaneConditionReasonRolloutPromotionInProgress is a reason which
+	// indicates that a promotion is in progress.
+	DataPlaneConditionReasonRolloutPromotionInProgress consts.ConditionReason = "PromotionInProgress"
+
+	// DataPlaneConditionReasonRolloutPromotionFailed is a reason which indicates
+	// a DataPlane has failed to promote. This may be caused for example by
+	// a failure in updating a live Service.
+	DataPlaneConditionReasonRolloutPromotionFailed consts.ConditionReason = "PromotionFailed"
+
+	// DataPlaneConditionReasonRolloutPromotionDone is a reason which indicates that a promotion is done.
+	DataPlaneConditionReasonRolloutPromotionDone consts.ConditionReason = "PromotionDone"
+)
+
+const (
+	// DataPlaneConditionMessageRolledOutRolloutInitialized contains the message
+	// that is set for the RolledOut Condition when Reason is Progressing
+	// and the DataPlane has initiated a rollout.
+	DataPlaneConditionMessageRolledOutRolloutInitialized = "Rollout initialized"
+
+	// DataPlaneConditionMessageRolledOutPreviewDeploymentNotYetReady contains the message
+	// that is set for the RolledOut Condition when Reason is Progressing
+	// and the operator is waiting for preview Deployment to be ready.
+	DataPlaneConditionMessageRolledOutPreviewDeploymentNotYetReady = "Preview Deployment not yet ready"
+)


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request introduces new constants related to the BlueGreen deployment strategy for the DataPlane component. These changes help in tracking the status and reasons for various stages of the DataPlane rollout process.



**Which issue this PR fixes**

part of https://github.com/Kong/kubernetes-configuration/issues/303

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
