### PR TITLE
ci: enable kube-api-linter for konnect/v1alpha2

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -6,4 +6,4 @@ plugins:
 - module: 'sigs.k8s.io/kube-api-linter'
   # This version will not get auto updated so ideally we'd add a renovate
   # config to update this file automatically.
-  version: 55d257d89b6570c9870dc29beabaafd97ea607cb
+  version: bce00ef0e9a6cb1c3a2362c95a0ab9362919d7b8

--- a/.golangci-kube-api.yaml
+++ b/.golangci-kube-api.yaml
@@ -13,9 +13,7 @@ linters:
             disable:
               - "*"
             enable:
-              # Konnect related fields have underscores in their names, which
-              # is not recommended and yields errors with jsontags linter.
-              # - jsontags
+              - jsontags
               - duplicatemarkers
               # - maxlength
               - nofloats
@@ -30,3 +28,9 @@ linters:
               isFirstField: Warn
               useProtobuf: Warn
               usePatchStrategy: Warn
+            nomaps:
+              policy: AllowStringToStringMaps
+            # We allow underscores as that's what many Konnect related fields use.
+            jsonTags:
+              jsonTagRegex: "^[a-z][a-z0-9_]*(?:[A-Z][a-z0-9_]*)*$"
+

--- a/Makefile
+++ b/Makefile
@@ -234,14 +234,17 @@ GOLANGCI_LINT_KUBE_API_LINTER = $(PROJECT_DIR)/bin/golangci-kube-api-linter
 # .custom-gcl.yml it will not cause a rebuild. Until that changes, we need to
 # manually remove the binary and call `make lint.api` to rebuild it.
 
+.PHONY: lint.api.remove
+lint.api.remove:
+	@rm -f $(GOLANGCI_LINT_KUBE_API_LINTER)
+
 .PHONY: lint.api
 lint.api: golangci-lint
-# Cannot add konnect/v1alpha2 just yet because: https://github.com/kubernetes-sigs/kube-api-linter/issues/101
-# api/konnect/v1alpha2/konnect_extension_types.go:113:2: nomaps: Labels should not use a map type, use a list type with a unique name/identifier instead (kubeapilinter)
 	@[[ -f $(GOLANGCI_LINT_KUBE_API_LINTER) ]] || $(GOLANGCI_LINT) custom -v
 	$(GOLANGCI_LINT_KUBE_API_LINTER) run --config $(PROJECT_DIR)/.golangci-kube-api.yaml -v \
 		./api/gateway-operator/v2alpha1/... \
-		./api/konnect/v1alpha1/...
+		./api/konnect/v1alpha1/... \
+		./api/konnect/v1alpha2/...
 
 .PHONY: test.samples
 test.samples: kustomize


### PR DESCRIPTION
**What this PR does / why we need it**:

Set `nomaps` policy to `AllowStringToStringMaps` to allow string based types as key and elements of maps and allow underscores in json tags.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
