### PR TITLE
chore: release v2.0.0-alpha.1

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-v2.0.0-alpha.0
+v2.0.0-alpha.1
 not-latest

--- a/config/crd/gateway-operator/configuration.konghq.com_kongcacertificates.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongcacertificates.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: kongcacertificates.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongcertificates.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongcertificates.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: kongcertificates.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongconsumergroups.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongconsumergroups.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: kongconsumergroups.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongconsumers.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongconsumers.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: kongconsumers.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongcredentialacls.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongcredentialacls.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: kongcredentialacls.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongcredentialapikeys.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongcredentialapikeys.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: kongcredentialapikeys.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongcredentialbasicauths.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongcredentialbasicauths.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: kongcredentialbasicauths.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongcredentialhmacs.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongcredentialhmacs.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: kongcredentialhmacs.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongcredentialjwts.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongcredentialjwts.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: kongcredentialjwts.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongdataplaneclientcertificates.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongdataplaneclientcertificates.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: kongdataplaneclientcertificates.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongkeys.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongkeys.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: kongkeys.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongkeysets.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongkeysets.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: kongkeysets.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_konglicenses.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_konglicenses.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: konglicenses.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongpluginbindings.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongpluginbindings.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: kongpluginbindings.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongplugins.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongplugins.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: kongplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongroutes.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongroutes.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: kongroutes.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongservices.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongservices.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: kongservices.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongsnis.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongsnis.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: kongsnis.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongtargets.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongtargets.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: kongtargets.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongupstreams.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongupstreams.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: kongupstreams.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/configuration.konghq.com_kongvaults.yaml
+++ b/config/crd/gateway-operator/configuration.konghq.com_kongvaults.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: kongvaults.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/gateway-operator/gateway-operator.konghq.com_aigateways.yaml
+++ b/config/crd/gateway-operator/gateway-operator.konghq.com_aigateways.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: aigateways.gateway-operator.konghq.com
 spec:
   group: gateway-operator.konghq.com

--- a/config/crd/gateway-operator/gateway-operator.konghq.com_controlplanes.yaml
+++ b/config/crd/gateway-operator/gateway-operator.konghq.com_controlplanes.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: controlplanes.gateway-operator.konghq.com
 spec:
   group: gateway-operator.konghq.com

--- a/config/crd/gateway-operator/gateway-operator.konghq.com_dataplanemetricsextensions.yaml
+++ b/config/crd/gateway-operator/gateway-operator.konghq.com_dataplanemetricsextensions.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: dataplanemetricsextensions.gateway-operator.konghq.com
 spec:
   group: gateway-operator.konghq.com

--- a/config/crd/gateway-operator/gateway-operator.konghq.com_dataplanes.yaml
+++ b/config/crd/gateway-operator/gateway-operator.konghq.com_dataplanes.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: dataplanes.gateway-operator.konghq.com
 spec:
   group: gateway-operator.konghq.com

--- a/config/crd/gateway-operator/gateway-operator.konghq.com_gatewayconfigurations.yaml
+++ b/config/crd/gateway-operator/gateway-operator.konghq.com_gatewayconfigurations.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: gatewayconfigurations.gateway-operator.konghq.com
 spec:
   group: gateway-operator.konghq.com

--- a/config/crd/gateway-operator/gateway-operator.konghq.com_kongplugininstallations.yaml
+++ b/config/crd/gateway-operator/gateway-operator.konghq.com_kongplugininstallations.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: kongplugininstallations.gateway-operator.konghq.com
 spec:
   group: gateway-operator.konghq.com

--- a/config/crd/gateway-operator/gateway-operator.konghq.com_konnectextensions.yaml
+++ b/config/crd/gateway-operator/gateway-operator.konghq.com_konnectextensions.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: konnectextensions.gateway-operator.konghq.com
 spec:
   group: gateway-operator.konghq.com

--- a/config/crd/gateway-operator/gateway-operator.konghq.com_watchnamespacegrants.yaml
+++ b/config/crd/gateway-operator/gateway-operator.konghq.com_watchnamespacegrants.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: watchnamespacegrants.gateway-operator.konghq.com
 spec:
   group: gateway-operator.konghq.com

--- a/config/crd/gateway-operator/konnect.konghq.com_konnectapiauthconfigurations.yaml
+++ b/config/crd/gateway-operator/konnect.konghq.com_konnectapiauthconfigurations.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: konnectapiauthconfigurations.konnect.konghq.com
 spec:
   group: konnect.konghq.com

--- a/config/crd/gateway-operator/konnect.konghq.com_konnectcloudgatewaydataplanegroupconfigurations.yaml
+++ b/config/crd/gateway-operator/konnect.konghq.com_konnectcloudgatewaydataplanegroupconfigurations.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: konnectcloudgatewaydataplanegroupconfigurations.konnect.konghq.com
 spec:
   group: konnect.konghq.com

