### PR TITLE
chore: adjust validation for `KongRoute` to allow migration from serviceless to service bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ Adding a new version? You'll need three changes:
   [#381](https://github.com/Kong/kubernetes-configuration/pull/381)
 - Add Type and KonnectID fields to the `KonnectGatewayControlPlane` CRD.
   [#387](https://github.com/Kong/kubernetes-configuration/pull/387)
+- Change validation rules for `KongRoute` to allow its migration from serviceless
+  (`KonnectGatewayControlPlane` bound) to `KongService` bound and vice versa.
+  [#386](https://github.com/Kong/kubernetes-configuration/pull/386)
 
 ## [v1.3.2]
 

--- a/api/configuration/v1alpha1/kongroute_types.go
+++ b/api/configuration/v1alpha1/kongroute_types.go
@@ -38,12 +38,10 @@ import (
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Programmed",description="The Resource is Programmed on Konnect",type=string,JSONPath=`.status.conditions[?(@.type=='Programmed')].status`
-// +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.serviceRef) || has(self.spec.serviceRef)", message="serviceRef is required once set"
 // +kubebuilder:validation:XValidation:rule="has(self.spec.protocols) && self.spec.protocols.exists(p, p == 'http') ? (has(self.spec.hosts) || has(self.spec.methods) || has(self.spec.paths) || has(self.spec.paths) || has(self.spec.paths) || has(self.spec.headers) ) : true", message="If protocols has 'http', at least one of 'hosts', 'methods', 'paths' or 'headers' must be set"
-// +kubebuilder:validation:XValidation:rule="has(self.spec.controlPlaneRef) && !has(self.spec.serviceRef) || !has(self.spec.controlPlaneRef) && has(self.spec.serviceRef)", message="Has to set either controlPlaneRef or serviceRef"
 // +kubebuilder:validation:XValidation:rule="(!has(self.spec.controlPlaneRef) || !has(self.spec.controlPlaneRef.konnectNamespacedRef)) ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)", message="spec.controlPlaneRef cannot specify namespace for namespaced resource"
-// +kubebuilder:validation:XValidation:rule="!has(self.spec.serviceRef) ? true : (!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.serviceRef == self.spec.serviceRef", message="spec.serviceRef is immutable when an entity is already Programmed"
-// +kubebuilder:validation:XValidation:rule="!has(self.spec.controlPlaneRef) ? true :(!self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)", message="controlPlaneRef is required once set"
+// +kubebuilder:validation:XValidation:rule="(!has(self.spec) || !has(self.spec.controlPlaneRef)) ? true : (!has(self.status) || !self.status.conditions.exists(c, c.type == 'Programmed' && c.status == 'True')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef", message="spec.controlPlaneRef is immutable when an entity is already Programmed"
 // +apireference:kgo:include
 // +kong:channels=gateway-operator
 type KongRoute struct {

--- a/config/crd/gateway-operator/configuration.konghq.com_kongroutes.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongroutes.yaml
@@ -381,28 +381,21 @@ spec:
         - spec
         type: object
         x-kubernetes-validations:
-        - message: serviceRef is required once set
-          rule: '!has(oldSelf.spec.serviceRef) || has(self.spec.serviceRef)'
         - message: If protocols has 'http', at least one of 'hosts', 'methods', 'paths'
             or 'headers' must be set
           rule: 'has(self.spec.protocols) && self.spec.protocols.exists(p, p == ''http'')
             ? (has(self.spec.hosts) || has(self.spec.methods) || has(self.spec.paths)
             || has(self.spec.paths) || has(self.spec.paths) || has(self.spec.headers)
             ) : true'
-        - message: Has to set either controlPlaneRef or serviceRef
-          rule: has(self.spec.controlPlaneRef) && !has(self.spec.serviceRef) || !has(self.spec.controlPlaneRef)
-            && has(self.spec.serviceRef)
         - message: spec.controlPlaneRef cannot specify namespace for namespaced resource
           rule: '(!has(self.spec.controlPlaneRef) || !has(self.spec.controlPlaneRef.konnectNamespacedRef))
             ? true : !has(self.spec.controlPlaneRef.konnectNamespacedRef.__namespace__)'
-        - message: spec.serviceRef is immutable when an entity is already Programmed
-          rule: '!has(self.spec.serviceRef) ? true : (!self.status.conditions.exists(c,
-            c.type == ''Programmed'' && c.status == ''True'')) ? true : oldSelf.spec.serviceRef
-            == self.spec.serviceRef'
+        - message: controlPlaneRef is required once set
+          rule: '!has(oldSelf.spec.controlPlaneRef) || has(self.spec.controlPlaneRef)'
         - message: spec.controlPlaneRef is immutable when an entity is already Programmed
-          rule: '!has(self.spec.controlPlaneRef) ? true :(!self.status.conditions.exists(c,
-            c.type == ''Programmed'' && c.status == ''True'')) ? true : oldSelf.spec.controlPlaneRef
-            == self.spec.controlPlaneRef'
+          rule: '(!has(self.spec) || !has(self.spec.controlPlaneRef)) ? true : (!has(self.status)
+            || !self.status.conditions.exists(c, c.type == ''Programmed'' && c.status
+            == ''True'')) ? true : oldSelf.spec.controlPlaneRef == self.spec.controlPlaneRef'
     served: true
     storage: true
     subresources:

