### PR TITLE
feat: add scale subresource for DataPlane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Adding a new version? You'll need three changes:
   [#375](https://github.com/Kong/kubernetes-configuration/pull/375)
 - Allow setting `DataPlane`'s `NodePort` port number
   [#401](https://github.com/Kong/kubernetes-configuration/pull/401)
+- Added `scale` subresource to `DataPlane` CRD.
+  [#402](https://github.com/Kong/kubernetes-configuration/pull/402)
 
 ### Changes
 

--- a/api/gateway-operator/v1beta1/dataplane_types.go
+++ b/api/gateway-operator/v1beta1/dataplane_types.go
@@ -37,6 +37,7 @@ func init() {
 // +kong:channels=gateway-operator
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:subresource:scale:specpath=.spec.deployment.replicas,statuspath=.status.replicas,selectorpath=.status.selector
 // +kubebuilder:resource:shortName=kodp,categories=kong;all
 // +kubebuilder:printcolumn:name="Ready",description="The Resource is ready",type=string,JSONPath=`.status.conditions[?(@.type=='Ready')].status`
 // +kubebuilder:validation:XValidation:message="DataPlane requires an image to be set on proxy container",rule="has(self.spec.deployment.podTemplateSpec) && has(self.spec.deployment.podTemplateSpec.spec.containers) && self.spec.deployment.podTemplateSpec.spec.containers.exists(c, c.name == 'proxy' && has(c.image))"

--- a/config/crd/gateway-operator/gateway-operator.konghq.com_dataplanes.yaml
+++ b/config/crd/gateway-operator/gateway-operator.konghq.com_dataplanes.yaml
@@ -9496,4 +9496,8 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.deployment.replicas
+        statusReplicasPath: .status.replicas
       status: {}


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request introduces support for the Kubernetes scale subresource in the `DataPlane` custom resource definition (CRD) for the Gateway Operator. The changes enhance the CRD by enabling horizontal scaling capabilities and providing necessary paths for replicas and selectors.


* **Added scale subresource annotation in `dataplane_types.go`:**
  - Included the `+kubebuilder:subresource:scale` annotation to define paths for `spec.replicas`, `status.replicas`, and `status.selector`.



**Which issue this PR fixes**

part of https://github.com/Kong/gateway-operator/issues/1498

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
