### PR TITLE
chore(controlplane): deprecate v1beta1

### DIFF
--- a/api/gateway-operator/v1beta1/controlplane_types.go
+++ b/api/gateway-operator/v1beta1/controlplane_types.go
@@ -31,6 +31,7 @@ func init() {
 // ControlPlane is the Schema for the controlplanes API
 //
 // +genclient
+// +kubebuilder:deprecatedversion:warning="This API version has been deprecated in favor of v2alpha1 and it will be removed in the future."
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status

--- a/config/crd/gateway-operator/gateway-operator.konghq.com_controlplanes.yaml
+++ b/config/crd/gateway-operator/gateway-operator.konghq.com_controlplanes.yaml
@@ -29,6 +29,9 @@ spec:
       jsonPath: .status.conditions[?(@.type=='Provisioned')].status
       name: Provisioned
       type: string
+    deprecated: true
+    deprecationWarning: This API version has been deprecated in favor of v2alpha1
+      and it will be removed in the future.
     name: v1beta1
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
**What this PR does / why we need it**:

Mark `ControlPlane` `v1beta1` as deprecated.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
