### PR TITLE
chore!: change storage version of ControlPlane to v2alpha1

### DIFF
--- a/api/gateway-operator/v1beta1/controlplane_types.go
+++ b/api/gateway-operator/v1beta1/controlplane_types.go
@@ -31,7 +31,6 @@ func init() {
 // ControlPlane is the Schema for the controlplanes API
 //
 // +genclient
-// +kubebuilder:storageversion
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status

--- a/api/gateway-operator/v2alpha1/controlplane_types.go
+++ b/api/gateway-operator/v2alpha1/controlplane_types.go
@@ -31,6 +31,7 @@ func init() {
 //
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:storageversion
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=kocp,categories=kong;all

--- a/config/crd/gateway-operator/gateway-operator.konghq.com_controlplanes.yaml
+++ b/config/crd/gateway-operator/gateway-operator.konghq.com_controlplanes.yaml
@@ -8380,7 +8380,7 @@ spec:
             && self.spec.deployment.podTemplateSpec.spec.containers.exists(c, c.name
             == 'controller' && has(c.image))
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -8743,6 +8743,6 @@ spec:
             type: object
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}


### PR DESCRIPTION
**What this PR does / why we need it**:

To allow usage of new `ControlPlane` version: `v2alpha1` in KGO we need to change the storage version of that CRD to be `v2alpha1`.

This is a breaking change.

**Which issue this PR fixes**

Part of https://github.com/Kong/gateway-operator/issues/1607

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
