### PR TITLE
ci: allow releases from release branches

### DIFF
--- a/.github/workflows/release_on_version_change.yaml
+++ b/.github/workflows/release_on_version_change.yaml
@@ -5,7 +5,8 @@ on:
     paths:
       - VERSION
     branches:
-      - main
+      - 'main'
+      - 'release/*'
 
 jobs:
   version:


### PR DESCRIPTION
**What this PR does / why we need it**:

Allow releasing from release branches. This will allow to release e.g. patches without incorporating bigger changes that landed in `main` already.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
