### PR TITLE
fix: fix KongUpstreamPolicy CRD CEL validation rules on hash_on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ Adding a new version? You'll need three changes:
   [#441](https://github.com/Kong/kubernetes-configuration/pull/441)
   [#454](https://github.com/Kong/kubernetes-configuration/pull/454)
 
+## [v1.5.2]
+
+[v1.5.2]: https://github.com/Kong/kubernetes-configuration/compare/v1.5.1...v1.5.2
+
 ### Fixes
 
 - Fix `KongUpstreamPolicy` CRD CEL validation rules on `hash_on`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,11 @@ Adding a new version? You'll need three changes:
   [#441](https://github.com/Kong/kubernetes-configuration/pull/441)
   [#454](https://github.com/Kong/kubernetes-configuration/pull/454)
 
+### Fixes
+
+- Fix `KongUpstreamPolicy` CRD CEL validation rules on `hash_on`.
+  [#498](https://github.com/Kong/kubernetes-configuration/pull/498)
+
 ## [v1.5.1]
 
 [v1.5.1]: https://github.com/Kong/kubernetes-configuration/compare/v1.5.0...v1.5.1

--- a/api/configuration/v1beta1/kongupstreampolicy_types.go
+++ b/api/configuration/v1beta1/kongupstreampolicy_types.go
@@ -47,11 +47,9 @@ func init() {
 // +kubebuilder:validation:XValidation:rule="has(self.spec.hashOn) ? has(self.spec.algorithm) && (self.spec.algorithm == \"consistent-hashing\" || self.spec.algorithm == \"sticky-sessions\") : true", message="spec.algorithm must be set to either 'consistent-hashing' or 'sticky-sessions' when spec.hashOn is set."
 // +kubebuilder:validation:XValidation:rule="has(self.spec.hashOnFallback) ? [has(self.spec.hashOnFallback.input), has(self.spec.hashOnFallback.header), has(self.spec.hashOnFallback.uriCapture), has(self.spec.hashOnFallback.queryArg)].filter(fieldSet, fieldSet == true).size() <= 1 : true", message="Only one of spec.hashOnFallback.(input|header|uriCapture|queryArg) can be set."
 // +kubebuilder:validation:XValidation:rule="has(self.spec.hashOnFallback) ? has(self.spec.algorithm) && self.spec.algorithm == \"consistent-hashing\" : true", message="spec.algorithm must be set to \"consistent-hashing\" when spec.hashOnFallback is set."
-// +kubebuilder:validation:XValidation:rule="has(self.spec.hashOnFallback) ? !has(self.spec.hashOnFallback.cookie) : true", message="spec.hashOnFallback.cookie must not be set."
-// +kubebuilder:validation:XValidation:rule="has(self.spec.hashOnFallback) ? !has(self.spec.hashOnFallback.cookiePath) : true", message="spec.hashOnFallback.cookiePath must not be set."
+// +kubebuilder:validation:XValidation:rule="has(self.spec.hashOn) && has(self.spec.hashOn.cookie) ? !has(self.spec.hashOnFallback) : true", message="spec.hashOnFallback must not be set when spec.hashOn.cookie is set."
 // +kubebuilder:validation:XValidation:rule="has(self.spec.healthchecks) && has(self.spec.healthchecks.passive) && has(self.spec.healthchecks.passive.healthy) ? !has(self.spec.healthchecks.passive.healthy.interval) : true", message="spec.healthchecks.passive.healthy.interval must not be set."
 // +kubebuilder:validation:XValidation:rule="has(self.spec.healthchecks) && has(self.spec.healthchecks.passive) && has(self.spec.healthchecks.passive.unhealthy) ? !has(self.spec.healthchecks.passive.unhealthy.interval) : true", message="spec.healthchecks.passive.unhealthy.interval must not be set."
-// +kubebuilder:validation:XValidation:rule="has(self.spec.hashOn) && has(self.spec.hashOn.cookie) ? !has(self.spec.hashOnFallback) : true", message="spec.hashOnFallback must not be set when spec.hashOn.cookie is set."
 // +kubebuilder:validation:XValidation:rule="has(self.spec.stickySessions) ? (has(self.spec.hashOn) && has(self.spec.hashOn.input) && self.spec.hashOn.input == 'none' && !has(self.spec.hashOn.cookie) && !has(self.spec.hashOn.cookiePath) && !has(self.spec.hashOn.header) && !has(self.spec.hashOn.uriCapture) && !has(self.spec.hashOn.queryArg)) : true", message="When spec.stickySessions is set, spec.hashOn.input must be set to 'none' (no other hash_on fields allowed)."
 // +kubebuilder:validation:XValidation:rule="has(self.spec.stickySessions) ? has(self.spec.stickySessions.cookie) : true", message="spec.stickySessions.cookie is required when spec.stickySessions is set."
 // +kubebuilder:validation:XValidation:rule="has(self.spec.stickySessions) ? (has(self.spec.algorithm) && self.spec.algorithm == \"sticky-sessions\") : true", message="spec.algorithm must be set to 'sticky-sessions' when spec.stickySessions is set."
@@ -113,32 +111,46 @@ type KongUpstreamPolicySpec struct {
 
 // HashInput is the input for consistent-hashing load balancing algorithm.
 // Use "none" to disable hashing, it is required for sticky sessions.
+//
 // +kubebuilder:validation:Enum=ip;consumer;path;none
 // +apireference:kic:include
 type HashInput string
 
 // KongUpstreamHash defines how to calculate hash for consistent-hashing load balancing algorithm.
 // Only one of the fields must be set.
+//
 // +apireference:kic:include
 type KongUpstreamHash struct {
 	// Input allows using one of the predefined inputs (ip, consumer, path, none).
 	// Set this to `none` if you want to use sticky sessions.
-	// For other parametrized inputs, use one of the fields below.
+	// For other parameterized inputs, use one of the fields below.
+	//
+	// +optional
 	Input *HashInput `json:"input,omitempty"`
 
 	// Header is the name of the header to use as hash input.
+	//
+	// +optional
 	Header *string `json:"header,omitempty"`
 
 	// Cookie is the name of the cookie to use as hash input.
+	//
+	// +optional
 	Cookie *string `json:"cookie,omitempty"`
 
 	// CookiePath is cookie path to set in the response headers.
+	//
+	// +optional
 	CookiePath *string `json:"cookiePath,omitempty"`
 
 	// QueryArg is the name of the query argument to use as hash input.
+	//
+	// +optional
 	QueryArg *string `json:"queryArg,omitempty"`
 
 	// URICapture is the name of the URI capture group to use as hash input.
+	//
+	// +optional
 	URICapture *string `json:"uriCapture,omitempty"`
 }
 

--- a/config/crd/ingress-controller/configuration.konghq.com_kongupstreampolicies.yaml
+++ b/config/crd/ingress-controller/configuration.konghq.com_kongupstreampolicies.yaml
@@ -95,7 +95,7 @@ spec:
                     description: |-
                       Input allows using one of the predefined inputs (ip, consumer, path, none).
                       Set this to `none` if you want to use sticky sessions.
-                      For other parametrized inputs, use one of the fields below.
+                      For other parameterized inputs, use one of the fields below.
                     enum:
                     - ip
                     - consumer
@@ -131,7 +131,7 @@ spec:
                     description: |-
                       Input allows using one of the predefined inputs (ip, consumer, path, none).
                       Set this to `none` if you want to use sticky sessions.
-                      For other parametrized inputs, use one of the fields below.
+                      For other parameterized inputs, use one of the fields below.
                     enum:
                     - ip
                     - consumer
@@ -689,11 +689,9 @@ spec:
             is set.
           rule: 'has(self.spec.hashOnFallback) ? has(self.spec.algorithm) && self.spec.algorithm
             == "consistent-hashing" : true'
-        - message: spec.hashOnFallback.cookie must not be set.
-          rule: 'has(self.spec.hashOnFallback) ? !has(self.spec.hashOnFallback.cookie)
-            : true'
-        - message: spec.hashOnFallback.cookiePath must not be set.
-          rule: 'has(self.spec.hashOnFallback) ? !has(self.spec.hashOnFallback.cookiePath)
+        - message: spec.hashOnFallback must not be set when spec.hashOn.cookie is
+            set.
+          rule: 'has(self.spec.hashOn) && has(self.spec.hashOn.cookie) ? !has(self.spec.hashOnFallback)
             : true'
         - message: spec.healthchecks.passive.healthy.interval must not be set.
           rule: 'has(self.spec.healthchecks) && has(self.spec.healthchecks.passive)
@@ -702,10 +700,6 @@ spec:
         - message: spec.healthchecks.passive.unhealthy.interval must not be set.
           rule: 'has(self.spec.healthchecks) && has(self.spec.healthchecks.passive)
             && has(self.spec.healthchecks.passive.unhealthy) ? !has(self.spec.healthchecks.passive.unhealthy.interval)
-            : true'
-        - message: spec.hashOnFallback must not be set when spec.hashOn.cookie is
-            set.
-          rule: 'has(self.spec.hashOn) && has(self.spec.hashOn.cookie) ? !has(self.spec.hashOnFallback)
             : true'
         - message: When spec.stickySessions is set, spec.hashOn.input must be set
             to 'none' (no other hash_on fields allowed).

--- a/config/samples/kongupstreampolicy_hashon_cookie.yaml
+++ b/config/samples/kongupstreampolicy_hashon_cookie.yaml
@@ -1,0 +1,10 @@
+apiVersion: configuration.konghq.com/v1beta1
+kind: KongUpstreamPolicy
+metadata:
+  namespace: default
+  name: kongupstreampolicy-hashon-cookie
+spec:
+  algorithm: consistent-hashing
+  hashOn:
+    cookie: session-cookie-name
+    cookiePath: /session

--- a/config/samples/kongupstreampolicy_hashon_header_hashonfallback_cookie.yaml
+++ b/config/samples/kongupstreampolicy_hashon_header_hashonfallback_cookie.yaml
@@ -1,0 +1,12 @@
+apiVersion: configuration.konghq.com/v1beta1
+kind: KongUpstreamPolicy
+metadata:
+  namespace: default
+  name: kongupstreampolicy-hashon-header-hashonfallback-cookie
+spec:
+  algorithm: consistent-hashing
+  hashOn:
+    header: X-Session-ID
+  hashOnFallback:
+    cookie: session-cookie-name
+    cookiePath: /session

--- a/docs/all-api-reference.md
+++ b/docs/all-api-reference.md
@@ -1908,7 +1908,7 @@ Only one of the fields must be set.
 
 | Field | Description |
 | --- | --- |
-| `input` _[HashInput](#hashinput)_ | Input allows using one of the predefined inputs (ip, consumer, path, none). Set this to `none` if you want to use sticky sessions. For other parametrized inputs, use one of the fields below. |
+| `input` _[HashInput](#hashinput)_ | Input allows using one of the predefined inputs (ip, consumer, path, none). Set this to `none` if you want to use sticky sessions. For other parameterized inputs, use one of the fields below. |
 | `header` _string_ | Header is the name of the header to use as hash input. |
 | `cookie` _string_ | Cookie is the name of the cookie to use as hash input. |
 | `cookiePath` _string_ | CookiePath is cookie path to set in the response headers. |

--- a/docs/configuration-api-reference.md
+++ b/docs/configuration-api-reference.md
@@ -1885,7 +1885,7 @@ Only one of the fields must be set.
 
 | Field | Description |
 | --- | --- |
-| `input` _[HashInput](#hashinput)_ | Input allows using one of the predefined inputs (ip, consumer, path, none). Set this to `none` if you want to use sticky sessions. For other parametrized inputs, use one of the fields below. |
+| `input` _[HashInput](#hashinput)_ | Input allows using one of the predefined inputs (ip, consumer, path, none). Set this to `none` if you want to use sticky sessions. For other parameterized inputs, use one of the fields below. |
 | `header` _string_ | Header is the name of the header to use as hash input. |
 | `cookie` _string_ | Cookie is the name of the cookie to use as hash input. |
 | `cookiePath` _string_ | CookiePath is cookie path to set in the response headers. |

--- a/test/crdsvalidation/configuration.konghq.com/kongupstreampolicy_test.go
+++ b/test/crdsvalidation/configuration.konghq.com/kongupstreampolicy_test.go
@@ -262,4 +262,96 @@ func TestKongUpstreamPolicy(t *testing.T) {
 			},
 		}.Run(t)
 	})
+
+	t.Run("consistent-hashing", func(t *testing.T) {
+		common.TestCasesGroup[*configurationv1beta1.KongUpstreamPolicy]{
+			{
+				Name: "hash on cookie with valid input",
+				TestObject: &configurationv1beta1.KongUpstreamPolicy{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongUpstreamPolicySpec{
+						Algorithm: lo.ToPtr("consistent-hashing"),
+						HashOn: &configurationv1beta1.KongUpstreamHash{
+							Cookie:     lo.ToPtr("session-cookie-name"),
+							CookiePath: lo.ToPtr("/cookie-path"),
+						},
+					},
+				},
+			},
+			{
+				Name: "hash on cookie requires cookiePath field to be set",
+				TestObject: &configurationv1beta1.KongUpstreamPolicy{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongUpstreamPolicySpec{
+						Algorithm: lo.ToPtr("consistent-hashing"),
+						HashOn: &configurationv1beta1.KongUpstreamHash{
+							Cookie: lo.ToPtr("session-cookie-name"),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("When spec.hashOn.cookie is set, spec.hashOn.cookiePath is required."),
+			},
+			{
+				Name: "hash on cookiePath requires cookie field to be set",
+				TestObject: &configurationv1beta1.KongUpstreamPolicy{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongUpstreamPolicySpec{
+						Algorithm: lo.ToPtr("consistent-hashing"),
+						HashOn: &configurationv1beta1.KongUpstreamHash{
+							CookiePath: lo.ToPtr("/cookie-path"),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("When spec.hashOn.cookiePath is set, spec.hashOn.cookie is required."),
+			},
+			{
+				Name: "hash on header with valid input",
+				TestObject: &configurationv1beta1.KongUpstreamPolicy{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongUpstreamPolicySpec{
+						Algorithm: lo.ToPtr("consistent-hashing"),
+						HashOn: &configurationv1beta1.KongUpstreamHash{
+							Header: lo.ToPtr("X-Custom-Header"),
+						},
+					},
+				},
+			},
+			{
+				Name: "hash on header, hash on fallback cookie with valid input",
+				TestObject: &configurationv1beta1.KongUpstreamPolicy{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongUpstreamPolicySpec{
+						Algorithm: lo.ToPtr("consistent-hashing"),
+						HashOn: &configurationv1beta1.KongUpstreamHash{
+							Header: lo.ToPtr("X-Custom-Header"),
+						},
+						HashOnFallback: &configurationv1beta1.KongUpstreamHash{
+							Cookie:     lo.ToPtr("fallback-cookie"),
+							CookiePath: lo.ToPtr("/fallback-cookie-path"),
+						},
+					},
+				},
+			},
+			{
+				// NOTE: Per https://developer.konghq.com/gateway/entities/upstream/#consistent-hashing
+				// > The hash_fallback setting is invalid and can’t be used if cookie is the primary hashing mechanism.
+				Name: "hash on fallback (cookie) cannot be set when hash on cookie is set",
+				TestObject: &configurationv1beta1.KongUpstreamPolicy{
+					ObjectMeta: common.CommonObjectMeta,
+					Spec: configurationv1beta1.KongUpstreamPolicySpec{
+						Algorithm: lo.ToPtr("consistent-hashing"),
+						HashOn: &configurationv1beta1.KongUpstreamHash{
+							Cookie:     lo.ToPtr("cookie"),
+							CookiePath: lo.ToPtr("/cookie-path"),
+						},
+						HashOnFallback: &configurationv1beta1.KongUpstreamHash{
+							Cookie:     lo.ToPtr("fallback-cookie"),
+							CookiePath: lo.ToPtr("/fallback-cookie-path"),
+						},
+					},
+				},
+				ExpectedErrorMessage: lo.ToPtr("spec.hashOnFallback must not be set when spec.hashOn.cookie is set."),
+			},
+		}.Run(t)
+	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Make sure that users can use `hash_on_fallback` with `cookie` when `hash_on` is set to something else.

This is a backported version of #499

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

Related PR in KIC https://github.com/Kong/kubernetes-ingress-controller/pull/7583

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
