### PR TITLE
fix: set default IngressClass for `ControlPlane` conversion

### DIFF
--- a/api/gateway-operator/v1beta1/controlplane_conversion.go
+++ b/api/gateway-operator/v1beta1/controlplane_conversion.go
@@ -67,7 +67,10 @@ func (c *ControlPlane) ConvertTo(dstRaw conversion.Hub) error {
 
 	dst.ObjectMeta = c.ObjectMeta
 
-	if err := c.Spec.convertTo(&dst.Spec.ControlPlaneOptions, c.Spec.IngressClass); err != nil {
+	// Setting IngressClass wasn't required in v1beta1, but for v2beta1 it is,
+	// thus fill with a default value to make it work without hassle.
+	class := lo.FromPtrOr(c.Spec.IngressClass, "kong")
+	if err := c.Spec.convertTo(&dst.Spec.ControlPlaneOptions, &class); err != nil {
 		return err
 	}
 	dst.Spec.Extensions = c.Spec.Extensions

--- a/test/conversion/gateway-operator.konghq.com/v1beta1/controlplane_test.go
+++ b/test/conversion/gateway-operator.konghq.com/v1beta1/controlplane_test.go
@@ -27,6 +27,7 @@ func TestControlPlane_ConvertTo(t *testing.T) {
 		name                 string
 		spec                 operatorv1beta1.ControlPlaneSpec
 		expectsDataPlane     bool
+		expectedIngressClass *string
 		expectedFeatureGates []operatorv2beta1.ControlPlaneFeatureGate
 		expectedControllers  []operatorv2beta1.ControlPlaneController
 		expectedError        error
@@ -76,9 +77,9 @@ func TestControlPlane_ConvertTo(t *testing.T) {
 						},
 					},
 				},
-				IngressClass: lo.ToPtr("kong"),
 			},
-			expectsDataPlane: true,
+			expectedIngressClass: lo.ToPtr("kong"),
+			expectsDataPlane:     true,
 			expectedFeatureGates: []operatorv2beta1.ControlPlaneFeatureGate{
 				{Name: "GatewayAlpha", State: operatorv2beta1.FeatureGateStateEnabled},
 				{Name: "ExperimentalFeature", State: operatorv2beta1.FeatureGateStateDisabled},
@@ -190,9 +191,10 @@ func TestControlPlane_ConvertTo(t *testing.T) {
 						List: []string{"namespace1", "namespace2"},
 					},
 				},
-				IngressClass: lo.ToPtr("kong"),
+				IngressClass: lo.ToPtr("test"),
 			},
-			expectsDataPlane: false,
+			expectedIngressClass: lo.ToPtr("test"),
+			expectsDataPlane:     false,
 		},
 		{
 			name: "With own namespace watching",
@@ -203,7 +205,8 @@ func TestControlPlane_ConvertTo(t *testing.T) {
 					},
 				},
 			},
-			expectsDataPlane: false,
+			expectedIngressClass: lo.ToPtr("kong"),
+			expectsDataPlane:     false,
 		},
 	}
 
@@ -246,7 +249,7 @@ func TestControlPlane_ConvertTo(t *testing.T) {
 				require.Nil(t, dst.Spec.DataPlane.Ref)
 			}
 
-			require.Equal(t, tc.spec.IngressClass, dst.Spec.IngressClass)
+			require.Equal(t, tc.expectedIngressClass, dst.Spec.IngressClass)
 
 			if tc.spec.WatchNamespaces != nil {
 				require.NotNil(t, dst.Spec.WatchNamespaces)


### PR DESCRIPTION
**What this PR does / why we need it**:

Without this fix, an attempt to apply, e.g. [controlplane-dataplane-watchnamespaces.yaml](https://github.com/Kong/kong-operator/blob/main/config/samples/controlplane-dataplane-watchnamespaces.yaml) ends with a failure like that

```json
{"level":"error","ts":"2025-08-28T13:41:09Z","msg":"Reconciler error","controller":"controlplane","controllerGroup":"gateway-operator.konghq.com","controllerKind":"ControlPlane","ControlPlane":{"name":"controlplane-example","namespace":"default"},"namespace":"default","name":"controlplane-example","reconcileID":"f09b58aa-82b4-46b8-8169-3b82009292f2","error":"failed to patch ControlPlane status with DataPlane name dataplane-cp-watchnamespace: ControlPlane.gateway-operator.konghq.com \"controlplane-example\" is invalid: spec: Invalid value: \"object\": When dataplane target is of type 'ref' the ingressClass must be set","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.21.0/pkg/internal/controller/controller.go:353\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.21.0/pkg/internal/controller/controller.go:300\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.1\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.21.0/pkg/internal/controller/controller.go:202"}
```

