### PR TITLE
chore: do not mark `DataPlaneMetricsExtension` as EE only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Adding a new version? You'll need three changes:
 - The old `gateway-operator.konghq.com` `KonnectExtension` has been definitely removed
   after its deprecation in v1.5.0.
   [#450](https://github.com/Kong/kubernetes-configuration/pull/450)
+- `DataPlaneMetricsExtension` is not marked as EE only anymore.
+  [#456](https://github.com/Kong/kubernetes-configuration/pull/456)
 
 ## [v1.4.1]
 

--- a/api/gateway-operator/v1alpha1/dataplane_metrics_extension_types.go
+++ b/api/gateway-operator/v1alpha1/dataplane_metrics_extension_types.go
@@ -44,8 +44,6 @@ const (
 // Additionally, it will also make the operator expose DataPlane's metrics
 // enriched with metadata required for in-cluster Kubernetes autoscaling.
 //
-// NOTE: This is an enterprise feature. In order to use it you need to use
-// the EE version of Kong Gateway Operator with a valid license.
 // +apireference:kgo:include
 // +kong:channels=gateway-operator
 type DataPlaneMetricsExtension struct {

--- a/config/crd/gateway-operator/gateway-operator.konghq.com_dataplanemetricsextensions.yaml
+++ b/config/crd/gateway-operator/gateway-operator.konghq.com_dataplanemetricsextensions.yaml
@@ -28,9 +28,6 @@ spec:
           the specified metrics configuration.
           Additionally, it will also make the operator expose DataPlane's metrics
           enriched with metadata required for in-cluster Kubernetes autoscaling.
-
-          NOTE: This is an enterprise feature. In order to use it you need to use
-          the EE version of Kong Gateway Operator with a valid license.
         properties:
           apiVersion:
             description: |-

--- a/docs/all-api-reference.md
+++ b/docs/all-api-reference.md
@@ -2106,9 +2106,7 @@ It can be attached to a ControlPlane using its spec.extensions.
 When attached it will make the ControlPlane configure its DataPlane with
 the specified metrics configuration.
 Additionally, it will also make the operator expose DataPlane's metrics
-enriched with metadata required for in-cluster Kubernetes autoscaling.<br /><br />
-NOTE: This is an enterprise feature. In order to use it you need to use
-the EE version of Kong Gateway Operator with a valid license.
+enriched with metadata required for in-cluster Kubernetes autoscaling.
 
 <!-- data_plane_metrics_extension description placeholder -->
 

--- a/docs/gateway-operator-api-reference.md
+++ b/docs/gateway-operator-api-reference.md
@@ -66,9 +66,7 @@ It can be attached to a ControlPlane using its spec.extensions.
 When attached it will make the ControlPlane configure its DataPlane with
 the specified metrics configuration.
 Additionally, it will also make the operator expose DataPlane's metrics
-enriched with metadata required for in-cluster Kubernetes autoscaling.<br /><br />
-NOTE: This is an enterprise feature. In order to use it you need to use
-the EE version of Kong Gateway Operator with a valid license.
+enriched with metadata required for in-cluster Kubernetes autoscaling.
 
 <!-- data_plane_metrics_extension description placeholder -->
 


### PR DESCRIPTION
**What this PR does / why we need it**:

For KO everything is OSS, so marking CRD as EE only is redundant

**Which issue this PR fixes**

Leftover from

- https://github.com/Kong/gateway-operator/issues/1493

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
