### PR TITLE
fix(konnect): fix KonnectGatewayControlPlane CEL rules checking `cloud_gateway` field

### DIFF
--- a/api/konnect/v1alpha1/konnect_gateway_controlplane_types.go
+++ b/api/konnect/v1alpha1/konnect_gateway_controlplane_types.go
@@ -46,7 +46,7 @@ type KonnectGatewayControlPlane struct {
 // +kubebuilder:validation:XValidation:message="when specified, spec.cluster_type must be one of 'CLUSTER_TYPE_CONTROL_PLANE_GROUP', 'CLUSTER_TYPE_CONTROL_PLANE' or 'CLUSTER_TYPE_K8S_INGRESS_CONTROLLER'", rule="!has(self.cluster_type) ? true : ['CLUSTER_TYPE_CONTROL_PLANE_GROUP', 'CLUSTER_TYPE_CONTROL_PLANE', 'CLUSTER_TYPE_K8S_INGRESS_CONTROLLER'].exists(ct, ct == self.cluster_type)"
 // +kubebuilder:validation:XValidation:message="spec.members is only applicable for ControlPlanes that are created as groups", rule="(has(self.cluster_type) && self.cluster_type != 'CLUSTER_TYPE_CONTROL_PLANE_GROUP') ? !has(self.members) : true"
 // +kubebuilder:validation:XValidation:message="spec.cluster_type is immutable", rule="!has(self.cluster_type) ? !has(oldSelf.cluster_type) : self.cluster_type == oldSelf.cluster_type"
-// +kubebuilder:validation:XValidation:message="cloud_gateway cannot be set for cluster_type 'CLUSTER_TYPE_K8S_INGRESS_CONTROLLER'", rule="has(self.cluster_type) && self.cluster_type == 'CLUSTER_TYPE_K8S_INGRESS_CONTROLLER' ? self.cloud_gateway == false : true"
+// +kubebuilder:validation:XValidation:message="cloud_gateway cannot be set for cluster_type 'CLUSTER_TYPE_K8S_INGRESS_CONTROLLER'", rule="has(self.cluster_type) && self.cluster_type == 'CLUSTER_TYPE_K8S_INGRESS_CONTROLLER' ? !has(self.cloud_gateway) : true"
 // +apireference:kgo:include
 type KonnectGatewayControlPlaneSpec struct {
 	sdkkonnectcomp.CreateControlPlaneRequest `json:",inline"`

--- a/config/crd/gateway-operator/konnect.konghq.com_konnectgatewaycontrolplanes.yaml
+++ b/config/crd/gateway-operator/konnect.konghq.com_konnectgatewaycontrolplanes.yaml
@@ -180,7 +180,7 @@ spec:
                 == oldSelf.cluster_type'
             - message: cloud_gateway cannot be set for cluster_type 'CLUSTER_TYPE_K8S_INGRESS_CONTROLLER'
               rule: 'has(self.cluster_type) && self.cluster_type == ''CLUSTER_TYPE_K8S_INGRESS_CONTROLLER''
-                ? self.cloud_gateway == false : true'
+                ? !has(self.cloud_gateway) : true'
           status:
             description: Status defines the observed state of KonnectGatewayControlPlane.
             properties:

--- a/test/crdsvalidation/konnect.konghq.com/konnectgatewaycontrolplane_test.go
+++ b/test/crdsvalidation/konnect.konghq.com/konnectgatewaycontrolplane_test.go
@@ -684,7 +684,7 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 				ExpectedUpdateErrorMessage: lo.ToPtr("spec.cluster_type is immutable"),
 			},
 			{
-				Name: "cannot set cloud_gateway for cluster_type CLUSTER_TYPE_K8S_INGRESS_CONTROLLER",
+				Name: "cannot set cloud_gateway to true for cluster_type CLUSTER_TYPE_K8S_INGRESS_CONTROLLER",
 				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
 					ObjectMeta: common.CommonObjectMeta,
 					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
@@ -701,6 +701,42 @@ func TestKonnectGatewayControlPlane(t *testing.T) {
 					},
 				},
 				ExpectedErrorMessage: lo.ToPtr("cloud_gateway cannot be set for cluster_type 'CLUSTER_TYPE_K8S_INGRESS_CONTROLLER'"),
+			},
+			{
+				Name: "cannot set cloud_gateway to false for cluster_type CLUSTER_TYPE_K8S_INGRESS_CONTROLLER",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:         "cp-1",
+							ClusterType:  sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeK8SIngressController.ToPointer(),
+							CloudGateway: lo.ToPtr(false),
+						},
+						KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("cloud_gateway cannot be set for cluster_type 'CLUSTER_TYPE_K8S_INGRESS_CONTROLLER'"),
+			},
+			{
+				Name: "not setting cloud_gateway for cluster_type CLUSTER_TYPE_K8S_INGRESS_CONTROLLER passes",
+				TestObject: &konnectv1alpha1.KonnectGatewayControlPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: konnectv1alpha1.KonnectGatewayControlPlaneSpec{
+						CreateControlPlaneRequest: sdkkonnectcomp.CreateControlPlaneRequest{
+							Name:        "cp-1",
+							ClusterType: sdkkonnectcomp.CreateControlPlaneRequestClusterTypeClusterTypeK8SIngressController.ToPointer(),
+						},
+						KonnectConfiguration: konnectv1alpha1.KonnectConfiguration{
+							APIAuthConfigurationRef: konnectv1alpha1.KonnectAPIAuthConfigurationRef{
+								Name: "name-1",
+							},
+						},
+					},
+				},
 			},
 		}.Run(t)
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:

Noticed in https://github.com/Kong/gateway-operator/actions/runs/13786423423/job/38558100419?pr=1315#step:5:1378

```
    konnect_entities_kongservice_test.go:165: 
        	Error Trace:	/home/runner/work/gateway-operator/gateway-operator/test/helpers/deploy/deploy_resources.go:203
        	            				/home/runner/work/gateway-operator/gateway-operator/test/helpers/deploy/deploy_resources.go:245
        	            				/home/runner/work/gateway-operator/gateway-operator/test/envtest/konnect_entities_kongservice_test.go:165
        	Error:      	Received unexpected error:
        	            	KonnectGatewayControlPlane.konnect.konghq.com "cp-a55b3655" is invalid: spec: Invalid value: "object": no such key: cloud_gateway evaluating rule: cloud_gateway cannot be set for cluster_type 'CLUSTER_TYPE_K8S_INGRESS_CONTROLLER'
        	Test:       	TestKongService/trying_to_attach_KongService_to_KonnectGatewayControlPlane_of_type_KIC_fails_(due_to_CP_being_read_only)
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
