### PR TITLE
chore: explicitly state kind and version in deprecation notice

### DIFF
--- a/api/gateway-operator/v1beta1/controlplane_types.go
+++ b/api/gateway-operator/v1beta1/controlplane_types.go
@@ -31,7 +31,7 @@ func init() {
 // ControlPlane is the Schema for the controlplanes API
 //
 // +genclient
-// +kubebuilder:deprecatedversion:warning="This API version has been deprecated in favor of v2alpha1 and it will be removed in the future."
+// +kubebuilder:deprecatedversion:warning="ControlPlane v1beta1 has been deprecated in favor of v2alpha1 and it will be removed in the future."
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status

--- a/api/gateway-operator/v1beta1/gatewayconfiguration_types.go
+++ b/api/gateway-operator/v1beta1/gatewayconfiguration_types.go
@@ -31,7 +31,7 @@ func init() {
 // +genclient
 // +apireference:kgo:include
 // +kong:channels=gateway-operator
-// +kubebuilder:deprecatedversion:warning="This API has been deprecated in favor of v2alpha1 API version and it will be removed in future."
+// +kubebuilder:deprecatedversion:warning="GatewayConfiguration v1beta1 has been deprecated in favor of v2alpha1 and it will be removed in future."
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=kogc,categories=kong;all

--- a/config/crd/gateway-operator/gateway-operator.konghq.com_controlplanes.yaml
+++ b/config/crd/gateway-operator/gateway-operator.konghq.com_controlplanes.yaml
@@ -30,7 +30,7 @@ spec:
       name: Provisioned
       type: string
     deprecated: true
-    deprecationWarning: This API version has been deprecated in favor of v2alpha1
+    deprecationWarning: ControlPlane v1beta1 has been deprecated in favor of v2alpha1
       and it will be removed in the future.
     name: v1beta1
     schema:

--- a/config/crd/gateway-operator/gateway-operator.konghq.com_gatewayconfigurations.yaml
+++ b/config/crd/gateway-operator/gateway-operator.konghq.com_gatewayconfigurations.yaml
@@ -21,8 +21,8 @@ spec:
   scope: Namespaced
   versions:
   - deprecated: true
-    deprecationWarning: This API has been deprecated in favor of v2alpha1 API version
-      and it will be removed in future.
+    deprecationWarning: GatewayConfiguration v1beta1 has been deprecated in favor
+      of v2alpha1 and it will be removed in future.
     name: v1beta1
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
**What this PR does / why we need it**:

When applying manifests with multiple objects users can receive the following deprecation notices:

```
Warning: This API version has been deprecated in favor of v2alpha1 and it will be removed in the future.
Warning: This API has been deprecated in favor of v2alpha1 API version and it will be removed in future.
```

which currently come from `ControlPlane` and `GatewayConfiguration` `v1beta1`.

This is ambiguous and makes it hard to track down which type is indeed deprecated.

This PR fixes it by making the deprecation notices explicitly call out the kind and API version.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
