### PR TITLE
ci: add kube-api-linter for konnect/v1alpha1

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -1,8 +1,9 @@
-# These versions in this file will not get auto updated so ideally we'd add a renovate
-# config to update this file automatically.
+# renovate: datasource=github-releases depName=golangci/golangci-lint
 version: v2.1.6
 name: golangci-kube-api-linter
 destination: ./bin
 plugins:
 - module: 'sigs.k8s.io/kube-api-linter'
-  version: f86bf7bd4b19bba7a3afa6403cde702fed643ec2
+  # This version will not get auto updated so ideally we'd add a renovate
+  # config to update this file automatically.
+  version: 55d257d89b6570c9870dc29beabaafd97ea607cb

--- a/.golangci-kube-api.yaml
+++ b/.golangci-kube-api.yaml
@@ -13,8 +13,10 @@ linters:
             disable:
               - "*"
             enable:
+              # Konnect related fields have underscores in their names, which
+              # is not recommended and yields errors with jsontags linter.
+              # - jsontags
               - duplicatemarkers
-              - jsontags
               # - maxlength
               - nofloats
               - nomaps

--- a/Makefile
+++ b/Makefile
@@ -236,9 +236,12 @@ GOLANGCI_LINT_KUBE_API_LINTER = $(PROJECT_DIR)/bin/golangci-kube-api-linter
 
 .PHONY: lint.api
 lint.api: golangci-lint
+# Cannot add konnect/v1alpha2 just yet because: https://github.com/kubernetes-sigs/kube-api-linter/issues/101
+# api/konnect/v1alpha2/konnect_extension_types.go:113:2: nomaps: Labels should not use a map type, use a list type with a unique name/identifier instead (kubeapilinter)
 	@[[ -f $(GOLANGCI_LINT_KUBE_API_LINTER) ]] || $(GOLANGCI_LINT) custom -v
 	$(GOLANGCI_LINT_KUBE_API_LINTER) run --config $(PROJECT_DIR)/.golangci-kube-api.yaml -v \
-		./api/gateway-operator/v2alpha1/...
+		./api/gateway-operator/v2alpha1/... \
+		./api/konnect/v1alpha1/...
 
 .PHONY: test.samples
 test.samples: kustomize

