### PR TITLE
Deprecate static autoscale in KonnectCloudGatewayDataPlaneConfiguration

### DIFF
--- a/api/konnect/v1alpha1/konnect_cloudgateway_dataplane_configuration_types.go
+++ b/api/konnect/v1alpha1/konnect_cloudgateway_dataplane_configuration_types.go
@@ -136,6 +136,9 @@ type ConfigurationDataPlaneGroupAutoscaleType string
 
 const (
 	// ConfigurationDataPlaneGroupAutoscaleTypeStatic is the autoscale type for static configuration.
+	//
+	// Deprecated: ConfigurationDataPlaneGroupAutoscaleTypeStatic is deprecated. Use
+	// ConfigurationDataPlaneGroupAutoscaleTypeAutopilot instead.
 	ConfigurationDataPlaneGroupAutoscaleTypeStatic ConfigurationDataPlaneGroupAutoscaleType = "static"
 
 	// ConfigurationDataPlaneGroupAutoscaleTypeAutopilot is the autoscale type for autopilot configuration.

--- a/test/crdsvalidation/konnect.konghq.com/konnectcloudgatewaydataplanegroupconfiguration_test.go
+++ b/test/crdsvalidation/konnect.konghq.com/konnectcloudgatewaydataplanegroupconfiguration_test.go
@@ -25,7 +25,7 @@ func TestKonnectDataPlaneGroupConfiguration(t *testing.T) {
 		KonnectID: lo.ToPtr("12345"),
 	}
 	autoscaleConfiguration := konnectv1alpha1.ConfigurationDataPlaneGroupAutoscale{
-		Type: konnectv1alpha1.ConfigurationDataPlaneGroupAutoscaleTypeStatic,
+		Type: konnectv1alpha1.ConfigurationDataPlaneGroupAutoscaleTypeStatic, //nolint:staticcheck
 		Static: &konnectv1alpha1.ConfigurationDataPlaneGroupAutoscaleStatic{
 			InstanceType:       sdkkonnectcomp.InstanceTypeNameSmall,
 			RequestedInstances: 3,
@@ -48,7 +48,7 @@ func TestKonnectDataPlaneGroupConfiguration(t *testing.T) {
 								Region:     "us-west-2",
 								NetworkRef: networkRefKonnectID,
 								Autoscale: konnectv1alpha1.ConfigurationDataPlaneGroupAutoscale{
-									Type: konnectv1alpha1.ConfigurationDataPlaneGroupAutoscaleTypeStatic,
+									Type: konnectv1alpha1.ConfigurationDataPlaneGroupAutoscaleTypeStatic, //nolint:staticcheck
 									Static: &konnectv1alpha1.ConfigurationDataPlaneGroupAutoscaleStatic{
 										InstanceType:       sdkkonnectcomp.InstanceTypeNameSmall,
 										RequestedInstances: 3,
@@ -73,7 +73,7 @@ func TestKonnectDataPlaneGroupConfiguration(t *testing.T) {
 								Region:     "us-west-2",
 								NetworkRef: networkRefKonnectID,
 								Autoscale: konnectv1alpha1.ConfigurationDataPlaneGroupAutoscale{
-									Type: konnectv1alpha1.ConfigurationDataPlaneGroupAutoscaleTypeStatic,
+									Type: konnectv1alpha1.ConfigurationDataPlaneGroupAutoscaleTypeStatic, //nolint:staticcheck
 									Autopilot: &konnectv1alpha1.ConfigurationDataPlaneGroupAutoscaleAutopilot{
 										BaseRps: 123,
 									},
@@ -159,7 +159,7 @@ func TestKonnectDataPlaneGroupConfiguration(t *testing.T) {
 									},
 								},
 								Autoscale: konnectv1alpha1.ConfigurationDataPlaneGroupAutoscale{
-									Type: konnectv1alpha1.ConfigurationDataPlaneGroupAutoscaleTypeStatic,
+									Type: konnectv1alpha1.ConfigurationDataPlaneGroupAutoscaleTypeStatic, //nolint:staticcheck
 									Static: &konnectv1alpha1.ConfigurationDataPlaneGroupAutoscaleStatic{
 										InstanceType:       sdkkonnectcomp.InstanceTypeNameSmall,
 										RequestedInstances: 3,
@@ -190,7 +190,7 @@ func TestKonnectDataPlaneGroupConfiguration(t *testing.T) {
 									},
 								},
 								Autoscale: konnectv1alpha1.ConfigurationDataPlaneGroupAutoscale{
-									Type: konnectv1alpha1.ConfigurationDataPlaneGroupAutoscaleTypeStatic,
+									Type: konnectv1alpha1.ConfigurationDataPlaneGroupAutoscaleTypeStatic, //nolint:staticcheck
 									Static: &konnectv1alpha1.ConfigurationDataPlaneGroupAutoscaleStatic{
 										InstanceType:       sdkkonnectcomp.InstanceTypeNameSmall,
 										RequestedInstances: 3,


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**

Related to https://github.com/Kong/kong-operator/issues/1779

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
