### PR TITLE
chore: CP provisioning reasons renamed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,8 @@ Adding a new version? You'll need three changes:
 - Added test cases to cover CEL rules.
   [#538](https://github.com/Kong/kubernetes-configuration/pull/538)
 - The `ControlPlane` provisioned conditions reasons have been renamed.
-  The reason for the condition status true is now `Provisioned`, while the related
-  to the provisioning non completed yet has been renamed to `ProvisioningInProgress`.
+  The reason for the condition status true is now `Provisioned`, while the reason
+  related to the provisioning non completed yet has been renamed to `ProvisioningInProgress`.
   [#546](https://github.com/Kong/kubernetes-configuration/pull/546)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ Adding a new version? You'll need three changes:
 - Added test cases to cover CEL rules.
   [#538](https://github.com/Kong/kubernetes-configuration/pull/538)
 - The `ControlPlane` provisioned conditions reasons have been renamed.
-  The reason for the condition status true is no `Provisioned`, while the related
+  The reason for the condition status true is now `Provisioned`, while the related
   to the provisioning non completed yet has been renamed to `ProvisioningInProgress`.
   [#546](https://github.com/Kong/kubernetes-configuration/pull/546)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ Adding a new version? You'll need three changes:
 
 - Added test cases to cover CEL rules.
   [#538](https://github.com/Kong/kubernetes-configuration/pull/538)
+- The `ControlPlane` provisioned conditions reasons have been renamed.
+  The reason for the condition status true is no `Provisioned`, while the related
+  to the provisioning non completed yet has been renamed to `ProvisioningInProgress`.
+  [#546](https://github.com/Kong/kubernetes-configuration/pull/546)
 
 ### Added
 

--- a/api/gateway-operator/controlplane/conditions.go
+++ b/api/gateway-operator/controlplane/conditions.go
@@ -26,13 +26,13 @@ const (
 type ConditionReason string
 
 const (
-	// ConditionReasonPodsNotReady is a reason which indicates why a ControlPlane
-	// has not yet reached a fully Provisioned status.
-	ConditionReasonPodsNotReady consts.ConditionReason = "PodsNotReady"
+	// ConditionReasonProvisioningInProgress is a reason which indicates that a ControlPlane
+	// is currently being provisioned.
+	ConditionReasonProvisioningInProgress consts.ConditionReason = "ProvisioningInProgress"
 
-	// ConditionReasonPodsReady is a reason which indicates how a ControlPlane
-	// reached fully Provisioned status.
-	ConditionReasonPodsReady consts.ConditionReason = "PodsReady"
+	// ConditionReasonProvisioned is a reason which indicates that a ControlPlane
+	// has been fully provisioned.
+	ConditionReasonProvisioned consts.ConditionReason = "Provisioned"
 
 	// ConditionReasonNoDataPlane is a reason which indicates that no DataPlane
 	// has been provisioned.


### PR DESCRIPTION
**What this PR does / why we need it**:

- The PodsReady reason has been changed to Provisioned.
- The PodsNotReady reason has been changed to ProvisioningInProgress.

**Which issue this PR fixes**

Related to https://github.com/Kong/kong-operator/issues/1948

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
