### PR TITLE
feat(controlplane): change the default status condition for ControlPlane to Provisioned

### DIFF
--- a/api/gateway-operator/v2beta1/controlplane_types.go
+++ b/api/gateway-operator/v2beta1/controlplane_types.go
@@ -458,7 +458,7 @@ type ControlPlaneStatus struct {
 	// +patchStrategy=merge
 	// +patchMergeKey=type
 	// +kubebuilder:validation:MaxItems=8
-	// +kubebuilder:default={{type: "Scheduled", status: "Unknown", reason:"NotReconciled", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"}}
+	// +kubebuilder:default={{type: "Provisioned", status: "Unknown", reason:"NotReconciled", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"}}
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
 
 	// FeatureGates is a list of effective feature gates for this ControlPlane.

--- a/config/crd/gateway-operator/gateway-operator.konghq.com_controlplanes.yaml
+++ b/config/crd/gateway-operator/gateway-operator.konghq.com_controlplanes.yaml
@@ -8805,7 +8805,7 @@ spec:
                   message: Waiting for controller
                   reason: NotReconciled
                   status: Unknown
-                  type: Scheduled
+                  type: Provisioned
                 description: Conditions describe the current conditions of the Gateway.
                 items:
                   description: Condition contains details for one aspect of the current


### PR DESCRIPTION
**What this PR does / why we need it**:

Operator doesn't use the `Scheduled` condition anymore, it only uses `Provisioned` so change the default to contain the latter only.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
