### PR TITLE
feat: conversion for `ControlPlane` from `v1beta1` to `v2beta1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ Adding a new version? You'll need three changes:
 
 ### Changes
 
+- Implemented conversion functions between `Controlplane` `v1beta1` and
+  `v2beta1`, enabling seamless migration between API versions.
+  [#558](https://github.com/Kong/kubernetes-configuration/pull/558)
 - Implemented conversion functions between `KonnectGatewayControlPlane` `v1alpha1` and
   `v1alpha2`, enabling seamless migration between API versions.
   To prevent import cycles, `v1alpha1` now imports required types from `v1alpha2`.

--- a/api/gateway-operator/v1beta1/controlplane_conversion.go
+++ b/api/gateway-operator/v1beta1/controlplane_conversion.go
@@ -1,0 +1,552 @@
+package v1beta1
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/conversion"
+
+	operatorv2beta1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v2beta1"
+)
+
+const (
+	errWrongConvertToControlPlane   = "ControlPlane ConvertTo: expected *operatorv2beta1.ControlPlane, got %T"
+	errWrongConvertFromControlPlane = "ControlPlane ConvertFrom: expected *operatorv2beta1.ControlPlane, got %T"
+)
+
+// Environment variable names for configuration.
+// Based on https://developer.konghq.com/kubernetes-ingress-controller/reference/configuration-options
+const (
+	envControllerFeatureGates                            = "CONTROLLER_FEATURE_GATES"
+	envControllerEnableReverseSync                       = "CONTROLLER_ENABLE_REVERSE_SYNC"
+	envControllerGatewayDiscoveryReadinessCheckInterval  = "CONTROLLER_GATEWAY_DISCOVERY_READINESS_CHECK_INTERVAL"
+	envControllerGatewayDiscoveryReadinessCheckTimeout   = "CONTROLLER_GATEWAY_DISCOVERY_READINESS_CHECK_TIMEOUT"
+	envControllerK8sInitCacheSyncDuration                = "CONTROLLER_INIT_CACHE_SYNC_DURATION"
+	envControllerCombinedServicesFromDifferentHTTPRoutes = "CONTROLLER_COMBINED_SERVICES_FROM_DIFFERENT_HTTPROUTES"
+	envControllerUseLastValidConfigForFallback           = "CONTROLLER_USE_LAST_VALID_CONFIG_FOR_FALLBACK"
+	envControllerEnableDrainSupport                      = "CONTROLLER_ENABLE_DRAIN_SUPPORT"
+	envControllerEnableConfigDump                        = "CONTROLLER_DUMP_CONFIG"
+	envControllerEnableConfigDumpSensitive               = "CONTROLLER_DUMP_SENSITIVE_CONFIG"
+	envControllerEnableKonnectConsumersSync              = "CONTROLLER_KONNECT_DISABLE_CONSUMERS_SYNC"
+	envControllerEnableKonnectLicensing                  = "CONTROLLER_KONNECT_LICENSING_ENABLED"
+	envControllerKonnectInitialLicensePollingPeriod      = "CONTROLLER_KONNECT_INITIAL_LICENSE_POLLING_PERIOD"
+	envControllerKonnectPollingPeriod                    = "CONTROLLER_KONNECT_LICENSE_POLLING_PERIOD"
+	envControllerEnableKonnectLicensingStorage           = "CONTROLLER_KONNECT_LICENSE_STORAGE_ENABLED"
+	envControllerKonnectNodeRefreshPeriod                = "CONTROLLER_KONNECT_REFRESH_NODE_PERIOD"
+	envControllerKonnectConfigUploadPeriod               = "CONTROLLER_KONNECT_UPLOAD_CONFIG_PERIOD"
+
+	// Environment variable prefix for controller enable/disable. After the prefix is here the name of a controller.
+	// It matches format of what is in the new ControlPlane.
+	envControllerPrefix = "CONTROLLER_ENABLE_CONTROLLER_"
+
+	// Environment variable that maps to boolean values.
+	envValueTrue  = "true"
+	envValueFalse = "false"
+	envValueOne   = "1"
+	envValueZero  = "0"
+
+	// State values.
+	stateEnabled  = "enabled"
+	stateDisabled = "disabled"
+)
+
+// ConvertTo converts from this version (v1beta1) to the Hub version.
+func (c *ControlPlane) ConvertTo(dstRaw conversion.Hub) error {
+	dst, ok := dstRaw.(*operatorv2beta1.ControlPlane)
+	if !ok {
+		return fmt.Errorf(errWrongConvertToControlPlane, dstRaw)
+	}
+
+	dst.ObjectMeta = c.ObjectMeta
+
+	var containerEnvVars []corev1.EnvVar
+	if pts := c.Spec.Deployment.PodTemplateSpec; pts != nil && len(pts.Spec.Containers) > 0 {
+		containerEnvVars = pts.Spec.Containers[0].Env
+	}
+
+	fgs, err := featureGatesFromEnvVar(containerEnvVars)
+	if err != nil {
+		return err
+	}
+	ctrls, err := cpControllersFormatFromEnvVars(containerEnvVars)
+	if err != nil {
+		return err
+	}
+
+	nn := lo.FromPtr(c.Spec.WatchNamespaces)
+	dst.Spec.ControlPlaneOptions = operatorv2beta1.ControlPlaneOptions{
+		IngressClass: c.Spec.IngressClass,
+
+		WatchNamespaces: lo.ToPtr(operatorv2beta1.WatchNamespaces{
+			Type: operatorv2beta1.WatchNamespacesType(nn.Type),
+			List: nn.List,
+		}),
+		FeatureGates: fgs,
+		Controllers:  ctrls,
+		DataPlaneSync: &operatorv2beta1.ControlPlaneDataPlaneSync{
+			ReverseSync: parseEnvForToggle[operatorv2beta1.ControlPlaneReverseSyncState](envControllerEnableReverseSync, containerEnvVars),
+		},
+		GatewayDiscovery: &operatorv2beta1.ControlPlaneGatewayDiscovery{
+			ReadinessCheckInterval: parseEnvForDuration(envControllerGatewayDiscoveryReadinessCheckInterval, containerEnvVars),
+			ReadinessCheckTimeout:  parseEnvForDuration(envControllerGatewayDiscoveryReadinessCheckTimeout, containerEnvVars),
+		},
+		Cache: &operatorv2beta1.ControlPlaneK8sCache{
+			InitSyncDuration: parseEnvForDuration(envControllerK8sInitCacheSyncDuration, containerEnvVars),
+		},
+		Translation: &operatorv2beta1.ControlPlaneTranslationOptions{
+			CombinedServicesFromDifferentHTTPRoutes: parseEnvForToggle[operatorv2beta1.ControlPlaneCombinedServicesFromDifferentHTTPRoutesState](envControllerCombinedServicesFromDifferentHTTPRoutes, containerEnvVars),
+			FallbackConfiguration: func() *operatorv2beta1.ControlPlaneFallbackConfiguration {
+				lastCfg := parseEnvForToggle[operatorv2beta1.ControlPlaneFallbackConfigurationState](envControllerUseLastValidConfigForFallback, containerEnvVars)
+				if lastCfg == nil {
+					return nil
+				}
+				return &operatorv2beta1.ControlPlaneFallbackConfiguration{
+					UseLastValidConfig: lastCfg,
+				}
+			}(),
+			DrainSupport: parseEnvForToggle[operatorv2beta1.ControlPlaneDrainSupportState](envControllerEnableDrainSupport, containerEnvVars),
+		},
+		ConfigDump: &operatorv2beta1.ControlPlaneConfigDump{
+			State:         getConfigDumpState(envControllerEnableConfigDump, containerEnvVars),
+			DumpSensitive: getConfigDumpState(envControllerEnableConfigDumpSensitive, containerEnvVars),
+		},
+		Konnect: &operatorv2beta1.ControlPlaneKonnectOptions{
+			ConsumersSync: parseEnvForToggle[operatorv2beta1.ControlPlaneKonnectConsumersSyncState](envControllerEnableKonnectConsumersSync, containerEnvVars),
+			Licensing: func() *operatorv2beta1.ControlPlaneKonnectLicensing {
+				state := parseEnvForToggle[operatorv2beta1.ControlPlaneKonnectLicensingState](envControllerEnableKonnectLicensing, containerEnvVars)
+				if state == nil || *state == operatorv2beta1.ControlPlaneKonnectLicensingStateDisabled {
+					return nil
+				}
+				return &operatorv2beta1.ControlPlaneKonnectLicensing{
+					State:                state,
+					InitialPollingPeriod: parseEnvForDuration(envControllerKonnectInitialLicensePollingPeriod, containerEnvVars),
+					PollingPeriod:        parseEnvForDuration(envControllerKonnectPollingPeriod, containerEnvVars),
+					StorageState:         parseEnvForToggle[operatorv2beta1.ControlPlaneKonnectLicensingState](envControllerEnableKonnectLicensingStorage, containerEnvVars),
+				}
+			}(),
+			NodeRefreshPeriod:  parseEnvForDuration(envControllerKonnectNodeRefreshPeriod, containerEnvVars),
+			ConfigUploadPeriod: parseEnvForDuration(envControllerKonnectConfigUploadPeriod, containerEnvVars),
+		},
+	}
+	dst.Spec.Extensions = c.Spec.Extensions
+
+	if dp := lo.FromPtr(c.Spec.DataPlane); dp != "" {
+		dst.Spec.DataPlane = operatorv2beta1.ControlPlaneDataPlaneTarget{
+			Type: operatorv2beta1.ControlPlaneDataPlaneTargetRefType,
+			Ref: &operatorv2beta1.ControlPlaneDataPlaneTargetRef{
+				Name: dp,
+			},
+		}
+	} else {
+		dst.Spec.DataPlane = operatorv2beta1.ControlPlaneDataPlaneTarget{
+			Type: operatorv2beta1.ControlPlaneDataPlaneTargetManagedByType,
+		}
+	}
+
+	dst.Status = operatorv2beta1.ControlPlaneStatus{
+		Conditions: c.Status.Conditions,
+	}
+
+	return nil
+}
+
+// ConvertFrom converts from the Hub version to this version (v1beta1).
+func (c *ControlPlane) ConvertFrom(srcRaw conversion.Hub) error {
+	src, ok := srcRaw.(*operatorv2beta1.ControlPlane)
+	if !ok {
+		return fmt.Errorf(errWrongConvertFromControlPlane, srcRaw)
+	}
+
+	c.ObjectMeta = src.ObjectMeta
+
+	c.Spec.IngressClass = src.Spec.IngressClass
+	if src.Spec.WatchNamespaces != nil {
+		c.Spec.WatchNamespaces = lo.ToPtr(WatchNamespaces{
+			Type: WatchNamespacesType(src.Spec.WatchNamespaces.Type),
+			List: src.Spec.WatchNamespaces.List,
+		})
+	}
+	c.Spec.Extensions = src.Spec.Extensions
+	if src.Spec.DataPlane.Type == operatorv2beta1.ControlPlaneDataPlaneTargetRefType && src.Spec.DataPlane.Ref != nil {
+		c.Spec.DataPlane = &src.Spec.DataPlane.Ref.Name
+	}
+
+	c.Spec.Deployment.PodTemplateSpec = &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "controller",
+					Env:  buildContainerEnvVars(src.Spec.ControlPlaneOptions),
+				},
+			},
+		},
+	}
+
+	c.Status = ControlPlaneStatus{
+		Conditions: src.Status.Conditions,
+	}
+
+	return nil
+}
+
+func featureGatesFromEnvVar(envs []corev1.EnvVar) ([]operatorv2beta1.ControlPlaneFeatureGate, error) {
+	fgEnvVar, ok := lo.Find(envs, func(fg corev1.EnvVar) bool {
+		return fg.Name == envControllerFeatureGates
+	})
+	if !ok {
+		return nil, nil
+	}
+
+	fgKeyValues := strings.Split(fgEnvVar.Value, ",")
+	featureGates := make([]operatorv2beta1.ControlPlaneFeatureGate, 0, len(fgKeyValues))
+	for _, fgKeyValue := range fgKeyValues {
+		key, value, err := parseKeyValue(fgKeyValue)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse feature gate, %w", err)
+		}
+
+		var fgState operatorv2beta1.FeatureGateState
+		switch value {
+		case envValueTrue:
+			fgState = operatorv2beta1.FeatureGateStateEnabled
+		case envValueFalse:
+			fgState = operatorv2beta1.FeatureGateStateDisabled
+		default:
+			return nil, fmt.Errorf("invalid value for feature gate %s, expected 'true' or 'false' as value", fgKeyValue)
+		}
+		featureGates = append(featureGates, operatorv2beta1.ControlPlaneFeatureGate{
+			Name:  key,
+			State: fgState,
+		})
+	}
+	return featureGates, nil
+}
+
+func envVarFromFeatureGates(featureGates []operatorv2beta1.ControlPlaneFeatureGate) []corev1.EnvVar {
+	if len(featureGates) == 0 {
+		return nil
+	}
+
+	fgPairs := make([]string, 0, len(featureGates))
+	for _, fg := range featureGates {
+		var value string
+		switch fg.State {
+		case operatorv2beta1.FeatureGateStateEnabled:
+			value = envValueTrue
+		case operatorv2beta1.FeatureGateStateDisabled:
+			value = envValueFalse
+		default:
+			// Skip invalid states,
+			continue
+		}
+		fgPairs = append(fgPairs, fmt.Sprintf("%s=%s", fg.Name, value))
+	}
+
+	if len(fgPairs) == 0 {
+		return nil
+	}
+
+	return []corev1.EnvVar{
+		{
+			Name:  envControllerFeatureGates,
+			Value: strings.Join(fgPairs, ","),
+		},
+	}
+}
+
+func envVarsFromCPControllersFormat(controllers []operatorv2beta1.ControlPlaneController) []corev1.EnvVar {
+	if len(controllers) == 0 {
+		return nil
+	}
+
+	envVars := make([]corev1.EnvVar, 0, len(controllers))
+	for _, ctrl := range controllers {
+		var value string
+		switch ctrl.State {
+		case operatorv2beta1.ControllerStateEnabled:
+			value = envValueTrue
+		case operatorv2beta1.ControllerStateDisabled:
+			value = envValueFalse
+		default:
+			// Skip invalid states.
+			continue
+		}
+
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  envControllerPrefix + ctrl.Name,
+			Value: value,
+		})
+	}
+
+	return envVars
+}
+
+func cpControllersFormatFromEnvVars(envs []corev1.EnvVar) ([]operatorv2beta1.ControlPlaneController, error) {
+	controllersEnvs := lo.Filter(envs, func(env corev1.EnvVar, _ int) bool {
+		return strings.HasPrefix(env.Name, envControllerPrefix)
+	})
+	var ctrls []operatorv2beta1.ControlPlaneController
+	for _, ctrlEnv := range controllersEnvs {
+		ctrlName := strings.TrimPrefix(ctrlEnv.Name, envControllerPrefix)
+		var ctrlState operatorv2beta1.ControllerState
+		switch strings.ToLower(strings.TrimSpace(ctrlEnv.Value)) {
+		case envValueTrue:
+			ctrlState = operatorv2beta1.ControllerStateEnabled
+		case envValueFalse:
+			ctrlState = operatorv2beta1.ControllerStateDisabled
+		default:
+			return nil, fmt.Errorf("invalid value for controller %s, expected 'true' or 'false' as value", ctrlEnv.Name)
+		}
+
+		ctrls = append(ctrls, operatorv2beta1.ControlPlaneController{
+			Name:  ctrlName,
+			State: ctrlState,
+		})
+	}
+
+	return ctrls, nil
+}
+
+func parseKeyValue(keyValue string) (key string, value string, err error) {
+	parts := strings.Split(keyValue, "=")
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("invalid key-value pair %q, expected 'key=value' format", keyValue)
+	}
+	key = strings.TrimSpace(parts[0])
+	value = strings.ToLower(strings.TrimSpace(parts[1]))
+	if key == "" || value == "" {
+		return "", "", fmt.Errorf("invalid key-value pair %q, expected 'key=value' format", keyValue)
+	}
+	return key, value, nil
+}
+
+func parseEnvForToggle[T ~string](key string, envVars []corev1.EnvVar) (value *T) {
+	v, ok := lo.Find(envVars, func(env corev1.EnvVar) bool {
+		return env.Name == key
+	})
+	if !ok {
+		return nil
+	}
+	switch strings.ToLower(v.Value) {
+	case envValueTrue, envValueOne:
+		return lo.ToPtr(T(stateEnabled))
+	case envValueFalse, envValueZero:
+		return lo.ToPtr(T(stateDisabled))
+	}
+	return nil
+}
+
+func parseEnvForDuration(key string, envVars []corev1.EnvVar) *metav1.Duration {
+	v, ok := lo.Find(envVars, func(env corev1.EnvVar) bool {
+		return env.Name == key
+	})
+	if !ok {
+		return nil
+	}
+	if v.Value == "" {
+		return nil
+	}
+	d, err := time.ParseDuration(v.Value)
+	if err != nil {
+		return nil
+	}
+	return &metav1.Duration{
+		Duration: d,
+	}
+}
+
+// buildContainerEnvVars builds the complete set of environment variables from ControlPlaneOptions.
+func buildContainerEnvVars(opts operatorv2beta1.ControlPlaneOptions) []corev1.EnvVar {
+	var envVars []corev1.EnvVar
+
+	envVars = append(envVars, envVarFromFeatureGates(opts.FeatureGates)...)
+	envVars = append(envVars, envVarsFromCPControllersFormat(opts.Controllers)...)
+
+	envVars = append(envVars, envVarFromDataPlaneSync(opts.DataPlaneSync)...)
+	envVars = append(envVars, envVarFromGatewayDiscovery(opts.GatewayDiscovery)...)
+	envVars = append(envVars, envVarFromCache(opts.Cache)...)
+	envVars = append(envVars, envVarFromTranslation(opts.Translation)...)
+	envVars = append(envVars, envVarFromConfigDump(opts.ConfigDump)...)
+	envVars = append(envVars, envVarFromKonnect(opts.Konnect)...)
+
+	return envVars
+}
+
+// envVarFromDataPlaneSync converts DataPlaneSync options to environment variables.
+func envVarFromDataPlaneSync(dps *operatorv2beta1.ControlPlaneDataPlaneSync) []corev1.EnvVar {
+	if dps == nil {
+		return nil
+	}
+
+	var envVars []corev1.EnvVar
+	if dps.ReverseSync != nil {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  envControllerEnableReverseSync,
+			Value: toggleToEnvValue(*dps.ReverseSync),
+		})
+	}
+	return envVars
+}
+
+// envVarFromGatewayDiscovery converts GatewayDiscovery options to environment variables.
+func envVarFromGatewayDiscovery(gd *operatorv2beta1.ControlPlaneGatewayDiscovery) []corev1.EnvVar {
+	if gd == nil {
+		return nil
+	}
+
+	var envVars []corev1.EnvVar
+	if gd.ReadinessCheckInterval != nil {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  envControllerGatewayDiscoveryReadinessCheckInterval,
+			Value: gd.ReadinessCheckInterval.Duration.String(),
+		})
+	}
+	if gd.ReadinessCheckTimeout != nil {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  envControllerGatewayDiscoveryReadinessCheckTimeout,
+			Value: gd.ReadinessCheckTimeout.Duration.String(),
+		})
+	}
+	return envVars
+}
+
+// envVarFromCache converts Cache options to environment variables.
+func envVarFromCache(cache *operatorv2beta1.ControlPlaneK8sCache) []corev1.EnvVar {
+	if cache == nil {
+		return nil
+	}
+
+	var envVars []corev1.EnvVar
+	if cache.InitSyncDuration != nil {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  envControllerK8sInitCacheSyncDuration,
+			Value: cache.InitSyncDuration.Duration.String(),
+		})
+	}
+	return envVars
+}
+
+// envVarFromTranslation converts Translation options to environment variables.
+func envVarFromTranslation(trans *operatorv2beta1.ControlPlaneTranslationOptions) []corev1.EnvVar {
+	if trans == nil {
+		return nil
+	}
+
+	var envVars []corev1.EnvVar
+	if trans.CombinedServicesFromDifferentHTTPRoutes != nil {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  envControllerCombinedServicesFromDifferentHTTPRoutes,
+			Value: toggleToEnvValue(*trans.CombinedServicesFromDifferentHTTPRoutes),
+		})
+	}
+	if trans.FallbackConfiguration != nil && trans.FallbackConfiguration.UseLastValidConfig != nil {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  envControllerUseLastValidConfigForFallback,
+			Value: toggleToEnvValue(*trans.FallbackConfiguration.UseLastValidConfig),
+		})
+	}
+	if trans.DrainSupport != nil {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  envControllerEnableDrainSupport,
+			Value: toggleToEnvValue(*trans.DrainSupport),
+		})
+	}
+	return envVars
+}
+
+// envVarFromConfigDump converts ConfigDump options to environment variables.
+func envVarFromConfigDump(cd *operatorv2beta1.ControlPlaneConfigDump) []corev1.EnvVar {
+	if cd == nil {
+		return nil
+	}
+
+	var envVars []corev1.EnvVar
+	envVars = append(envVars, corev1.EnvVar{
+		Name:  envControllerEnableConfigDump,
+		Value: toggleToEnvValue(cd.State),
+	})
+	envVars = append(envVars, corev1.EnvVar{
+		Name:  envControllerEnableConfigDumpSensitive,
+		Value: toggleToEnvValue(cd.DumpSensitive),
+	})
+	return envVars
+}
+
+// envVarFromKonnect converts Konnect options to environment variables.
+func envVarFromKonnect(konnect *operatorv2beta1.ControlPlaneKonnectOptions) []corev1.EnvVar {
+	if konnect == nil {
+		return nil
+	}
+
+	var envVars []corev1.EnvVar
+	if konnect.ConsumersSync != nil {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  envControllerEnableKonnectConsumersSync,
+			Value: toggleToEnvValue(*konnect.ConsumersSync),
+		})
+	}
+	if konnect.Licensing != nil {
+		if konnect.Licensing.State != nil {
+			envVars = append(envVars, corev1.EnvVar{
+				Name:  envControllerEnableKonnectLicensing,
+				Value: toggleToEnvValue(*konnect.Licensing.State),
+			})
+		}
+		if konnect.Licensing.InitialPollingPeriod != nil {
+			envVars = append(envVars, corev1.EnvVar{
+				Name:  envControllerKonnectInitialLicensePollingPeriod,
+				Value: konnect.Licensing.InitialPollingPeriod.Duration.String(),
+			})
+		}
+		if konnect.Licensing.PollingPeriod != nil {
+			envVars = append(envVars, corev1.EnvVar{
+				Name:  envControllerKonnectPollingPeriod,
+				Value: konnect.Licensing.PollingPeriod.Duration.String(),
+			})
+		}
+		if konnect.Licensing.StorageState != nil {
+			envVars = append(envVars, corev1.EnvVar{
+				Name:  envControllerEnableKonnectLicensingStorage,
+				Value: toggleToEnvValue(*konnect.Licensing.StorageState),
+			})
+		}
+	}
+	if konnect.NodeRefreshPeriod != nil {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  envControllerKonnectNodeRefreshPeriod,
+			Value: konnect.NodeRefreshPeriod.Duration.String(),
+		})
+	}
+	if konnect.ConfigUploadPeriod != nil {
+		envVars = append(envVars, corev1.EnvVar{
+			Name:  envControllerKonnectConfigUploadPeriod,
+			Value: konnect.ConfigUploadPeriod.Duration.String(),
+		})
+	}
+	return envVars
+}
+
+// toggleToEnvValue converts a toggle state to environment variable value.
+func toggleToEnvValue[T ~string](state T) string {
+	switch strings.ToLower(string(state)) {
+	case stateEnabled:
+		return envValueTrue
+	case stateDisabled:
+		return envValueFalse
+	default:
+		return envValueFalse
+	}
+}
+
+// getConfigDumpState safely gets ConfigDumpState from environment variables.
+func getConfigDumpState(key string, envVars []corev1.EnvVar) operatorv2beta1.ConfigDumpState {
+	state := parseEnvForToggle[operatorv2beta1.ConfigDumpState](key, envVars)
+	if state == nil {
+		return operatorv2beta1.ConfigDumpStateDisabled
+	}
+	return *state
+}

--- a/api/gateway-operator/v1beta1/controlplane_types.go
+++ b/api/gateway-operator/v1beta1/controlplane_types.go
@@ -19,7 +19,6 @@ package v1beta1
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/conversion"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	commonv1alpha1 "github.com/kong/kubernetes-configuration/v2/api/common/v1alpha1"
@@ -166,16 +165,4 @@ func (c *ControlPlane) SetConditions(conditions []metav1.Condition) {
 // GetExtensions retrieves the ControlPlane Extensions
 func (c *ControlPlane) GetExtensions() []commonv1alpha1.ExtensionRef {
 	return c.Spec.Extensions
-}
-
-// ConvertTo converts from this version (v1beta1) to the Hub version.
-func (c *ControlPlane) ConvertTo(dstRaw conversion.Hub) error {
-	_ = dstRaw
-	panic("v1beta1 ControlPlane ConvertTo(...) is not implemented yet")
-}
-
-// ConvertFrom converts from the Hub version to this version (v1beta1).
-func (c *ControlPlane) ConvertFrom(srcRaw conversion.Hub) error {
-	_ = srcRaw
-	panic("v1beta1 ControlPlane ConvertFrom(...) is not implemented yet")
 }

--- a/test/conversion/gateway-operator.konghq.com/v1beta1/controlplane_test.go
+++ b/test/conversion/gateway-operator.konghq.com/v1beta1/controlplane_test.go
@@ -1,0 +1,479 @@
+package v1beta1_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	commonv1alpha1 "github.com/kong/kubernetes-configuration/v2/api/common/v1alpha1"
+	operatorv1beta1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v1beta1"
+	operatorv2beta1 "github.com/kong/kubernetes-configuration/v2/api/gateway-operator/v2beta1"
+)
+
+type dummyHub struct{}
+
+func (d *dummyHub) Hub() {}
+
+func (d *dummyHub) GetObjectKind() schema.ObjectKind { return schema.EmptyObjectKind }
+func (d *dummyHub) DeepCopyObject() runtime.Object   { return &dummyHub{} }
+
+func testConversionError(t *testing.T, testFunc func() error, expectedMsgFormat string) {
+	t.Helper()
+	err := testFunc()
+	require.Error(t, err)
+	expectedMsg := fmt.Sprintf(expectedMsgFormat, &dummyHub{})
+	require.EqualError(t, err, expectedMsg)
+}
+
+func TestControlPlane_ConvertTo(t *testing.T) {
+	t.Run("error: wrong hub type", func(t *testing.T) {
+		obj := &operatorv1beta1.ControlPlane{}
+		testConversionError(t, func() error {
+			return obj.ConvertTo(&dummyHub{})
+		}, "ControlPlane ConvertTo: expected *operatorv2beta1.ControlPlane, got %T")
+	})
+
+	cases := []struct {
+		name                 string
+		spec                 operatorv1beta1.ControlPlaneSpec
+		expectsDataPlane     bool
+		expectedFeatureGates []operatorv2beta1.ControlPlaneFeatureGate
+		expectedControllers  []operatorv2beta1.ControlPlaneController
+	}{
+		{
+			name: "With DataPlane ref",
+			spec: operatorv1beta1.ControlPlaneSpec{
+				ControlPlaneOptions: operatorv1beta1.ControlPlaneOptions{
+					DataPlane: lo.ToPtr("test-dataplane"),
+					WatchNamespaces: &operatorv1beta1.WatchNamespaces{
+						Type: operatorv1beta1.WatchNamespacesTypeAll,
+					},
+					Extensions: []commonv1alpha1.ExtensionRef{
+						{
+							Group: "konnect.konghq.com",
+							Kind:  "KonnectExtension",
+							NamespacedRef: commonv1alpha1.NamespacedRef{
+								Name: "test-extension",
+							},
+						},
+					},
+					Deployment: operatorv1beta1.ControlPlaneDeploymentOptions{
+						Replicas: lo.ToPtr(int32(2)),
+						PodTemplateSpec: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  "controller",
+										Image: "kong/controller:latest",
+										Env: []corev1.EnvVar{
+											{
+												Name:  "CONTROLLER_FEATURE_GATES",
+												Value: "GatewayAlpha=true,ExperimentalFeature=false",
+											},
+											{
+												Name:  "CONTROLLER_ENABLE_CONTROLLER_INGRESS_CLASS_NETWORKINGV1",
+												Value: "true",
+											},
+											{
+												Name:  "CONTROLLER_ENABLE_CONTROLLER_KONG_PLUGIN",
+												Value: "false",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				IngressClass: lo.ToPtr("kong"),
+			},
+			expectsDataPlane: true,
+			expectedFeatureGates: []operatorv2beta1.ControlPlaneFeatureGate{
+				{Name: "GatewayAlpha", State: operatorv2beta1.FeatureGateStateEnabled},
+				{Name: "ExperimentalFeature", State: operatorv2beta1.FeatureGateStateDisabled},
+			},
+			expectedControllers: []operatorv2beta1.ControlPlaneController{
+				{Name: "INGRESS_CLASS_NETWORKINGV1", State: operatorv2beta1.ControllerStateEnabled},
+				{Name: "KONG_PLUGIN", State: operatorv2beta1.ControllerStateDisabled},
+			},
+		},
+		{
+			name: "Without DataPlane ref (managed by owner)",
+			spec: operatorv1beta1.ControlPlaneSpec{
+				ControlPlaneOptions: operatorv1beta1.ControlPlaneOptions{
+					WatchNamespaces: &operatorv1beta1.WatchNamespaces{
+						Type: operatorv1beta1.WatchNamespacesTypeList,
+						List: []string{"namespace1", "namespace2"},
+					},
+				},
+				IngressClass: lo.ToPtr("kong"),
+			},
+			expectsDataPlane: false,
+		},
+		{
+			name: "With own namespace watching",
+			spec: operatorv1beta1.ControlPlaneSpec{
+				ControlPlaneOptions: operatorv1beta1.ControlPlaneOptions{
+					WatchNamespaces: &operatorv1beta1.WatchNamespaces{
+						Type: operatorv1beta1.WatchNamespacesTypeOwn,
+					},
+				},
+			},
+			expectsDataPlane: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := &operatorv1beta1.ControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-controlplane",
+					Namespace: "test-namespace",
+				},
+				Spec: tc.spec,
+				Status: operatorv1beta1.ControlPlaneStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   "Ready",
+							Status: metav1.ConditionTrue,
+							Reason: "AllGood",
+						},
+					},
+				},
+			}
+
+			dst := &operatorv2beta1.ControlPlane{}
+			err := obj.ConvertTo(dst)
+			require.NoError(t, err)
+
+			require.Equal(t, obj.ObjectMeta, dst.ObjectMeta)
+
+			if tc.expectsDataPlane {
+				require.Equal(t, operatorv2beta1.ControlPlaneDataPlaneTargetRefType, dst.Spec.DataPlane.Type)
+				require.NotNil(t, dst.Spec.DataPlane.Ref)
+				require.Equal(t, lo.FromPtr(tc.spec.DataPlane), dst.Spec.DataPlane.Ref.Name)
+			} else {
+				require.Equal(t, operatorv2beta1.ControlPlaneDataPlaneTargetManagedByType, dst.Spec.DataPlane.Type)
+				require.Nil(t, dst.Spec.DataPlane.Ref)
+			}
+
+			require.Equal(t, tc.spec.IngressClass, dst.Spec.IngressClass)
+
+			if tc.spec.WatchNamespaces != nil {
+				require.NotNil(t, dst.Spec.WatchNamespaces)
+				require.Equal(t, operatorv2beta1.WatchNamespacesType(tc.spec.WatchNamespaces.Type), dst.Spec.WatchNamespaces.Type)
+				require.Equal(t, tc.spec.WatchNamespaces.List, dst.Spec.WatchNamespaces.List)
+			} else {
+				require.Nil(t, dst.Spec.WatchNamespaces)
+			}
+
+			require.Equal(t, tc.spec.Extensions, dst.Spec.Extensions)
+
+			if tc.expectedFeatureGates != nil {
+				require.ElementsMatch(t, tc.expectedFeatureGates, dst.Spec.FeatureGates)
+			}
+
+			if tc.expectedControllers != nil {
+				require.ElementsMatch(t, tc.expectedControllers, dst.Spec.Controllers)
+			}
+
+			require.Equal(t, obj.Status.Conditions, dst.Status.Conditions)
+		})
+	}
+}
+
+func TestControlPlane_ConvertFrom(t *testing.T) {
+	t.Run("error: wrong hub type", func(t *testing.T) {
+		obj := &operatorv1beta1.ControlPlane{}
+		testConversionError(t, func() error {
+			return obj.ConvertFrom(&dummyHub{})
+		}, "ControlPlane ConvertFrom: expected *operatorv2beta1.ControlPlane, got %T")
+	})
+
+	cases := []struct {
+		name             string
+		src              operatorv2beta1.ControlPlaneSpec
+		expectsDataPlane bool
+	}{
+		{
+			name: "With DataPlane ref",
+			src: operatorv2beta1.ControlPlaneSpec{
+				DataPlane: operatorv2beta1.ControlPlaneDataPlaneTarget{
+					Type: operatorv2beta1.ControlPlaneDataPlaneTargetRefType,
+					Ref: &operatorv2beta1.ControlPlaneDataPlaneTargetRef{
+						Name: "test-dataplane",
+					},
+				},
+				ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+					IngressClass: lo.ToPtr("kong"),
+					WatchNamespaces: &operatorv2beta1.WatchNamespaces{
+						Type: operatorv2beta1.WatchNamespacesTypeAll,
+					},
+					FeatureGates: []operatorv2beta1.ControlPlaneFeatureGate{
+						{Name: "GatewayAlpha", State: operatorv2beta1.FeatureGateStateEnabled},
+						{Name: "ExperimentalFeature", State: operatorv2beta1.FeatureGateStateDisabled},
+					},
+				},
+				Extensions: []commonv1alpha1.ExtensionRef{
+					{
+						Group: "konnect.konghq.com",
+						Kind:  "KonnectExtension",
+						NamespacedRef: commonv1alpha1.NamespacedRef{
+							Name: "test-extension",
+						},
+					},
+				},
+			},
+			expectsDataPlane: true,
+		},
+		{
+			name: "With managedByOwner DataPlane",
+			src: operatorv2beta1.ControlPlaneSpec{
+				DataPlane: operatorv2beta1.ControlPlaneDataPlaneTarget{
+					Type: operatorv2beta1.ControlPlaneDataPlaneTargetManagedByType,
+				},
+				ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+					IngressClass: lo.ToPtr("kong"),
+					WatchNamespaces: &operatorv2beta1.WatchNamespaces{
+						Type: operatorv2beta1.WatchNamespacesTypeList,
+						List: []string{"namespace1", "namespace2"},
+					},
+				},
+			},
+			expectsDataPlane: false,
+		},
+		{
+			name: "With own namespace watching",
+			src: operatorv2beta1.ControlPlaneSpec{
+				DataPlane: operatorv2beta1.ControlPlaneDataPlaneTarget{
+					Type: operatorv2beta1.ControlPlaneDataPlaneTargetManagedByType,
+				},
+				ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+					WatchNamespaces: &operatorv2beta1.WatchNamespaces{
+						Type: operatorv2beta1.WatchNamespacesTypeOwn,
+					},
+				},
+			},
+			expectsDataPlane: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := &operatorv1beta1.ControlPlane{}
+
+			src := &operatorv2beta1.ControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-controlplane",
+					Namespace: "test-namespace",
+				},
+				Spec: tc.src,
+				Status: operatorv2beta1.ControlPlaneStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   "Ready",
+							Status: metav1.ConditionTrue,
+							Reason: "AllGood",
+						},
+					},
+					FeatureGates: []operatorv2beta1.ControlPlaneFeatureGate{
+						{Name: "StatusFeatureGate", State: operatorv2beta1.FeatureGateStateEnabled},
+					},
+					Controllers: []operatorv2beta1.ControlPlaneController{
+						{Name: "StatusController", State: operatorv2beta1.ControllerStateEnabled},
+					},
+				},
+			}
+
+			require.NoError(t, obj.ConvertFrom(src))
+
+			require.Equal(t, src.ObjectMeta, obj.ObjectMeta)
+
+			if tc.expectsDataPlane {
+				require.NotNil(t, obj.Spec.DataPlane)
+				require.Equal(t, tc.src.DataPlane.Ref.Name, *obj.Spec.DataPlane)
+			} else {
+				require.Nil(t, obj.Spec.DataPlane)
+			}
+
+			require.Equal(t, tc.src.IngressClass, obj.Spec.IngressClass)
+
+			if tc.src.WatchNamespaces != nil {
+				require.NotNil(t, obj.Spec.WatchNamespaces)
+				require.Equal(t, operatorv1beta1.WatchNamespacesType(tc.src.WatchNamespaces.Type), obj.Spec.WatchNamespaces.Type)
+				require.Equal(t, tc.src.WatchNamespaces.List, obj.Spec.WatchNamespaces.List)
+			} else {
+				require.Nil(t, obj.Spec.WatchNamespaces)
+			}
+
+			require.Equal(t, tc.src.Extensions, obj.Spec.Extensions)
+
+			require.Equal(t, src.Status.Conditions, obj.Status.Conditions)
+		})
+	}
+}
+
+func TestControlPlane_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		src  operatorv2beta1.ControlPlaneSpec
+	}{
+		{
+			name: "Complete configuration with all options",
+			src: operatorv2beta1.ControlPlaneSpec{
+				DataPlane: operatorv2beta1.ControlPlaneDataPlaneTarget{
+					Type: operatorv2beta1.ControlPlaneDataPlaneTargetRefType,
+					Ref: &operatorv2beta1.ControlPlaneDataPlaneTargetRef{
+						Name: "test-dataplane",
+					},
+				},
+				ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+					IngressClass: lo.ToPtr("kong"),
+					WatchNamespaces: &operatorv2beta1.WatchNamespaces{
+						Type: operatorv2beta1.WatchNamespacesTypeAll,
+					},
+					FeatureGates: []operatorv2beta1.ControlPlaneFeatureGate{
+						{Name: "GatewayAlpha", State: operatorv2beta1.FeatureGateStateEnabled},
+						{Name: "ExperimentalFeature", State: operatorv2beta1.FeatureGateStateDisabled},
+					},
+					Controllers: []operatorv2beta1.ControlPlaneController{
+						{Name: "INGRESS_CLASS_NETWORKINGV1", State: operatorv2beta1.ControllerStateEnabled},
+						{Name: "KONG_PLUGIN", State: operatorv2beta1.ControllerStateDisabled},
+					},
+					DataPlaneSync: &operatorv2beta1.ControlPlaneDataPlaneSync{
+						ReverseSync: lo.ToPtr(operatorv2beta1.ControlPlaneReverseSyncStateEnabled),
+					},
+					GatewayDiscovery: &operatorv2beta1.ControlPlaneGatewayDiscovery{
+						ReadinessCheckInterval: &metav1.Duration{Duration: 30 * time.Second},
+						ReadinessCheckTimeout:  &metav1.Duration{Duration: 5 * time.Second},
+					},
+					Cache: &operatorv2beta1.ControlPlaneK8sCache{
+						InitSyncDuration: &metav1.Duration{Duration: 60 * time.Second},
+					},
+					Translation: &operatorv2beta1.ControlPlaneTranslationOptions{
+						CombinedServicesFromDifferentHTTPRoutes: lo.ToPtr(operatorv2beta1.ControlPlaneCombinedServicesFromDifferentHTTPRoutesStateEnabled),
+						FallbackConfiguration: &operatorv2beta1.ControlPlaneFallbackConfiguration{
+							UseLastValidConfig: lo.ToPtr(operatorv2beta1.ControlPlaneFallbackConfigurationStateDisabled),
+						},
+						DrainSupport: lo.ToPtr(operatorv2beta1.ControlPlaneDrainSupportStateEnabled),
+					},
+					ConfigDump: &operatorv2beta1.ControlPlaneConfigDump{
+						State:         operatorv2beta1.ConfigDumpStateEnabled,
+						DumpSensitive: operatorv2beta1.ConfigDumpStateDisabled,
+					},
+					Konnect: &operatorv2beta1.ControlPlaneKonnectOptions{
+						ConsumersSync: lo.ToPtr(operatorv2beta1.ControlPlaneKonnectConsumersSyncStateEnabled),
+						Licensing: &operatorv2beta1.ControlPlaneKonnectLicensing{
+							State:                lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateEnabled),
+							InitialPollingPeriod: &metav1.Duration{Duration: 10 * time.Second},
+							PollingPeriod:        &metav1.Duration{Duration: 60 * time.Second},
+							StorageState:         lo.ToPtr(operatorv2beta1.ControlPlaneKonnectLicensingStateDisabled),
+						},
+						NodeRefreshPeriod:  &metav1.Duration{Duration: 30 * time.Second},
+						ConfigUploadPeriod: &metav1.Duration{Duration: 10 * time.Second},
+					},
+				},
+				Extensions: []commonv1alpha1.ExtensionRef{
+					{
+						Group: "konnect.konghq.com",
+						Kind:  "KonnectExtension",
+						NamespacedRef: commonv1alpha1.NamespacedRef{
+							Name: "test-extension",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Minimal configuration with managed dataplane",
+			src: operatorv2beta1.ControlPlaneSpec{
+				DataPlane: operatorv2beta1.ControlPlaneDataPlaneTarget{
+					Type: operatorv2beta1.ControlPlaneDataPlaneTargetManagedByType,
+				},
+				ControlPlaneOptions: operatorv2beta1.ControlPlaneOptions{
+					IngressClass: lo.ToPtr("kong"),
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			original := &operatorv2beta1.ControlPlane{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-controlplane",
+					Namespace: "test-namespace",
+				},
+				Spec: tc.src,
+				Status: operatorv2beta1.ControlPlaneStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   "Ready",
+							Status: metav1.ConditionTrue,
+							Reason: "AllGood",
+						},
+					},
+				},
+			}
+
+			intermediate := &operatorv1beta1.ControlPlane{}
+			err := intermediate.ConvertFrom(original)
+			require.NoError(t, err)
+
+			roundTrip := &operatorv2beta1.ControlPlane{}
+			err = intermediate.ConvertTo(roundTrip)
+			require.NoError(t, err)
+
+			require.Equal(t, original.ObjectMeta, roundTrip.ObjectMeta)
+			require.Equal(t, original.Spec.DataPlane, roundTrip.Spec.DataPlane)
+			require.Equal(t, original.Spec.IngressClass, roundTrip.Spec.IngressClass)
+
+			if original.Spec.WatchNamespaces == nil {
+				if roundTrip.Spec.WatchNamespaces != nil {
+					require.Empty(t, roundTrip.Spec.WatchNamespaces.Type)
+					require.Nil(t, roundTrip.Spec.WatchNamespaces.List)
+				}
+			} else {
+				require.Equal(t, original.Spec.WatchNamespaces, roundTrip.Spec.WatchNamespaces)
+			}
+
+			require.Equal(t, original.Spec.Extensions, roundTrip.Spec.Extensions)
+			require.ElementsMatch(t, original.Spec.FeatureGates, roundTrip.Spec.FeatureGates)
+			require.ElementsMatch(t, original.Spec.Controllers, roundTrip.Spec.Controllers)
+			require.Equal(t, original.Status.Conditions, roundTrip.Status.Conditions)
+
+			if original.Spec.DataPlaneSync != nil {
+				require.NotNil(t, roundTrip.Spec.DataPlaneSync)
+				require.Equal(t, original.Spec.DataPlaneSync.ReverseSync, roundTrip.Spec.DataPlaneSync.ReverseSync)
+			}
+			if original.Spec.GatewayDiscovery != nil {
+				require.NotNil(t, roundTrip.Spec.GatewayDiscovery)
+				require.Equal(t, original.Spec.GatewayDiscovery.ReadinessCheckInterval, roundTrip.Spec.GatewayDiscovery.ReadinessCheckInterval)
+				require.Equal(t, original.Spec.GatewayDiscovery.ReadinessCheckTimeout, roundTrip.Spec.GatewayDiscovery.ReadinessCheckTimeout)
+			}
+			if original.Spec.Cache != nil {
+				require.NotNil(t, roundTrip.Spec.Cache)
+				require.Equal(t, original.Spec.Cache.InitSyncDuration, roundTrip.Spec.Cache.InitSyncDuration)
+			}
+			if original.Spec.Translation != nil {
+				require.NotNil(t, roundTrip.Spec.Translation)
+				require.Equal(t, original.Spec.Translation, roundTrip.Spec.Translation)
+			}
+			if original.Spec.ConfigDump != nil {
+				require.NotNil(t, roundTrip.Spec.ConfigDump)
+				require.Equal(t, original.Spec.ConfigDump, roundTrip.Spec.ConfigDump)
+			}
+			if original.Spec.Konnect != nil {
+				require.NotNil(t, roundTrip.Spec.Konnect)
+				require.Equal(t, original.Spec.Konnect, roundTrip.Spec.Konnect)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Implements conversion for `ControlPlane` from `v1beta1` to `v2beta1`, which should cover most cases and features that may be configured using the old method and maps to the new one. Status does not need explicit conversion. Ignoring it just works. It will be properly set in the expected format and work (readiness is detected) when the change from PR https://github.com/Kong/kong-operator/pull/2057 will be merged (small workaround and actual usage of code from this PR)

**Which issue this PR fixes**

Part of https://github.com/Kong/kong-operator/issues/1368

Of course, after the merge bump of this library has to happen in the KO repo.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