--- a/config/crd/gateway-operator/konnect.konghq.com_konnectcloudgatewaynetworks.yaml
+++ b/config/crd/gateway-operator/konnect.konghq.com_konnectcloudgatewaynetworks.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: konnectcloudgatewaynetworks.konnect.konghq.com
 spec:
   group: konnect.konghq.com

--- a/config/crd/gateway-operator/konnect.konghq.com_konnectcloudgatewaytransitgateways.yaml
+++ b/config/crd/gateway-operator/konnect.konghq.com_konnectcloudgatewaytransitgateways.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: konnectcloudgatewaytransitgateways.konnect.konghq.com
 spec:
   group: konnect.konghq.com

--- a/config/crd/gateway-operator/konnect.konghq.com_konnectextensions.yaml
+++ b/config/crd/gateway-operator/konnect.konghq.com_konnectextensions.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: konnectextensions.konnect.konghq.com
 spec:
   group: konnect.konghq.com

--- a/config/crd/gateway-operator/konnect.konghq.com_konnectgatewaycontrolplanes.yaml
+++ b/config/crd/gateway-operator/konnect.konghq.com_konnectgatewaycontrolplanes.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: konnectgatewaycontrolplanes.konnect.konghq.com
 spec:
   group: konnect.konghq.com

--- a/config/crd/ingress-controller-incubator/incubator.ingress-controller.konghq.com_kongservicefacades.yaml
+++ b/config/crd/ingress-controller-incubator/incubator.ingress-controller.konghq.com_kongservicefacades.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller-incubator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: kongservicefacades.incubator.ingress-controller.konghq.com
 spec:
   group: incubator.ingress-controller.konghq.com

--- a/config/crd/ingress-controller/configuration.konghq.com_ingressclassparameterses.yaml
+++ b/config/crd/ingress-controller/configuration.konghq.com_ingressclassparameterses.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: ingressclassparameterses.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/ingress-controller/configuration.konghq.com_kongclusterplugins.yaml
+++ b/config/crd/ingress-controller/configuration.konghq.com_kongclusterplugins.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: kongclusterplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/ingress-controller/configuration.konghq.com_kongconsumergroups.yaml
+++ b/config/crd/ingress-controller/configuration.konghq.com_kongconsumergroups.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: kongconsumergroups.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/ingress-controller/configuration.konghq.com_kongconsumers.yaml
+++ b/config/crd/ingress-controller/configuration.konghq.com_kongconsumers.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: kongconsumers.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/ingress-controller/configuration.konghq.com_kongcustomentities.yaml
+++ b/config/crd/ingress-controller/configuration.konghq.com_kongcustomentities.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: kongcustomentities.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/ingress-controller/configuration.konghq.com_kongingresses.yaml
+++ b/config/crd/ingress-controller/configuration.konghq.com_kongingresses.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: kongingresses.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/ingress-controller/configuration.konghq.com_konglicenses.yaml
+++ b/config/crd/ingress-controller/configuration.konghq.com_konglicenses.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: konglicenses.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/ingress-controller/configuration.konghq.com_kongplugins.yaml
+++ b/config/crd/ingress-controller/configuration.konghq.com_kongplugins.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: kongplugins.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/ingress-controller/configuration.konghq.com_kongupstreampolicies.yaml
+++ b/config/crd/ingress-controller/configuration.konghq.com_kongupstreampolicies.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   labels:
     gateway.networking.k8s.io/policy: direct
   name: kongupstreampolicies.configuration.konghq.com

--- a/config/crd/ingress-controller/configuration.konghq.com_kongvaults.yaml
+++ b/config/crd/ingress-controller/configuration.konghq.com_kongvaults.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller,gateway-operator
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: kongvaults.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/ingress-controller/configuration.konghq.com_tcpingresses.yaml
+++ b/config/crd/ingress-controller/configuration.konghq.com_tcpingresses.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: tcpingresses.configuration.konghq.com
 spec:
   group: configuration.konghq.com

--- a/config/crd/ingress-controller/configuration.konghq.com_udpingresses.yaml
+++ b/config/crd/ingress-controller/configuration.konghq.com_udpingresses.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     kubernetes-configuration.konghq.com/channels: ingress-controller
-    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.0
+    kubernetes-configuration.konghq.com/version: v2.0.0-alpha.1
   name: udpingresses.configuration.konghq.com
 spec:
   group: configuration.konghq.com


### PR DESCRIPTION
**What this PR does / why we need it**:

Release v2.0.0-alpha.1 after Go module has been bumped to v2 (https://github.com/Kong/kubernetes-configuration/pull/507).

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
