### PR TITLE
fix(dataplane): fix DataPlane CEL for spec updates during blue green rollout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Adding a new version? You'll need three changes:
 * Add the section header, like "## [v1.2.3]".
 * Add the diff link, like "[v2.7.0]: https://github.com/kong/kubernetes-ingress-controller/compare/v1.2.2...v1.2.3".
 --->
+- [v1.4.1](#v141)
 - [v1.4.0](#v140)
 - [v1.3.2](#v132)
 - [v1.3.1](#v131)
@@ -20,6 +21,20 @@ Adding a new version? You'll need three changes:
 - [v1.0.0](#v100)
 
 ## Unreleased
+
+### Fixes
+
+- Fix `DataPlane` CEL CEL validation rule during blue green rollout
+  [#439](https://github.com/Kong/kubernetes-configuration/pull/439)
+
+## [v1.4.1]
+
+[v1.4.1]: https://github.com/Kong/kubernetes-configuration/compare/v1.4.0...v1.4.1
+
+### Changes
+
+- Clarified the comment in `DataPlane` CRD on the allowed values for `Service` types.
+  [#429](https://github.com/Kong/kubernetes-configuration/pull/429)
 
 ## [v1.4.0]
 

--- a/api/gateway-operator/v1beta1/dataplane_types.go
+++ b/api/gateway-operator/v1beta1/dataplane_types.go
@@ -42,7 +42,7 @@ func init() {
 // +kubebuilder:printcolumn:name="Ready",description="The Resource is ready",type=string,JSONPath=`.status.conditions[?(@.type=='Ready')].status`
 // +kubebuilder:validation:XValidation:message="DataPlane requires an image to be set on proxy container",rule="has(self.spec.deployment.podTemplateSpec) && has(self.spec.deployment.podTemplateSpec.spec.containers) && self.spec.deployment.podTemplateSpec.spec.containers.exists(c, c.name == 'proxy' && has(c.image))"
 // +kubebuilder:validation:XValidation:message="DataPlane supports only db mode 'off'",rule="!has(self.spec.deployment.podTemplateSpec) ? true : ( self.spec.deployment.podTemplateSpec.spec.containers.size() == 0 || self.spec.deployment.podTemplateSpec.spec.containers[0].name == 'proxy' ? (!has(self.spec.deployment.podTemplateSpec.spec.containers[0].env) ? true : self.spec.deployment.podTemplateSpec.spec.containers[0].env.all(e, e.name != 'KONG_DATABASE' || e.value == 'off' || size(e.value)==0)) : true)"
-// +kubebuilder:validation:XValidation:message="DataPlane spec cannot be updated when promotion is in progress",rule="(self.spec != oldSelf.spec && has(self.status) && has (self.status.rollout)) ? self.status.rollout.conditions.all(c, c.type != 'RolledOut' || c.reason != 'PromotionInProgress') : true"
+// +kubebuilder:validation:XValidation:message="DataPlane spec cannot be updated when promotion is in progress",rule="(self.spec != oldSelf.spec && has(self.status) && has(self.status.rollout) && has(self.status.rollout.conditions)) ? self.status.rollout.conditions.all(c, c.type != 'RolledOut' || c.reason != 'PromotionInProgress') : true"
 type DataPlane struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/gateway-operator/gateway-operator.konghq.com_dataplanes.yaml
+++ b/config/crd/gateway-operator/gateway-operator.konghq.com_dataplanes.yaml
@@ -9536,9 +9536,9 @@ spec:
             e.name != ''KONG_DATABASE'' || e.value == ''off'' || size(e.value)==0))
             : true)'
         - message: DataPlane spec cannot be updated when promotion is in progress
-          rule: '(self.spec != oldSelf.spec && has(self.status) && has (self.status.rollout))
-            ? self.status.rollout.conditions.all(c, c.type != ''RolledOut'' || c.reason
-            != ''PromotionInProgress'') : true'
+          rule: '(self.spec != oldSelf.spec && has(self.status) && has(self.status.rollout)
+            && has(self.status.rollout.conditions)) ? self.status.rollout.conditions.all(c,
+            c.type != ''RolledOut'' || c.reason != ''PromotionInProgress'') : true'
     served: true
     storage: true
     subresources:

--- a/test/crdsvalidation/common/testcase.go
+++ b/test/crdsvalidation/common/testcase.go
@@ -110,8 +110,10 @@ func (tc *TestCase[T]) RunWithConfig(t *testing.T, cfg *rest.Config, scheme *run
 		desiredObj := tc.TestObject.DeepCopyObject().(T)
 
 		tCleanupObject := func(ctx context.Context, t *testing.T, obj client.Object) {
+			// NOTE: Deep copy the object as without this we end up causing a data race:
+			objToDelete := obj.DeepCopyObject().(T)
 			t.Cleanup(func() {
-				assert.NoError(t, client.IgnoreNotFound(cl.Delete(ctx, obj)))
+				assert.NoError(t, client.IgnoreNotFound(cl.Delete(ctx, objToDelete)))
 			})
 		}
 

--- a/test/crdsvalidation/gateway-operator.konghq.com/dataplane_test.go
+++ b/test/crdsvalidation/gateway-operator.konghq.com/dataplane_test.go
@@ -487,6 +487,36 @@ func TestDataplane(t *testing.T) {
 				ExpectedUpdateErrorMessage: lo.ToPtr("DataPlane spec cannot be updated when promotion is in progress"),
 			},
 			{
+				Name: "rollout status without conditions doesn't prevent spec updates",
+				TestObject: &operatorv1beta1.DataPlane{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: operatorv1beta1.DataPlaneSpec{
+						DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+							Deployment: validDataplaneOptions.Deployment,
+						},
+					},
+					Status: operatorv1beta1.DataPlaneStatus{
+						RolloutStatus: &operatorv1beta1.DataPlaneRolloutStatus{
+							Services: &operatorv1beta1.DataPlaneRolloutStatusServices{
+								Ingress: &operatorv1beta1.RolloutStatusService{
+									Name: "ingress",
+									Addresses: []operatorv1beta1.Address{
+										{
+											Type:       lo.ToPtr(operatorv1beta1.IPAddressType),
+											Value:      "10.1.2.3",
+											SourceType: operatorv1beta1.PublicIPAddressSourceType,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Update: func(d *operatorv1beta1.DataPlane) {
+					d.Spec.Deployment.PodTemplateSpec.Labels = map[string]string{"foo": "bar"}
+				},
+			},
+			{
 				Name: "can update spec when promotion complete",
 				TestObject: &operatorv1beta1.DataPlane{
 					ObjectMeta: common.CommonObjectMeta,


### PR DESCRIPTION
**What this PR does / why we need it**:

To prevent errors like these ones (KGO spotted in integration tests):

https://github.com/Kong/gateway-operator/actions/runs/15166190692/job/42644559491#step:5:3100

```
    dataplane_bluegreen_test.go:295: 
        	Error Trace:	/home/runner/work/gateway-operator/gateway-operator/test/integration/dataplane_bluegreen_test.go:502
        	            				/home/runner/work/gateway-operator/gateway-operator/test/integration/dataplane_bluegreen_test.go:295
        	Error:      	Received unexpected error:
        	            	DataPlane.gateway-operator.konghq.com "2093e52b-8987-40f1-bf91-305ad189d12b" is invalid: <nil>: Invalid value: "object": no such key: conditions evaluating rule: DataPlane spec cannot be updated when promotion is in progress
        	Test:       	TestDataPlaneBlueGreenHorizontalScaling
```

fix `DataPlane`'s CEL rule to account for `status.rollout.conditions` possibly not being present.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
