### PR TITLE
chore(release): prepare 1.2.0-rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,9 @@ Adding a new version? You'll need three changes:
 
 ## Unreleased
 
-## [v1.2.0-rc.2]
+## [v1.2.0-rc.3]
 
-[v1.2.0-rc.2]: https://github.com/Kong/kubernetes-configuration/compare/v1.1.0...v1.2.0-rc.2
+[v1.2.0-rc.3]: https://github.com/Kong/kubernetes-configuration/compare/v1.1.0...v1.2.0-rc.3
 
 ### Added
 

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-v1.2.0-rc.2
+v1.2.0-rc.3
 not-latest

--- a/config/crd/gateway-operator/configuration.konghq.com_kongcacertificates.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongcacertificates.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: kongcacertificates.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongcertificates.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongcertificates.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: kongcertificates.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongconsumergroups.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongconsumergroups.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: kongconsumergroups.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongconsumers.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongconsumers.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: kongconsumers.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongcredentialacls.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongcredentialacls.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: kongcredentialacls.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongcredentialapikeys.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongcredentialapikeys.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: kongcredentialapikeys.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongcredentialbasicauths.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongcredentialbasicauths.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: kongcredentialbasicauths.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongcredentialhmacs.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongcredentialhmacs.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: kongcredentialhmacs.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongcredentialjwts.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongcredentialjwts.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: kongcredentialjwts.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongdataplaneclientcertificates.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongdataplaneclientcertificates.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: kongdataplaneclientcertificates.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongkeys.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongkeys.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: kongkeys.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongkeysets.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongkeysets.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: kongkeysets.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_konglicenses.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_konglicenses.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: konglicenses.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongpluginbindings.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongpluginbindings.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: kongpluginbindings.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongplugins.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongplugins.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: kongplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongroutes.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongroutes.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: kongroutes.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongservices.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongservices.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: kongservices.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongsnis.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongsnis.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: kongsnis.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongtargets.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongtargets.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: kongtargets.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongupstreams.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongupstreams.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: kongupstreams.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongvaults.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongvaults.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: kongvaults.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/gateway-operator.konghq.com_aigateways.yaml
+++ b/config/crd/gateway-operator/gateway-operator.konghq.com_aigateways.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: aigateways.gateway-operator.konghq.com
 spec:
   group: gateway-operator.konghq.com

--- a/config/crd/gateway-operator/gateway-operator.konghq.com_controlplanes.yaml
+++ b/config/crd/gateway-operator/gateway-operator.konghq.com_controlplanes.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: controlplanes.gateway-operator.konghq.com
 spec:
   group: gateway-operator.konghq.com

--- a/config/crd/gateway-operator/gateway-operator.konghq.com_dataplanemetricsextensions.yaml
+++ b/config/crd/gateway-operator/gateway-operator.konghq.com_dataplanemetricsextensions.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: dataplanemetricsextensions.gateway-operator.konghq.com
 spec:
   group: gateway-operator.konghq.com

--- a/config/crd/gateway-operator/gateway-operator.konghq.com_dataplanes.yaml
+++ b/config/crd/gateway-operator/gateway-operator.konghq.com_dataplanes.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: dataplanes.gateway-operator.konghq.com
 spec:
   group: gateway-operator.konghq.com

--- a/config/crd/gateway-operator/gateway-operator.konghq.com_gatewayconfigurations.yaml
+++ b/config/crd/gateway-operator/gateway-operator.konghq.com_gatewayconfigurations.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: gatewayconfigurations.gateway-operator.konghq.com
 spec:
   group: gateway-operator.konghq.com

--- a/config/crd/gateway-operator/gateway-operator.konghq.com_kongplugininstallations.yaml
+++ b/config/crd/gateway-operator/gateway-operator.konghq.com_kongplugininstallations.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: kongplugininstallations.gateway-operator.konghq.com
 spec:
   group: gateway-operator.konghq.com

--- a/config/crd/gateway-operator/gateway-operator.konghq.com_konnectextensions.yaml
+++ b/config/crd/gateway-operator/gateway-operator.konghq.com_konnectextensions.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: konnectextensions.gateway-operator.konghq.com
 spec:
   group: gateway-operator.konghq.com

--- a/config/crd/gateway-operator/konnect.konghq.com_konnectapiauthconfigurations.yaml
+++ b/config/crd/gateway-operator/konnect.konghq.com_konnectapiauthconfigurations.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: konnectapiauthconfigurations.konnect.konghq.com
 spec:
   group: konnect.konghq.com