--- a/test/crdsvalidation/configuration.konghq.com/kongroute_test.go
+++ b/test/crdsvalidation/configuration.konghq.com/kongroute_test.go
@@ -27,12 +27,6 @@ func TestKongRoute(t *testing.T) {
 		common.NewCRDValidationTestCasesGroupCPRefChange(t, obj, common.NotSupportedByKIC, common.ControlPlaneRefNotRequired).Run(t)
 	})
 
-	t.Run("cp ref, type=kic", func(t *testing.T) {
-		// NOTE: empty cp ref is not allowed in this context because a route can be attached to a service
-		// but this test doesn't check that.
-		common.NewCRDValidationTestCasesGroupCPRefChangeKICUnsupportedTypes(t, obj, common.EmptyControlPlaneRefNotAllowed).Run(t)
-	})
-
 	t.Run("protocols", func(t *testing.T) {
 		common.TestCasesGroup[*configurationv1alpha1.KongRoute]{
 			{
@@ -81,23 +75,6 @@ func TestKongRoute(t *testing.T) {
 					},
 				},
 				ExpectedErrorMessage: lo.ToPtr("If protocols has 'http', at least one of 'hosts', 'methods', 'paths' or 'headers' must be set"),
-			},
-		}.Run(t)
-	})
-
-	t.Run("no service ref and no cp ref provided", func(t *testing.T) {
-		common.TestCasesGroup[*configurationv1alpha1.KongRoute]{
-			{
-				Name: "have to provide either controlPlaneRef or serviceRef",
-				TestObject: &configurationv1alpha1.KongRoute{
-					ObjectMeta: common.CommonObjectMeta,
-					Spec: configurationv1alpha1.KongRouteSpec{
-						KongRouteAPISpec: configurationv1alpha1.KongRouteAPISpec{
-							Paths: []string{"/"},
-						},
-					},
-				},
-				ExpectedErrorMessage: lo.ToPtr("Has to set either controlPlaneRef or serviceRef"),
 			},
 		}.Run(t)
 	})
@@ -168,68 +145,6 @@ func TestKongRoute(t *testing.T) {
 					},
 				},
 				ExpectedErrorMessage: lo.ToPtr("when type is namespacedRef, namespacedRef must be set"),
-			},
-			{
-				Name: "NamespacedRef reference name cannot be changed when an entity is Programmed",
-				TestObject: &configurationv1alpha1.KongRoute{
-					ObjectMeta: common.CommonObjectMeta,
-					Spec: configurationv1alpha1.KongRouteSpec{
-						ServiceRef: &configurationv1alpha1.ServiceRef{
-							Type: configurationv1alpha1.ServiceRefNamespacedRef,
-							NamespacedRef: &commonv1alpha1.NameRef{
-								Name: "test-konnect-service",
-							},
-						},
-						KongRouteAPISpec: configurationv1alpha1.KongRouteAPISpec{
-							Paths: []string{"/"},
-						},
-					},
-					Status: configurationv1alpha1.KongRouteStatus{
-						Conditions: []metav1.Condition{
-							{
-								Type:               "Programmed",
-								Status:             metav1.ConditionTrue,
-								Reason:             "Programmed",
-								LastTransitionTime: metav1.Now(),
-							},
-						},
-					},
-				},
-				Update: func(ks *configurationv1alpha1.KongRoute) {
-					ks.Spec.ServiceRef.NamespacedRef.Name = "new-konnect-service"
-				},
-				ExpectedUpdateErrorMessage: lo.ToPtr("spec.serviceRef is immutable when an entity is already Programmed"),
-			},
-			{
-				Name: "NamespacedRef reference type cannot be changed when an entity is Programmed",
-				TestObject: &configurationv1alpha1.KongRoute{
-					ObjectMeta: common.CommonObjectMeta,
-					Spec: configurationv1alpha1.KongRouteSpec{
-						ServiceRef: &configurationv1alpha1.ServiceRef{
-							Type: configurationv1alpha1.ServiceRefNamespacedRef,
-							NamespacedRef: &commonv1alpha1.NameRef{
-								Name: "test-konnect-service",
-							},
-						},
-						KongRouteAPISpec: configurationv1alpha1.KongRouteAPISpec{
-							Paths: []string{"/"},
-						},
-					},
-					Status: configurationv1alpha1.KongRouteStatus{
-						Conditions: []metav1.Condition{
-							{
-								Type:               "Programmed",
-								Status:             metav1.ConditionTrue,
-								Reason:             "Programmed",
-								LastTransitionTime: metav1.Now(),
-							},
-						},
-					},
-				},
-				Update: func(ks *configurationv1alpha1.KongRoute) {
-					ks.Spec.ServiceRef.Type = "otherRef"
-				},
-				ExpectedUpdateErrorMessage: lo.ToPtr("Unsupported value: \"otherRef\": supported values: \"namespacedRef\""),
 			},
 		}.Run(t)
 	})

