### PR TITLE
ci: auto update kubeapilinter

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -4,6 +4,4 @@ name: golangci-kube-api-linter
 destination: ./bin
 plugins:
 - module: 'sigs.k8s.io/kube-api-linter'
-  # This version will not get auto updated so ideally we'd add a renovate
-  # config to update this file automatically.
   version: e719da12d8403e66335882c7ad704f8e95927ce0

--- a/renovate.json
+++ b/renovate.json
@@ -33,6 +33,18 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\nversion: v(?<currentValue>.*)"
       ]
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        ".custom-gcl\\.yml$"
+      ],
+      "matchStrings": [
+        "version:\\s*(?<currentValue>)(?<currentDigest>[a-f0-9]{7,40})"
+      ],
+      "currentValueTemplate": "main",
+      "datasourceTemplate": "git-refs",
+      "lookupNameTemplate": "https://github.com/kubernetes-sigs/kube-api-linter"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
**What this PR does / why we need it**:

Tested locally via: 

```
docker run --rm -it -v $PWD/renovate.json:/usr/src/app/renovate.json -v /tmp:/tmp -v $(pwd):/tmp/workdir -w /tmp/workdir -e LOG_LEVEL=debug -e GITHUB_COM_TOKEN=${GITHUB_TOKEN} renovate/renovate --platform local --base-dir /tmp/
```

```
...
DEBUG: packageFiles with updates (repository=local)
       "config": {
         "regex": [
           {
             "deps": [
               {
                 "packageName": "https://github.com/kubernetes-sigs/kube-api-linter",
                 "currentValue": "main",
                 "currentDigest": "e719da12d8403e66335882c7ad704f8e95927ce0",
                 "datasource": "git-refs",
                 "replaceString": "version: e719da12d8403e66335882c7ad704f8e95927ce0",
                 "depName": "https://github.com/kubernetes-sigs/kube-api-linter",
                 "updates": [
                   {
                     "updateType": "digest",
                     "newValue": "main",
                     "newDigest": "1b29e82a0f55f5e1d4bc49c4bfc3e40c944a0200",
                     "branchName": "renovate/https-github.com-kubernetes-sigs-kube-api-linter-digest"
                   }
                 ],
                 "versioning": "semver-coerced",
                 "warnings": []
               }
             ],
             "matchStrings": [
               "version:\\s*(?<currentValue>)(?<currentDigest>[a-f0-9]{7,40})"
             ],
             "packageNameTemplate": "https://github.com/kubernetes-sigs/kube-api-linter",
             "currentValueTemplate": "main",
             "datasourceTemplate": "git-refs",
             "packageFile": ".custom-gcl.yml"
           }
         ]
       }
...
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