--- a/api/konnect/v1alpha1/konnect_apiauthconfiguration_types.go
+++ b/api/konnect/v1alpha1/konnect_apiauthconfiguration_types.go
@@ -82,9 +82,13 @@ type KonnectAPIAuthConfigurationSpec struct {
 // +apireference:kgo:include
 type KonnectAPIAuthConfigurationStatus struct {
 	// OrganizationID is the unique identifier of the organization in Konnect.
+	//
+	// +optional
 	OrganizationID string `json:"organizationID,omitempty"`
 
 	// ServerURL is configured server URL.
+	//
+	// +optional
 	ServerURL string `json:"serverURL,omitempty"`
 
 	// Conditions describe the status of the Konnect configuration.
@@ -93,6 +97,7 @@ type KonnectAPIAuthConfigurationStatus struct {
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=8
 	// +kubebuilder:default={{type: "Valid", status: "Unknown", reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"}}
+	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/api/konnect/v1alpha1/konnect_cloudgateway_dataplane_configuration_types.go
+++ b/api/konnect/v1alpha1/konnect_cloudgateway_dataplane_configuration_types.go
@@ -195,6 +195,8 @@ type KonnectCloudGatewayDataPlaneGroupConfigurationStatus struct {
 	KonnectEntityStatusWithControlPlaneRef `json:",inline"`
 
 	// DataPlaneGroups is a list of deployed data-plane groups.
+	//
+	// +kubebuilder:validation:Optional
 	DataPlaneGroups []KonnectCloudGatewayDataPlaneGroupConfigurationStatusGroup `json:"dataplane_groups,omitempty"`
 
 	// Conditions describe the current conditions of the KonnectCloudGatewayDataPlaneGroupConfiguration.
@@ -207,6 +209,7 @@ type KonnectCloudGatewayDataPlaneGroupConfigurationStatus struct {
 	// +listMapKey=type
 	// +kubebuilder:validation:MaxItems=8
 	// +kubebuilder:default={{type: "Programmed", status: "Unknown", reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"}}
+	// +kubebuilder:validation:Optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/api/konnect/v1alpha1/konnect_cloudgateway_network_types.go
+++ b/api/konnect/v1alpha1/konnect_cloudgateway_network_types.go
@@ -91,6 +91,8 @@ type KonnectCloudGatewayNetworkStatus struct {
 	KonnectEntityStatus `json:",inline"`
 
 	// State is the current state of the network. Can be e.g. initializing, ready, terminating.
+	//
+	// +kubebuilder:validation:Optional
 	State string `json:"state,omitempty"`
 
 	// Conditions describe the current conditions of the KonnectCloudGatewayNetwork.
@@ -103,6 +105,7 @@ type KonnectCloudGatewayNetworkStatus struct {
 	// +listMapKey=type
 	// +kubebuilder:validation:MaxItems=8
 	// +kubebuilder:default={{type: "Programmed", status: "Unknown", reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"}}
+	// +kubebuilder:validation:Optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/api/konnect/v1alpha1/konnect_cloudgateway_transitgateway_types.go
+++ b/api/konnect/v1alpha1/konnect_cloudgateway_transitgateway_types.go
@@ -181,8 +181,12 @@ type AzureVNETPeeringAttachmentConfig struct {
 // KonnectCloudGatewayTransitGatewayStatus defines the current state of KonnectCloudGatewayTransitGateway.
 type KonnectCloudGatewayTransitGatewayStatus struct {
 	KonnectEntityStatusWithNetworkRef `json:",inline"`
+
 	// State is the state of the transit gateway on Konnect side.
+	//
+	// +kubebuilder:validation:Optional
 	State sdkkonnectcomp.TransitGatewayState `json:"state,omitempty"`
+
 	// Conditions describe the current conditions of the KonnectCloudGatewayDataPlaneGroupConfiguration.
 	//
 	// Known condition types are:
@@ -193,6 +197,7 @@ type KonnectCloudGatewayTransitGatewayStatus struct {
 	// +listMapKey=type
 	// +kubebuilder:validation:MaxItems=8
 	// +kubebuilder:default={{type: "Programmed", status: "Unknown", reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"}}
+	// +kubebuilder:validation:Optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/api/konnect/v1alpha1/konnect_entity_status.go
+++ b/api/konnect/v1alpha1/konnect_entity_status.go
@@ -5,12 +5,18 @@ package v1alpha1
 type KonnectEntityStatus struct {
 	// ID is the unique identifier of the Konnect entity as assigned by Konnect API.
 	// If it's unset (empty string), it means the Konnect entity hasn't been created yet.
+	//
+	// +kubebuilder:validation:Optional
 	ID string `json:"id,omitempty"`
 
 	// ServerURL is the URL of the Konnect server in which the entity exists.
+	//
+	// +kubebuilder:validation:Optional
 	ServerURL string `json:"serverURL,omitempty"`
 
 	// OrgID is ID of Konnect Org that this entity has been created in.
+	//
+	// +kubebuilder:validation:Optional
 	OrgID string `json:"organizationID,omitempty"`
 }
 
@@ -59,6 +65,8 @@ type KonnectEntityStatusWithControlPlaneRef struct {
 	KonnectEntityStatus `json:",inline"`
 
 	// ControlPlaneID is the Konnect ID of the ControlPlane this Route is associated with.
+	//
+	// +kubebuilder:validation:Optional
 	ControlPlaneID string `json:"controlPlaneID,omitempty"`
 }
 

--- a/api/konnect/v1alpha1/konnect_gateway_controlplane_types.go
+++ b/api/konnect/v1alpha1/konnect_gateway_controlplane_types.go
@@ -139,6 +139,7 @@ type KonnectGatewayControlPlaneStatus struct {
 	// +listMapKey=type
 	// +kubebuilder:validation:MaxItems=8
 	// +kubebuilder:default={{type: "Programmed", status: "Unknown", reason:"Pending", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"}}
+	// +kubebuilder:validation:Optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/api/konnect/v1alpha2/konnect_extension_types.go
+++ b/api/konnect/v1alpha2/konnect_extension_types.go
@@ -105,7 +105,7 @@ type KonnectExtensionControlPlane struct {
 type KonnectExtensionDataPlane struct {
 	// Labels is a set of labels that will be applied to the Konnect DataPlane.
 	//
-	// +optional
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:MaxItems=5
 	// +kubebuilder:validation:XValidation:rule="self.all(key, key.matches('^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$'))",message="keys must match the pattern '^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$'."
 	// +kubebuilder:validation:XValidation:rule="self.all(key, !(key.startsWith('kong') || key.startsWith('konnect') || key.startsWith('insomnia') || key.startsWith('mesh') || key.startsWith('kic') || key.startsWith('_')))",message="keys must not start with 'kong', 'konnect', 'insomnia', 'mesh', 'kic', or '_'."
@@ -175,6 +175,7 @@ type KonnectExtensionStatus struct {
 	// a DataPlane through its extensions spec.
 	//
 	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:Optional
 	DataPlaneRefs []commonv1alpha1.NamespacedRef `json:"dataPlaneRefs,omitempty"`
 
 	// ControlPlaneRefs is the array  of ControlPlane references this is associated with.
@@ -182,6 +183,7 @@ type KonnectExtensionStatus struct {
 	// a ControlPlane through its extensions spec.
 	//
 	// +kubebuilder:validation:MaxItems=16
+	// +kubebuilder:validation:Optional
 	ControlPlaneRefs []commonv1alpha1.NamespacedRef `json:"controlPlaneRefs,omitempty"`
 
 	// DataPlaneClientAuth contains the configuration for the client certificate authentication for the DataPlane.
@@ -197,10 +199,10 @@ type KonnectExtensionStatus struct {
 	// Conditions describe the current conditions of the KonnectExtensionStatus.
 	// Known condition types are:
 	//
-	// +optional
 	// +listType=map
 	// +listMapKey=type
 	// +kubebuilder:validation:MaxItems=8
+	// +kubebuilder:validation:Optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/renovate.json
+++ b/renovate.json
@@ -15,13 +15,23 @@
   "schedule": "before 5am every weekday",
   "customManagers": [
     {
-      "description": "Match dependencies in .tools_verisons.yaml that are properly annotated with `# renovate: datasource={} depName={}.`",
+      "description": "Match dependencies in .tools_versions.yaml that are properly annotated with `# renovate: datasource={} depName={}.`",
       "customType": "regex",
       "fileMatch": [
         "\\.tools_versions\\.yaml$"
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n.+\"(?<currentValue>.*?)\""
+      ]
+    },
+    {
+      "description": "Match dependencies in .custom-gcl.yml that are properly annotated with `# renovate: datasource={} depName={}.`",
+      "customType": "regex",
+      "fileMatch": [
+        "\\.custom-gcl\\.yml$"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\nversion: v(?<currentValue>.*)"
       ]
     }
   ],


### PR DESCRIPTION
**What this PR does / why we need it**:

Can't add it for konnect/v1alpha2 because of the `map[string]DataPlaneLabelValue` usage. Related issue: https://github.com/kubernetes-sigs/kube-api-linter/issues/101

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