--- a/test/crdsvalidation/configuration.konghq.com/kongroute_test.go
+++ b/test/crdsvalidation/configuration.konghq.com/kongroute_test.go
@@ -27,6 +27,56 @@ func TestKongRoute(t *testing.T) {
 		common.NewCRDValidationTestCasesGroupCPRefChange(t, obj, common.NotSupportedByKIC, common.ControlPlaneRefNotRequired).Run(t)
 	})
 
+	t.Run("service ref", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1alpha1.KongRoute]{
+			{
+				Name: "bind servicebound to controlplane too",
+				TestObject: &configurationv1alpha1.KongRoute{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongRouteSpec{
+						ServiceRef: &configurationv1alpha1.ServiceRef{
+							Type: configurationv1alpha1.ServiceRefNamespacedRef,
+							NamespacedRef: &commonv1alpha1.NameRef{
+								Name: "test-konnect-service",
+							},
+						},
+					},
+				},
+				Update: func(kr *configurationv1alpha1.KongRoute) {
+					kr.Spec.ControlPlaneRef = &commonv1alpha1.ControlPlaneRef{
+						Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+						KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+							Name: "test-konnect-control-plane",
+						},
+					}
+				},
+			},
+			{
+				Name: "make serviceless",
+				TestObject: &configurationv1alpha1.KongRoute{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1alpha1.KongRouteSpec{
+						ServiceRef: &configurationv1alpha1.ServiceRef{
+							Type: configurationv1alpha1.ServiceRefNamespacedRef,
+							NamespacedRef: &commonv1alpha1.NameRef{
+								Name: "test-konnect-service",
+							},
+						},
+						ControlPlaneRef: &commonv1alpha1.ControlPlaneRef{
+							Type: configurationv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+							KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+								Name: "test-konnect-control-plane",
+							},
+						},
+					},
+				},
+				Update: func(kr *configurationv1alpha1.KongRoute) {
+					kr.Spec.ServiceRef = nil
+				},
+			},
+		}.Run(t)
+	})
+
 	t.Run("protocols", func(t *testing.T) {
 		common.TestCasesGroup[*configurationv1alpha1.KongRoute]{
 			{


### PR DESCRIPTION
**What this PR does / why we need it**:

Required by PR

- https://github.com/Kong/gateway-operator/pull/1492

Adjust validation rules for `KongRoute` to allow migration from serviceless (`KonnectGatewayControlPlane` bound) to `KongService` bound and vice versa. 


**Which issue this PR fixes**

Part of https://github.com/Kong/gateway-operator/issues/668

**Special notes for your reviewer**:

Inspired by how it looks for `Key` and `KeySet`, which supports such migration. 

Furthermore, validation for a rule with the message `spec.controlPlaneRef is immutable when an entity is already Programmed` is changed, because otherwise, in a controller logs

```log
2025-04-15T15:05:52+02:00	ERROR	Reconciler error	{"controller": "KongRoute", "controllerGroup": "configuration.konghq.com", "controllerKind": "KongRoute", "KongRoute": {"name":"kongroute-be7a5046","namespace":"044bd04a-461a-4787-bbd7-6795c42c1ef1"}, "namespace": "044bd04a-461a-4787-bbd7-6795c42c1ef1", "name": "kongroute-be7a5046", "reconcileID": "c8ee0f85-a32e-4535-8517-3e1513499e57", "error": "failed to update status after creating object: failed patching *v1alpha1.KongRoute, 044bd04a-461a-4787-bbd7-6795c42c1ef1/kongroute-be7a5046: KongRoute.configuration.konghq.com \"kongroute-be7a5046\" is invalid: <nil>: Invalid value: \"object\": no such key: controlPlaneRef evaluating rule: spec.controlPlaneRef is immutable when an entity is already Programmed"}
```

This PR makes it work like for [KongConsumer](https://github.com/Kong/kubernetes-configuration/blob/d2b030515a60094e227bf0333800f6b04f48284d/api/configuration/v1/kongconsumer_types.go#L40). The open question is - should we adjust it onther places too

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
