### PR TITLE
fix: allow `DataPlaneMetricsExtension` for `GatewayConfiguration`

### DIFF
--- a/api/gateway-operator/v1beta1/gatewayconfiguration_types.go
+++ b/api/gateway-operator/v1beta1/gatewayconfiguration_types.go
@@ -34,7 +34,7 @@ func init() {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=kogc,categories=kong;all
-// +kubebuilder:validation:XValidation:message="Extension not allowed for GatewayConfiguration",rule="has(self.spec.extensions) ? self.spec.extensions.all(e, e.group == 'konnect.konghq.com' && e.kind == 'KonnectExtension') : true"
+// +kubebuilder:validation:XValidation:message="Extension not allowed for GatewayConfiguration",rule="has(self.spec.extensions) ? self.spec.extensions.all(e, (e.group == 'konnect.konghq.com' && e.kind == 'KonnectExtension') || (e.group == 'gateway-operator.konghq.com' && e.kind == 'DataPlaneMetricsExtension')) : true"
 type GatewayConfiguration struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/gateway-operator/gateway-operator.konghq.com_gatewayconfigurations.yaml
+++ b/config/crd/gateway-operator/gateway-operator.konghq.com_gatewayconfigurations.yaml
@@ -17527,8 +17527,10 @@ spec:
         type: object
         x-kubernetes-validations:
         - message: Extension not allowed for GatewayConfiguration
-          rule: 'has(self.spec.extensions) ? self.spec.extensions.all(e, e.group ==
-            ''konnect.konghq.com'' && e.kind == ''KonnectExtension'') : true'
+          rule: 'has(self.spec.extensions) ? self.spec.extensions.all(e, (e.group
+            == ''konnect.konghq.com'' && e.kind == ''KonnectExtension'') || (e.group
+            == ''gateway-operator.konghq.com'' && e.kind == ''DataPlaneMetricsExtension''))
+            : true'
     served: true
     storage: true
     subresources:


### PR DESCRIPTION
**What this PR does / why we need it**:

For `ControlPlane` [e.kind == 'DataPlaneMetricsExtension'](https://github.com/Kong/kubernetes-configuration/blob/da21a286cd79d5c7decf1e64c8f801567fb57d0b/api/gateway-operator/v1beta1/controlplane_types.go#L92) is allowed, but for `GatewayConfiguration` it is missing which makes [TestControlPlaneExtensions_DataPlaneMetrics in KGO EE fail](https://github.com/Kong/gateway-operator-enterprise/blob/b332d3b9cd3256ba52e6be674b50df540b6b3439/test/integration/test_controlplane_extensions_dataplanemetrics.go#L179-L196). This PR fixes it 