### PR TITLE
chore(controlplane): Add controlPlaneOptionsValid condition type and reason

### DIFF
--- a/api/gateway-operator/controlplane/conditions.go
+++ b/api/gateway-operator/controlplane/conditions.go
@@ -15,6 +15,10 @@ const (
 	// indicate whether or not the ControlPlane has been granted permission to
 	// watch resources in the requested namespaces.
 	ConditionTypeWatchNamespaceGrantValid consts.ConditionType = "WatchNamespaceGrantValid"
+
+	// ConditionTypeOptionsValid is a condition type used to indicate whether or not
+	// the ControlPlane's options is valid by the checks of the operator.
+	ConditionTypeOptionsValid consts.ConditionType = "OptionsValid"
 )
 
 // -----------------------------------------------------------------------------
@@ -50,4 +54,12 @@ const (
 	// WatchNamespaceGrants are valid for the ControlPlane to be able to watch
 	// resources in requested namespaces.
 	ConditionReasonWatchNamespaceGrantValid consts.ConditionReason = "WatchNamespaceGrantValid"
+
+	// ConditionReasonOptionsValid is a reason which indicates that the options
+	// of the ControlPlane is valid with the check of the operator.
+	ConditionReasonOptionsValid consts.ConditionReason = "OptionsValid"
+
+	// ConditionReasonOptionsInvalid is a reason which indicates that the options
+	// of the ControlPlane is not valid with the check of the operator.
+	ConditionReasonOptionsInvalid consts.ConditionReason = "OptionsInvalid"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

Add condition type `ConditionTypeOptionsValid` and condition reasons `ConditionReasonOptionsValid` and `ConditionReasonOptionsInvalid` to indicate the validation status of condition options in Kong operator.
**Which issue this PR fixes**

Part of https://github.com/Kong/kong-operator/issues/1999

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

-  [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes 
No changelog required because this change does not affect the APIs.
