### PR TITLE
fix(dataplane): fix rollout in progress validation

### DIFF
--- a/api/gateway-operator/v1beta1/dataplane_types.go
+++ b/api/gateway-operator/v1beta1/dataplane_types.go
@@ -41,7 +41,7 @@ func init() {
 // +kubebuilder:printcolumn:name="Ready",description="The Resource is ready",type=string,JSONPath=`.status.conditions[?(@.type=='Ready')].status`
 // +kubebuilder:validation:XValidation:message="DataPlane requires an image to be set on proxy container",rule="has(self.spec.deployment.podTemplateSpec) && has(self.spec.deployment.podTemplateSpec.spec.containers) && self.spec.deployment.podTemplateSpec.spec.containers.exists(c, c.name == 'proxy' && has(c.image))"
 // +kubebuilder:validation:XValidation:message="DataPlane supports only db mode 'off'",rule="!has(self.spec.deployment.podTemplateSpec) ? true : ( self.spec.deployment.podTemplateSpec.spec.containers.size() == 0 || self.spec.deployment.podTemplateSpec.spec.containers[0].name == 'proxy' ? (!has(self.spec.deployment.podTemplateSpec.spec.containers[0].env) ? true : self.spec.deployment.podTemplateSpec.spec.containers[0].env.all(e, e.name != 'KONG_DATABASE' || e.value == 'off' || size(e.value)==0)) : true)"
-// +kubebuilder:validation:XValidation:message="DataPlane spec cannot be updated when promotion is in progress",rule="((self.spec == oldSelf.spec) || !has(self.status.rollout)) ? true : self.status.rollout.conditions.all(c, c.type != 'RolledOut' || c.reason != 'PromotionInProgress')"
+// +kubebuilder:validation:XValidation:message="DataPlane spec cannot be updated when promotion is in progress",rule="(self.spec != oldSelf.spec && has(self.status) && has (self.status.rollout)) ? self.status.rollout.conditions.all(c, c.type != 'RolledOut' || c.reason != 'PromotionInProgress') : true"
 type DataPlane struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/gateway-operator/gateway-operator.konghq.com_dataplanes.yaml
+++ b/config/crd/gateway-operator/gateway-operator.konghq.com_dataplanes.yaml
@@ -9469,9 +9469,9 @@ spec:
             e.name != ''KONG_DATABASE'' || e.value == ''off'' || size(e.value)==0))
             : true)'
         - message: DataPlane spec cannot be updated when promotion is in progress
-          rule: '((self.spec == oldSelf.spec) || !has(self.status.rollout)) ? true
-            : self.status.rollout.conditions.all(c, c.type != ''RolledOut'' || c.reason
-            != ''PromotionInProgress'')'
+          rule: '(self.spec != oldSelf.spec && has(self.status) && has (self.status.rollout))
+            ? self.status.rollout.conditions.all(c, c.type != ''RolledOut'' || c.reason
+            != ''PromotionInProgress'') : true'
     served: true
     storage: true
     subresources:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes rollout in progress validation for `DataPlane` objects.

Up until now we have not checked if `status` is set which caused some flakiness in tests, e.g. 

```
    test_dataplane_bluegreen.go:295: 
        	Error Trace:	/home/runner/go/pkg/mod/github.com/kong/gateway-operator@v1.5.1-0.20250326114827-ba5884dd83f7/test/integration/test_dataplane_bluegreen.go:502
        	            				/home/runner/go/pkg/mod/github.com/kong/gateway-operator@v1.5.1-0.20250326114827-ba5884dd83f7/test/integration/test_dataplane_bluegreen.go:295
        	Error:      	Received unexpected error:
        	            	DataPlane.gateway-operator.konghq.com "5dac8413-4250-497a-9bc5-a2cd9313ba7b" is invalid: <nil>: Invalid value: "object": no such key: conditions evaluating rule: DataPlane spec cannot be updated when promotion is in progress
        	Test:       	TestIntegration/TestDataPlaneBlueGreenHorizontalScaling
```

https://github.com/Kong/gateway-operator-enterprise/actions/runs/14195490026/job/39769557344#step:7:537

This PR fixes the validation expression and adds CRD validation tests.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