--- a/config/crd/gateway-operator/konnect.konghq.com_konnectcloudgatewaydataplanegroupconfigurations.yaml
+++ b/config/crd/gateway-operator/konnect.konghq.com_konnectcloudgatewaydataplanegroupconfigurations.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: konnectcloudgatewaydataplanegroupconfigurations.konnect.konghq.com
 spec:
   group: konnect.konghq.com

--- a/config/crd/gateway-operator/konnect.konghq.com_konnectcloudgatewaynetworks.yaml
+++ b/config/crd/gateway-operator/konnect.konghq.com_konnectcloudgatewaynetworks.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: konnectcloudgatewaynetworks.konnect.konghq.com
 spec:
   group: konnect.konghq.com

--- a/config/crd/gateway-operator/konnect.konghq.com_konnectextensions.yaml
+++ b/config/crd/gateway-operator/konnect.konghq.com_konnectextensions.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: konnectextensions.konnect.konghq.com
 spec:
   group: konnect.konghq.com

--- a/config/crd/gateway-operator/konnect.konghq.com_konnectgatewaycontrolplanes.yaml
+++ b/config/crd/gateway-operator/konnect.konghq.com_konnectgatewaycontrolplanes.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: konnectgatewaycontrolplanes.konnect.konghq.com
 spec:
   group: konnect.konghq.com

--- a/config/crd/ingress-controller-incubator/incubator.ingress-controller.konghq.com_kongservicefacades.yaml
+++ b/config/crd/ingress-controller-incubator/incubator.ingress-controller.konghq.com_kongservicefacades.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller-incubator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: kongservicefacades.incubator.ingress-controller.konghq.com
 spec:
   group: incubator.ingress-controller.konghq.com

--- a/config/crd/ingress-controller/configuration.konghq.com_ingressclassparameterses.yaml
+++ b/config/crd/ingress-controller/configuration.konghq.com_ingressclassparameterses.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: ingressclassparameterses.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/ingress-controller/configuration.konghq.com_kongclusterplugins.yaml
+++ b/config/crd/ingress-controller/configuration.konghq.com_kongclusterplugins.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: kongclusterplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/ingress-controller/configuration.konghq.com_kongconsumergroups.yaml
+++ b/config/crd/ingress-controller/configuration.konghq.com_kongconsumergroups.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: kongconsumergroups.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/ingress-controller/configuration.konghq.com_kongconsumers.yaml
+++ b/config/crd/ingress-controller/configuration.konghq.com_kongconsumers.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: kongconsumers.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/ingress-controller/configuration.konghq.com_kongcustomentities.yaml
+++ b/config/crd/ingress-controller/configuration.konghq.com_kongcustomentities.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: kongcustomentities.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/ingress-controller/configuration.konghq.com_kongingresses.yaml
+++ b/config/crd/ingress-controller/configuration.konghq.com_kongingresses.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: kongingresses.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/ingress-controller/configuration.konghq.com_konglicenses.yaml
+++ b/config/crd/ingress-controller/configuration.konghq.com_konglicenses.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: konglicenses.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/ingress-controller/configuration.konghq.com_kongplugins.yaml
+++ b/config/crd/ingress-controller/configuration.konghq.com_kongplugins.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: kongplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/ingress-controller/configuration.konghq.com_kongupstreampolicies.yaml
+++ b/config/crd/ingress-controller/configuration.konghq.com_kongupstreampolicies.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   labels:
     gateway.networking.k8s.io/policy: direct
   name: kongupstreampolicies.configuration.konghq.com

--- a/config/crd/ingress-controller/configuration.konghq.com_kongvaults.yaml
+++ b/config/crd/ingress-controller/configuration.konghq.com_kongvaults.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: kongvaults.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/ingress-controller/configuration.konghq.com_tcpingresses.yaml
+++ b/config/crd/ingress-controller/configuration.konghq.com_tcpingresses.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: tcpingresses.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/ingress-controller/configuration.konghq.com_udpingresses.yaml
+++ b/config/crd/ingress-controller/configuration.konghq.com_udpingresses.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller
-    kubernetes-configuration.konghq.com/version: v1.2.0-rc.2
+    kubernetes-configuration.konghq.com/version: v1.2.0-rc.3
   name: udpingresses.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/kong/kubernetes-configuration
 
 go 1.24.0
 
+retract v1.2.0-rc.2
+
 require (
 	github.com/Kong/sdk-konnect-go v0.2.21
 	github.com/kong/go-kong v0.63.0


### PR DESCRIPTION
**What this PR does / why we need it**:

Release `1.2.0-rc.2` has been released twice by mistake and GOPROXY caches the first version. New one needs to be performed.

