### PR TITLE
feat(controlplane): add WatchNamespaceGrantValid condition type with reasons

### DIFF
--- a/api/gateway-operator/controlplane/conditions.go
+++ b/api/gateway-operator/controlplane/conditions.go
@@ -11,6 +11,11 @@ const (
 	// not all Deployments (or Daemonsets) for the ControlPlane have been provisioned
 	// successfully.
 	ConditionTypeProvisioned consts.ConditionType = "Provisioned"
+
+	// ConditionTypeWatchNamespaceGrantValid is a condition type used to
+	// indicate whether or not the ControlPlane has been granted permission to
+	// watch resources in the requested namespaces.
+	ConditionTypeWatchNamespaceGrantValid consts.ConditionType = "WatchNamespaceGrantValid"
 )
 
 // -----------------------------------------------------------------------------
@@ -33,8 +38,13 @@ const (
 	// has been provisioned.
 	ConditionReasonNoDataPlane consts.ConditionReason = "NoDataPlane"
 
-	// ConditionReasonMissingReferenceGrant is a reason which indicates that
-	// ReferenceGrants are missing for the ControlPlane to be able to watch
+	// ConditionReasonWatchNamespaceGrantInvalid is a reason which indicates that
+	// WatchNamespaceGrants are invalid or missing for the ControlPlane to be able
+	// to watch resources in requested namespaces.
+	ConditionReasonWatchNamespaceGrantInvalid consts.ConditionReason = "WatchNamespaceGrantInvalid"
+
+	// ConditionReasonWatchNamespaceGrantValid is a reason which indicates that
+	// WatchNamespaceGrants are valid for the ControlPlane to be able to watch
 	// resources in requested namespaces.
-	ConditionReasonMissingReferenceGrant consts.ConditionReason = "MissingReferenceGrants"
+	ConditionReasonWatchNamespaceGrantValid consts.ConditionReason = "WatchNamespaceGrantValid"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

Extracting condition reasons and type to kubernetes-configuration from https://github.com/Kong/gateway-operator/pull/1410.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
